### PR TITLE
Datamanager multiple improvements

### DIFF
--- a/internal/datamanager/datamanager.go
+++ b/internal/datamanager/datamanager.go
@@ -193,7 +193,7 @@ func (d *DataManager) deleteEtcd(ctx context.Context) error {
 
 func (d *DataManager) Run(ctx context.Context, readyCh chan struct{}) error {
 	for {
-		err := d.InitEtcd(ctx)
+		err := d.InitEtcd(ctx, nil)
 		if err == nil {
 			break
 		}

--- a/internal/datamanager/datamanager_test.go
+++ b/internal/datamanager/datamanager_test.go
@@ -318,7 +318,7 @@ func TestWalCleaner(t *testing.T) {
 		}
 	}
 
-	if err := dm.checkpoint(ctx); err != nil {
+	if err := dm.checkpoint(ctx, true); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	if err := dm.walCleaner(ctx); err != nil {
@@ -436,7 +436,7 @@ func TestReadObject(t *testing.T) {
 	}
 
 	// do a checkpoint and wal clean
-	if err := dm.checkpoint(ctx); err != nil {
+	if err := dm.checkpoint(ctx, true); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	if err := dm.walCleaner(ctx); err != nil {
@@ -489,7 +489,7 @@ func doAndCheckCheckpoint(t *testing.T, ctx context.Context, dm *DataManager, ac
 	time.Sleep(500 * time.Millisecond)
 
 	// do a checkpoint
-	if err := dm.checkpoint(ctx); err != nil {
+	if err := dm.checkpoint(ctx, true); err != nil {
 		return nil, err
 	}
 

--- a/internal/datamanager/wal.go
+++ b/internal/datamanager/wal.go
@@ -460,13 +460,14 @@ func (d *DataManager) WriteWalAdditionalOps(ctx context.Context, actions []*Acti
 	}
 	d.log.Debugf("wrote wal file: %s", walDataFilePath)
 
-	walsData.LastCommittedWalSequence = walSequence.String()
-
 	walData := &WalData{
-		WalSequence:   walSequence.String(),
-		WalDataFileID: walDataFileID,
-		WalStatus:     WalStatusCommitted,
+		WalSequence:         walSequence.String(),
+		WalDataFileID:       walDataFileID,
+		WalStatus:           WalStatusCommitted,
+		PreviousWalSequence: walsData.LastCommittedWalSequence,
 	}
+
+	walsData.LastCommittedWalSequence = walSequence.String()
 
 	walsDataj, err := json.Marshal(walsData)
 	if err != nil {
@@ -922,9 +923,10 @@ func (d *DataManager) InitEtcd(ctx context.Context, dataStatus *DataStatus) erro
 		walFile.Close()
 
 		walData := &WalData{
-			WalSequence:   wal.WalSequence,
-			WalDataFileID: header.WalDataFileID,
-			WalStatus:     WalStatusCommittedStorage,
+			WalSequence:         wal.WalSequence,
+			WalDataFileID:       header.WalDataFileID,
+			WalStatus:           WalStatusCommittedStorage,
+			PreviousWalSequence: header.PreviousWalSequence,
 		}
 		if wal.Checkpointed {
 			walData.WalStatus = WalStatusCheckpointed
@@ -1101,13 +1103,14 @@ func (d *DataManager) InitEtcd(ctx context.Context, dataStatus *DataStatus) erro
 		return err
 	}
 
-	lastCommittedStorageWalSequence = walSequence.String()
-
 	walData := &WalData{
-		WalSequence:   walSequence.String(),
-		WalDataFileID: walDataFileID,
-		WalStatus:     WalStatusCommittedStorage,
+		WalSequence:         walSequence.String(),
+		WalDataFileID:       walDataFileID,
+		WalStatus:           WalStatusCommittedStorage,
+		PreviousWalSequence: lastCommittedStorageWalSequence,
 	}
+
+	lastCommittedStorageWalSequence = walSequence.String()
 
 	walsData := &WalsData{
 		LastCommittedWalSequence: lastCommittedStorageWalSequence,

--- a/internal/datamanager/wal.go
+++ b/internal/datamanager/wal.go
@@ -1025,6 +1025,10 @@ func (d *DataManager) InitEtcd(ctx context.Context, dataStatus *DataStatus) erro
 	lastCommittedStorageWalSequence := ""
 	wroteWals := 0
 	for wal := range d.ListOSTWals("") {
+		// if there're wals in ost but not a datastatus return an error
+		if dataStatus == nil {
+			return errors.Errorf("no datastatus in etcd but some wals are present, this shouldn't happen")
+		}
 		d.log.Debugf("wal: %s", wal)
 		if wal.Err != nil {
 			return wal.Err

--- a/internal/etcd/etcd.go
+++ b/internal/etcd/etcd.go
@@ -286,6 +286,22 @@ func (s *Store) Delete(ctx context.Context, key string) error {
 	return err
 }
 
+func (s *Store) DeletePrefix(ctx context.Context, prefix string) error {
+	etcdv3Options := []clientv3.OpOption{}
+
+	key := prefix
+	if len(key) == 0 {
+		key = "\x00"
+		etcdv3Options = append(etcdv3Options, clientv3.WithFromKey())
+	} else {
+		etcdv3Options = append(etcdv3Options, clientv3.WithPrefix())
+	}
+
+	_, err := s.c.Delete(ctx, key, etcdv3Options...)
+
+	return err
+}
+
 func (s *Store) AtomicDelete(ctx context.Context, key string, revision int64) (*etcdclientv3.TxnResponse, error) {
 	cmp := etcdclientv3.Compare(etcdclientv3.ModRevision(key), "=", revision)
 	req := etcdclientv3.OpDelete(key)

--- a/internal/services/configstore/readdb/readdb.go
+++ b/internal/services/configstore/readdb/readdb.go
@@ -188,6 +188,16 @@ func (r *ReadDB) SyncFromDump() (string, error) {
 		}
 	}
 
+	err = r.rdb.Do(func(tx *db.Tx) error {
+		if err := r.insertCommittedWalSequence(tx, dumpIndex.WalSequence); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+
 	return dumpIndex.WalSequence, nil
 }
 

--- a/internal/services/configstore/readdb/readdb.go
+++ b/internal/services/configstore/readdb/readdb.go
@@ -351,15 +351,10 @@ func (r *ReadDB) SyncRDB(ctx context.Context) error {
 	r.log.Debugf("firstAvailableWalData: %s", util.Dump(firstAvailableWalData))
 	r.log.Debugf("revision: %d", revision)
 	if firstAvailableWalData == nil {
-		if curWalSeq != "" {
-			// this happens if etcd has been reset
-			return errors.Errorf("our curwalseq is %q but there's no wal data on etcd", curWalSeq)
-		}
+		return errors.Errorf("no wal data in etcd")
 	}
-	if firstAvailableWalData != nil {
-		if curWalSeq < firstAvailableWalData.WalSequence {
-			return errors.Errorf("current applied wal seq %q is smaller than the first available wal on etcd %q", curWalSeq, firstAvailableWalData.WalSequence)
-		}
+	if curWalSeq < firstAvailableWalData.WalSequence {
+		return errors.Errorf("current applied wal seq %q is smaller than the first available wal in etcd %q", curWalSeq, firstAvailableWalData.WalSequence)
 	}
 
 	r.log.Infof("syncing from wals")

--- a/internal/services/runservice/readdb/readdb.go
+++ b/internal/services/runservice/readdb/readdb.go
@@ -602,6 +602,7 @@ func (r *ReadDB) SyncObjectStorage(ctx context.Context) error {
 		}
 	}
 
+	r.log.Infof("syncing from wals")
 	err = r.rdb.Do(func(tx *db.Tx) error {
 		if err := insertRevisionOST(tx, revision); err != nil {
 			return err
@@ -610,19 +611,19 @@ func (r *ReadDB) SyncObjectStorage(ctx context.Context) error {
 		// use the same revision as previous operation
 		for walElement := range r.dm.ListEtcdWals(ctx, revision) {
 			if walElement.Err != nil {
-				return err
+				return walElement.Err
 			}
 			if walElement.WalData.WalSequence <= curWalSeq {
 				continue
 			}
 
-			if err := r.insertCommittedWalSequenceOST(tx, walElement.WalData.WalSequence); err != nil {
-				return err
-			}
-
 			// update readdb only when the wal has been committed to etcd
 			if walElement.WalData.WalStatus != datamanager.WalStatusCommitted {
 				return nil
+			}
+
+			if err := r.insertCommittedWalSequenceOST(tx, walElement.WalData.WalSequence); err != nil {
+				return err
 			}
 
 			r.log.Debugf("applying wal to db")

--- a/internal/services/runservice/readdb/readdb.go
+++ b/internal/services/runservice/readdb/readdb.go
@@ -591,15 +591,10 @@ func (r *ReadDB) SyncObjectStorage(ctx context.Context) error {
 	r.log.Debugf("firstAvailableWalData: %s", util.Dump(firstAvailableWalData))
 	r.log.Debugf("revision: %d", revision)
 	if firstAvailableWalData == nil {
-		if curWalSeq != "" {
-			// this happens if etcd has been reset
-			return errors.Errorf("our curwalseq is %q but there's no wal data on etcd", curWalSeq)
-		}
+		return errors.Errorf("no wal data in etcd")
 	}
-	if firstAvailableWalData != nil {
-		if curWalSeq < firstAvailableWalData.WalSequence {
-			return errors.Errorf("current applied wal seq %q is smaller than the first available wal on etcd %q", curWalSeq, firstAvailableWalData.WalSequence)
-		}
+	if curWalSeq < firstAvailableWalData.WalSequence {
+		return errors.Errorf("current applied wal seq %q is smaller than the first available wal in etcd %q", curWalSeq, firstAvailableWalData.WalSequence)
 	}
 
 	r.log.Infof("syncing from wals")

--- a/internal/services/runservice/readdb/readdb.go
+++ b/internal/services/runservice/readdb/readdb.go
@@ -702,6 +702,16 @@ func (r *ReadDB) SyncFromDump() (string, error) {
 		}
 	}
 
+	err = r.rdb.Do(func(tx *db.Tx) error {
+		if err := r.insertCommittedWalSequenceOST(tx, dumpIndex.WalSequence); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+
 	return dumpIndex.WalSequence, nil
 }
 


### PR DESCRIPTION
* etcd: add DeletePrefix method
* datamanager: add deleteEtcd method
* datamanager: clean etcd data before reinitialization
* datamanager: add option to force a checkpoint
* datamanager: start initEtcd from last datastatus
* datamanager: create a new wal and checkpoint in initEtcd
* datamanager: accept optional datastatus in initEtcd
* datamanager: error if there're wals but not a datastatus in ost
* datamanager: save previous wal in waldata
* readdb: insert current wal sequence after checking wal status
* readdb: save walSequence provided by data file
* readdb: error if there's no wal in etcd
