### PR TITLE
db: use context functions

### DIFF
--- a/internal/db/create.go
+++ b/internal/db/create.go
@@ -15,6 +15,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 
 	sq "github.com/Masterminds/squirrel"
@@ -27,10 +28,10 @@ const dbVersionTableDDLTmpl = `
 
 const dbVersion = 1
 
-func (db *DB) Create(stmts []string) error {
+func (db *DB) Create(ctx context.Context, stmts []string) error {
 	sb := sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 
-	err := db.Do(func(tx *Tx) error {
+	err := db.Do(ctx, func(tx *Tx) error {
 		if _, err := tx.Exec(dbVersionTableDDLTmpl); err != nil {
 			return errors.Errorf("failed to create dbversion table: %w", err)
 		}
@@ -40,7 +41,7 @@ func (db *DB) Create(stmts []string) error {
 		return err
 	}
 
-	err = db.Do(func(tx *Tx) error {
+	err = db.Do(ctx, func(tx *Tx) error {
 		var version sql.NullInt64
 		q, args, err := sb.Select("max(version)").From("dbversion").ToSql()
 		if err != nil {

--- a/internal/services/configstore/action/org.go
+++ b/internal/services/configstore/action/org.go
@@ -44,7 +44,7 @@ func orgMemberResponse(orgUser *readdb.OrgUser) *OrgMemberResponse {
 
 func (h *ActionHandler) GetOrgMembers(ctx context.Context, orgRef string) ([]*OrgMemberResponse, error) {
 	var orgUsers []*readdb.OrgUser
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		org, err := h.readDB.GetOrg(tx, orgRef)
 		if err != nil {
@@ -85,7 +85,7 @@ func (h *ActionHandler) CreateOrg(ctx context.Context, org *types.Organization) 
 	cgNames := []string{util.EncodeSha256Hex("orgname-" + org.Name)}
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		cgt, err = h.readDB.GetChangeGroupsUpdateTokens(tx, cgNames)
 		if err != nil {
@@ -182,7 +182,7 @@ func (h *ActionHandler) DeleteOrg(ctx context.Context, orgRef string) error {
 
 	var cgt *datamanager.ChangeGroupsUpdateToken
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		// check org existance
 		org, err = h.readDB.GetOrgByName(tx, orgRef)
@@ -232,7 +232,7 @@ func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string
 	var cgt *datamanager.ChangeGroupsUpdateToken
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		// check existing org
 		org, err = h.readDB.GetOrg(tx, orgRef)
@@ -308,7 +308,7 @@ func (h *ActionHandler) RemoveOrgMember(ctx context.Context, orgRef, userRef str
 	var cgt *datamanager.ChangeGroupsUpdateToken
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		// check existing org
 		org, err = h.readDB.GetOrg(tx, orgRef)

--- a/internal/services/configstore/action/project.go
+++ b/internal/services/configstore/action/project.go
@@ -72,7 +72,7 @@ func (h *ActionHandler) CreateProject(ctx context.Context, project *types.Projec
 	var cgt *datamanager.ChangeGroupsUpdateToken
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		group, err := h.readDB.GetProjectGroup(tx, project.Parent.ID)
 		if err != nil {
@@ -167,7 +167,7 @@ func (h *ActionHandler) UpdateProject(ctx context.Context, req *UpdateProjectReq
 	var cgt *datamanager.ChangeGroupsUpdateToken
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		// check project exists
 		p, err := h.readDB.GetProject(tx, req.ProjectRef)
@@ -210,7 +210,7 @@ func (h *ActionHandler) UpdateProject(ctx context.Context, req *UpdateProjectReq
 				return err
 			}
 			if ap != nil {
-				return util.NewErrBadRequest(errors.Errorf("project with name %q, path %q already exists", req.Project.Name,pp))
+				return util.NewErrBadRequest(errors.Errorf("project with name %q, path %q already exists", req.Project.Name, pp))
 			}
 		}
 
@@ -269,7 +269,7 @@ func (h *ActionHandler) DeleteProject(ctx context.Context, projectRef string) er
 	var cgt *datamanager.ChangeGroupsUpdateToken
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 
 		// check project existance

--- a/internal/services/configstore/action/projectgroup.go
+++ b/internal/services/configstore/action/projectgroup.go
@@ -30,7 +30,7 @@ import (
 
 func (h *ActionHandler) GetProjectGroupSubgroups(ctx context.Context, projectGroupRef string) ([]*types.ProjectGroup, error) {
 	var projectGroups []*types.ProjectGroup
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		projectGroup, err := h.readDB.GetProjectGroup(tx, projectGroupRef)
 		if err != nil {
@@ -53,7 +53,7 @@ func (h *ActionHandler) GetProjectGroupSubgroups(ctx context.Context, projectGro
 
 func (h *ActionHandler) GetProjectGroupProjects(ctx context.Context, projectGroupRef string) ([]*types.Project, error) {
 	var projects []*types.Project
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		projectGroup, err := h.readDB.GetProjectGroup(tx, projectGroupRef)
 		if err != nil {
@@ -112,7 +112,7 @@ func (h *ActionHandler) CreateProjectGroup(ctx context.Context, projectGroup *ty
 	var cgt *datamanager.ChangeGroupsUpdateToken
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		parentProjectGroup, err := h.readDB.GetProjectGroup(tx, projectGroup.Parent.ID)
 		if err != nil {
 			return err
@@ -184,7 +184,7 @@ func (h *ActionHandler) UpdateProjectGroup(ctx context.Context, req *UpdateProje
 	var cgt *datamanager.ChangeGroupsUpdateToken
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		// check project exists
 		pg, err := h.readDB.GetProjectGroup(tx, req.ProjectGroupRef)
@@ -280,7 +280,7 @@ func (h *ActionHandler) DeleteProjectGroup(ctx context.Context, projectGroupRef 
 	var cgt *datamanager.ChangeGroupsUpdateToken
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 
 		// check project group existance

--- a/internal/services/configstore/action/remotesource.go
+++ b/internal/services/configstore/action/remotesource.go
@@ -74,7 +74,7 @@ func (h *ActionHandler) CreateRemoteSource(ctx context.Context, remoteSource *ty
 	cgNames := []string{util.EncodeSha256Hex("remotesourcename-" + remoteSource.Name)}
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		cgt, err = h.readDB.GetChangeGroupsUpdateTokens(tx, cgNames)
 		if err != nil {
@@ -129,7 +129,7 @@ func (h *ActionHandler) UpdateRemoteSource(ctx context.Context, req *UpdateRemot
 	var cgt *datamanager.ChangeGroupsUpdateToken
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 
 		// check remotesource exists
@@ -190,7 +190,7 @@ func (h *ActionHandler) DeleteRemoteSource(ctx context.Context, remoteSourceName
 	var cgt *datamanager.ChangeGroupsUpdateToken
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 
 		// check remoteSource existance

--- a/internal/services/configstore/action/secret.go
+++ b/internal/services/configstore/action/secret.go
@@ -29,7 +29,7 @@ import (
 
 func (h *ActionHandler) GetSecret(ctx context.Context, secretID string) (*types.Secret, error) {
 	var secret *types.Secret
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		secret, err = h.readDB.GetSecretByID(tx, secretID)
 		return err
@@ -47,7 +47,7 @@ func (h *ActionHandler) GetSecret(ctx context.Context, secretID string) (*types.
 
 func (h *ActionHandler) GetSecrets(ctx context.Context, parentType types.ConfigType, parentRef string, tree bool) ([]*types.Secret, error) {
 	var secrets []*types.Secret
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		parentID, err := h.readDB.ResolveConfigID(tx, parentType, parentRef)
 		if err != nil {
 			return err
@@ -105,7 +105,7 @@ func (h *ActionHandler) CreateSecret(ctx context.Context, secret *types.Secret) 
 	cgNames := []string{util.EncodeSha256Hex("secretname-" + secret.Name)}
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		cgt, err = h.readDB.GetChangeGroupsUpdateTokens(tx, cgNames)
 		if err != nil {
@@ -168,7 +168,7 @@ func (h *ActionHandler) UpdateSecret(ctx context.Context, req *UpdateSecretReque
 	// changegroup is the secret name
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 
 		parentID, err := h.readDB.ResolveConfigID(tx, req.Secret.Parent.Type, req.Secret.Parent.ID)
@@ -238,7 +238,7 @@ func (h *ActionHandler) DeleteSecret(ctx context.Context, parentType types.Confi
 	var cgt *datamanager.ChangeGroupsUpdateToken
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		parentID, err := h.readDB.ResolveConfigID(tx, parentType, parentRef)
 		if err != nil {

--- a/internal/services/configstore/action/user.go
+++ b/internal/services/configstore/action/user.go
@@ -50,7 +50,7 @@ func (h *ActionHandler) CreateUser(ctx context.Context, req *CreateUserRequest) 
 	var rs *types.RemoteSource
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		cgt, err = h.readDB.GetChangeGroupsUpdateTokens(tx, cgNames)
 		if err != nil {
@@ -156,7 +156,7 @@ func (h *ActionHandler) DeleteUser(ctx context.Context, userRef string) error {
 
 	var cgt *datamanager.ChangeGroupsUpdateToken
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 
 		// check user existance
@@ -206,7 +206,7 @@ func (h *ActionHandler) UpdateUser(ctx context.Context, req *UpdateUserRequest) 
 	var user *types.User
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		user, err = h.readDB.GetUser(tx, req.UserRef)
 		if err != nil {
@@ -289,7 +289,7 @@ func (h *ActionHandler) CreateUserLA(ctx context.Context, req *CreateUserLAReque
 	var cgt *datamanager.ChangeGroupsUpdateToken
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		user, err = h.readDB.GetUser(tx, req.UserRef)
 		if err != nil {
@@ -374,7 +374,7 @@ func (h *ActionHandler) DeleteUserLA(ctx context.Context, userRef, laID string) 
 	var cgt *datamanager.ChangeGroupsUpdateToken
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		user, err = h.readDB.GetUser(tx, userRef)
 		if err != nil {
@@ -444,7 +444,7 @@ func (h *ActionHandler) UpdateUserLA(ctx context.Context, req *UpdateUserLAReque
 	var cgt *datamanager.ChangeGroupsUpdateToken
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		user, err = h.readDB.GetUser(tx, req.UserRef)
 		if err != nil {
@@ -518,7 +518,7 @@ func (h *ActionHandler) CreateUserToken(ctx context.Context, userRef, tokenName 
 	var cgt *datamanager.ChangeGroupsUpdateToken
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		user, err = h.readDB.GetUser(tx, userRef)
 		if err != nil {
@@ -583,7 +583,7 @@ func (h *ActionHandler) DeleteUserToken(ctx context.Context, userRef, tokenName 
 	var cgt *datamanager.ChangeGroupsUpdateToken
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		user, err = h.readDB.GetUser(tx, userRef)
 		if err != nil {
@@ -644,7 +644,7 @@ func userOrgsResponse(userOrg *readdb.UserOrg) *UserOrgsResponse {
 
 func (h *ActionHandler) GetUserOrgs(ctx context.Context, userRef string) ([]*UserOrgsResponse, error) {
 	var userOrgs []*readdb.UserOrg
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		user, err := h.readDB.GetUser(tx, userRef)
 		if err != nil {

--- a/internal/services/configstore/action/variable.go
+++ b/internal/services/configstore/action/variable.go
@@ -29,7 +29,7 @@ import (
 
 func (h *ActionHandler) GetVariables(ctx context.Context, parentType types.ConfigType, parentRef string, tree bool) ([]*types.Variable, error) {
 	var variables []*types.Variable
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		parentID, err := h.readDB.ResolveConfigID(tx, parentType, parentRef)
 		if err != nil {
 			return err
@@ -81,7 +81,7 @@ func (h *ActionHandler) CreateVariable(ctx context.Context, variable *types.Vari
 	cgNames := []string{util.EncodeSha256Hex("variablename-" + variable.Name)}
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		cgt, err = h.readDB.GetChangeGroupsUpdateTokens(tx, cgNames)
 		if err != nil {
@@ -144,7 +144,7 @@ func (h *ActionHandler) UpdateVariable(ctx context.Context, req *UpdateVariableR
 	// changegroup is the variable name
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 
 		parentID, err := h.readDB.ResolveConfigID(tx, req.Variable.Parent.Type, req.Variable.Parent.ID)
@@ -214,7 +214,7 @@ func (h *ActionHandler) DeleteVariable(ctx context.Context, parentType types.Con
 	var cgt *datamanager.ChangeGroupsUpdateToken
 
 	// must do all the checks in a single transaction to avoid concurrent changes
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		parentID, err := h.readDB.ResolveConfigID(tx, parentType, parentRef)
 		if err != nil {

--- a/internal/services/configstore/api/org.go
+++ b/internal/services/configstore/api/org.go
@@ -40,11 +40,12 @@ func NewOrgHandler(logger *zap.Logger, readDB *readdb.ReadDB) *OrgHandler {
 }
 
 func (h *OrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	vars := mux.Vars(r)
 	orgRef := vars["orgref"]
 
 	var org *types.Organization
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		org, err = h.readDB.GetOrg(tx, orgRef)
 		return err
@@ -105,7 +106,6 @@ func NewDeleteOrgHandler(logger *zap.Logger, ah *action.ActionHandler) *DeleteOr
 }
 
 func (h *DeleteOrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	h.log.Infof("deleteorghandler")
 	ctx := r.Context()
 
 	vars := mux.Vars(r)
@@ -136,6 +136,7 @@ func NewOrgsHandler(logger *zap.Logger, readDB *readdb.ReadDB) *OrgsHandler {
 }
 
 func (h *OrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	query := r.URL.Query()
 
 	limitS := query.Get("limit")
@@ -163,7 +164,7 @@ func (h *OrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	start := query.Get("start")
 
 	var orgs []*types.Organization
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		orgs, err = h.readDB.GetOrgs(tx, start, limit, asc)
 		return err

--- a/internal/services/configstore/api/remotesource.go
+++ b/internal/services/configstore/api/remotesource.go
@@ -40,11 +40,12 @@ func NewRemoteSourceHandler(logger *zap.Logger, readDB *readdb.ReadDB) *RemoteSo
 }
 
 func (h *RemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	vars := mux.Vars(r)
 	rsRef := vars["remotesourceref"]
 
 	var remoteSource *types.RemoteSource
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		remoteSource, err = h.readDB.GetRemoteSource(tx, rsRef)
 		return err
@@ -171,6 +172,7 @@ func NewRemoteSourcesHandler(logger *zap.Logger, readDB *readdb.ReadDB) *RemoteS
 }
 
 func (h *RemoteSourcesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	query := r.URL.Query()
 
 	limitS := query.Get("limit")
@@ -197,7 +199,7 @@ func (h *RemoteSourcesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	start := query.Get("start")
 
-	remoteSources, err := h.readDB.GetRemoteSources(start, limit, asc)
+	remoteSources, err := h.readDB.GetRemoteSources(ctx, start, limit, asc)
 	if err != nil {
 		h.log.Errorf("err: %+v", err)
 		httpError(w, err)

--- a/internal/services/configstore/api/secret.go
+++ b/internal/services/configstore/api/secret.go
@@ -94,7 +94,7 @@ func (h *SecretsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		resSecrets[i] = &Secret{Secret: s}
 	}
 
-	err = h.readDB.Do(func(tx *db.Tx) error {
+	err = h.readDB.Do(ctx, func(tx *db.Tx) error {
 		// populate parent path
 		for _, s := range resSecrets {
 			pp, err := h.readDB.GetPath(tx, s.Parent.Type, s.Parent.ID)

--- a/internal/services/configstore/api/user.go
+++ b/internal/services/configstore/api/user.go
@@ -41,11 +41,12 @@ func NewUserHandler(logger *zap.Logger, readDB *readdb.ReadDB) *UserHandler {
 }
 
 func (h *UserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	vars := mux.Vars(r)
 	userRef := vars["userref"]
 
 	var user *types.User
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		user, err = h.readDB.GetUser(tx, userRef)
 		return err
@@ -198,6 +199,7 @@ func NewUsersHandler(logger *zap.Logger, readDB *readdb.ReadDB) *UsersHandler {
 }
 
 func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	query := r.URL.Query()
 
 	limitS := query.Get("limit")
@@ -232,7 +234,7 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "bytoken":
 		token := query.Get("token")
 		var user *types.User
-		err := h.readDB.Do(func(tx *db.Tx) error {
+		err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 			var err error
 			user, err = h.readDB.GetUserByTokenValue(tx, token)
 			return err
@@ -250,7 +252,7 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "bylinkedaccount":
 		linkedAccountID := query.Get("linkedaccountid")
 		var user *types.User
-		err := h.readDB.Do(func(tx *db.Tx) error {
+		err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 			var err error
 			user, err = h.readDB.GetUserByLinkedAccount(tx, linkedAccountID)
 			return err
@@ -269,7 +271,7 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		remoteUserID := query.Get("remoteuserid")
 		remoteSourceID := query.Get("remotesourceid")
 		var user *types.User
-		err := h.readDB.Do(func(tx *db.Tx) error {
+		err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 			var err error
 			user, err = h.readDB.GetUserByLinkedAccountRemoteUserIDandSource(tx, remoteUserID, remoteSourceID)
 			return err
@@ -286,7 +288,7 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		users = []*types.User{user}
 	default:
 		// default query
-		err := h.readDB.Do(func(tx *db.Tx) error {
+		err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 			var err error
 			users, err = h.readDB.GetUsers(tx, start, limit, asc)
 			return err

--- a/internal/services/configstore/api/variable.go
+++ b/internal/services/configstore/api/variable.go
@@ -67,7 +67,7 @@ func (h *VariablesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for i, v := range variables {
 		resVariables[i] = &Variable{Variable: v}
 	}
-	err = h.readDB.Do(func(tx *db.Tx) error {
+	err = h.readDB.Do(ctx, func(tx *db.Tx) error {
 		// populate parent path
 		for _, v := range resVariables {
 			pp, err := h.readDB.GetPath(tx, v.Parent.Type, v.Parent.ID)

--- a/internal/services/configstore/configstore_test.go
+++ b/internal/services/configstore/configstore_test.go
@@ -99,9 +99,9 @@ func setupConfigstore(t *testing.T, ctx context.Context, dir string) (*Configsto
 	return cs, tetcd
 }
 
-func getProjects(cs *Configstore) ([]*types.Project, error) {
+func getProjects(ctx context.Context, cs *Configstore) ([]*types.Project, error) {
 	var projects []*types.Project
-	err := cs.readDB.Do(func(tx *db.Tx) error {
+	err := cs.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		projects, err = cs.readDB.GetAllProjects(tx)
 		return err
@@ -109,9 +109,9 @@ func getProjects(cs *Configstore) ([]*types.Project, error) {
 	return projects, err
 }
 
-func getUsers(cs *Configstore) ([]*types.User, error) {
+func getUsers(ctx context.Context, cs *Configstore) ([]*types.User, error) {
 	var users []*types.User
-	err := cs.readDB.Do(func(tx *db.Tx) error {
+	err := cs.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		users, err = cs.readDB.GetUsers(tx, "", 0, true)
 		return err
@@ -242,12 +242,12 @@ func TestResync(t *testing.T) {
 
 	time.Sleep(5 * time.Second)
 
-	users1, err := getUsers(cs1)
+	users1, err := getUsers(ctx, cs1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	users2, err := getUsers(cs2)
+	users2, err := getUsers(ctx, cs2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -275,12 +275,12 @@ func TestResync(t *testing.T) {
 
 	time.Sleep(5 * time.Second)
 
-	users1, err = getUsers(cs1)
+	users1, err = getUsers(ctx, cs1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	users3, err := getUsers(cs3)
+	users3, err := getUsers(ctx, cs3)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestUser(t *testing.T) {
 		}
 	})
 	t.Run("concurrent user with same name creation", func(t *testing.T) {
-		prevUsers, err := getUsers(cs)
+		prevUsers, err := getUsers(ctx, cs)
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
@@ -364,7 +364,7 @@ func TestUser(t *testing.T) {
 
 		time.Sleep(5 * time.Second)
 
-		users, err := getUsers(cs)
+		users, err := getUsers(ctx, cs)
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
@@ -494,7 +494,7 @@ func TestProjectGroupsAndProjects(t *testing.T) {
 	})
 
 	t.Run("concurrent project with same name creation", func(t *testing.T) {
-		prevProjects, err := getProjects(cs)
+		prevProjects, err := getProjects(ctx, cs)
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
@@ -511,7 +511,7 @@ func TestProjectGroupsAndProjects(t *testing.T) {
 
 		time.Sleep(1 * time.Second)
 
-		projects, err := getProjects(cs)
+		projects, err := getProjects(ctx, cs)
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}

--- a/internal/services/configstore/readdb/remotesource.go
+++ b/internal/services/configstore/readdb/remotesource.go
@@ -15,6 +15,7 @@
 package readdb
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 
@@ -139,7 +140,7 @@ func getRemoteSourcesFilteredQuery(startRemoteSourceName string, limit int, asc 
 	return s
 }
 
-func (r *ReadDB) GetRemoteSources(startRemoteSourceName string, limit int, asc bool) ([]*types.RemoteSource, error) {
+func (r *ReadDB) GetRemoteSources(ctx context.Context, startRemoteSourceName string, limit int, asc bool) ([]*types.RemoteSource, error) {
 	var remoteSources []*types.RemoteSource
 
 	s := getRemoteSourcesFilteredQuery(startRemoteSourceName, limit, asc)
@@ -149,7 +150,7 @@ func (r *ReadDB) GetRemoteSources(startRemoteSourceName string, limit int, asc b
 		return nil, errors.Errorf("failed to build query: %w", err)
 	}
 
-	err = r.rdb.Do(func(tx *db.Tx) error {
+	err = r.rdb.Do(ctx, func(tx *db.Tx) error {
 		rows, err := tx.Query(q, args...)
 		if err != nil {
 			return err

--- a/internal/services/gateway/gateway.go
+++ b/internal/services/gateway/gateway.go
@@ -142,12 +142,12 @@ func (g *Gateway) Run(ctx context.Context) error {
 		return h
 	}
 
-if len(g.c.Web.AllowedOrigins) > 0 {
-	corsAllowedMethodsOptions := ghandlers.AllowedMethods([]string{"GET", "HEAD", "POST", "PUT", "DELETE"})
-	corsAllowedHeadersOptions := ghandlers.AllowedHeaders([]string{"Accept", "Accept-Encoding", "Authorization", "Content-Length", "Content-Type", "X-CSRF-Token", "Authorization"})
-	corsAllowedOriginsOptions := ghandlers.AllowedOrigins(g.c.Web.AllowedOrigins)
-	corsHandler = ghandlers.CORS(corsAllowedMethodsOptions, corsAllowedHeadersOptions, corsAllowedOriginsOptions)
-}
+	if len(g.c.Web.AllowedOrigins) > 0 {
+		corsAllowedMethodsOptions := ghandlers.AllowedMethods([]string{"GET", "HEAD", "POST", "PUT", "DELETE"})
+		corsAllowedHeadersOptions := ghandlers.AllowedHeaders([]string{"Accept", "Accept-Encoding", "Authorization", "Content-Length", "Content-Type", "X-CSRF-Token", "Authorization"})
+		corsAllowedOriginsOptions := ghandlers.AllowedOrigins(g.c.Web.AllowedOrigins)
+		corsHandler = ghandlers.CORS(corsAllowedMethodsOptions, corsAllowedHeadersOptions, corsAllowedOriginsOptions)
+	}
 
 	webhooksHandler := api.NewWebhooksHandler(logger, g.ah, g.configstoreClient, g.runserviceClient, g.c.APIExposedURL)
 

--- a/internal/services/runservice/action/action.go
+++ b/internal/services/runservice/action/action.go
@@ -381,7 +381,7 @@ func (h *ActionHandler) saveRun(ctx context.Context, rb *types.RunBundle, runcgt
 	run := rb.Run
 	rc := rb.Rc
 
-	c, cgt, err := h.getRunCounter(run.Group)
+	c, cgt, err := h.getRunCounter(ctx, run.Group)
 	h.log.Debugf("c: %d, cgt: %s", c, util.Dump(cgt))
 	if err != nil {
 		return err
@@ -570,7 +570,7 @@ func (h *ActionHandler) DeleteExecutor(ctx context.Context, executorID string) e
 	return nil
 }
 
-func (h *ActionHandler) getRunCounter(group string) (uint64, *datamanager.ChangeGroupsUpdateToken, error) {
+func (h *ActionHandler) getRunCounter(ctx context.Context, group string) (uint64, *datamanager.ChangeGroupsUpdateToken, error) {
 	// use the first group dir after the root
 	pl := util.PathList(group)
 	if len(pl) < 2 {
@@ -579,7 +579,7 @@ func (h *ActionHandler) getRunCounter(group string) (uint64, *datamanager.Change
 
 	var c uint64
 	var cgt *datamanager.ChangeGroupsUpdateToken
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		c, err = h.readDB.GetRunCounterOST(tx, pl[1])
 		if err != nil {

--- a/internal/services/runservice/api/api.go
+++ b/internal/services/runservice/api/api.go
@@ -323,12 +323,13 @@ func NewChangeGroupsUpdateTokensHandler(logger *zap.Logger, readDB *readdb.ReadD
 }
 
 func (h *ChangeGroupsUpdateTokensHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	query := r.URL.Query()
 	groups := query["changegroup"]
 
 	var cgt *types.ChangeGroupsUpdateToken
 
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		cgt, err = h.readDB.GetChangeGroupsUpdateTokens(tx, groups)
 		return err
@@ -372,6 +373,7 @@ func NewRunHandler(logger *zap.Logger, e *etcd.Store, dm *datamanager.DataManage
 }
 
 func (h *RunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	vars := mux.Vars(r)
 	runID := vars["runid"]
 
@@ -381,7 +383,7 @@ func (h *RunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var run *types.Run
 	var cgt *types.ChangeGroupsUpdateToken
 
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		run, err = h.readDB.GetRun(tx, runID)
 		if err != nil {
@@ -447,6 +449,7 @@ func NewRunsHandler(logger *zap.Logger, readDB *readdb.ReadDB) *RunsHandler {
 }
 
 func (h *RunsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	query := r.URL.Query()
 	phaseFilter := types.RunPhaseFromStringSlice(query["phase"])
 	resultFilter := types.RunResultFromStringSlice(query["result"])
@@ -482,7 +485,7 @@ func (h *RunsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var runs []*types.Run
 	var cgt *types.ChangeGroupsUpdateToken
 
-	err := h.readDB.Do(func(tx *db.Tx) error {
+	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		runs, err = h.readDB.GetRuns(tx, groups, lastRun, phaseFilter, resultFilter, start, limit, sortOrder)
 		if err != nil {


### PR DESCRIPTION
Use the go sql context functions (ExecContext, QueryContext etc...)

The context is saved inside Tx so the library users should only pass it one time
to the db.Do function.