### PR TITLE
dockerfile: remove agola git hook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # copy to agola binaries
-COPY --from=server_builder /agola/bin/agola /agola/bin/agola-toolbox-* /agola/bin/agola-git-hook /bin/
+COPY --from=server_builder /agola/bin/agola /agola/bin/agola-toolbox-* /bin/
 
 ENTRYPOINT ["/bin/agola"]
 


### PR DESCRIPTION
agola-git-hook has been removed in 6ee90a286c68d90afd12b7b3ed587c46f58c3080, this PR also removes it from the Dockerfile