### PR TITLE
gitlab: check getFile exists before content encoding

### DIFF
--- a/internal/gitsources/gitlab/gitlab.go
+++ b/internal/gitsources/gitlab/gitlab.go
@@ -152,6 +152,9 @@ func (c *Client) GetUserInfo() (*gitsource.UserInfo, error) {
 
 func (c *Client) GetFile(repopath, commit, file string) ([]byte, error) {
 	f, _, err := c.client.RepositoryFiles.GetFile(repopath, file, &gitlab.GetFileOptions{Ref: gitlab.String(commit)})
+	if err != nil {
+		return nil, err
+	}
 	data, err := base64.StdEncoding.DecodeString(f.Content)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Using gitlab as remote source, an error occurred in agola if no config.jsonnet present

Added check to verify file exists before content encoding