### PR TITLE
runservice: maintenance/export/import

### DIFF
--- a/internal/services/runservice/action/action.go
+++ b/internal/services/runservice/action/action.go
@@ -37,21 +37,27 @@ import (
 )
 
 type ActionHandler struct {
-	log    *zap.SugaredLogger
-	e      *etcd.Store
-	readDB *readdb.ReadDB
-	ost    *objectstorage.ObjStorage
-	dm     *datamanager.DataManager
+	log             *zap.SugaredLogger
+	e               *etcd.Store
+	readDB          *readdb.ReadDB
+	ost             *objectstorage.ObjStorage
+	dm              *datamanager.DataManager
+	maintenanceMode bool
 }
 
 func NewActionHandler(logger *zap.Logger, e *etcd.Store, readDB *readdb.ReadDB, ost *objectstorage.ObjStorage, dm *datamanager.DataManager) *ActionHandler {
 	return &ActionHandler{
-		log:    logger.Sugar(),
-		e:      e,
-		readDB: readDB,
-		ost:    ost,
-		dm:     dm,
+		log:             logger.Sugar(),
+		e:               e,
+		readDB:          readDB,
+		ost:             ost,
+		dm:              dm,
+		maintenanceMode: false,
 	}
+}
+
+func (h *ActionHandler) SetMaintenanceMode(maintenanceMode bool) {
+	h.maintenanceMode = maintenanceMode
 }
 
 type RunChangePhaseRequest struct {

--- a/internal/services/runservice/action/maintenance.go
+++ b/internal/services/runservice/action/maintenance.go
@@ -1,0 +1,73 @@
+// Copyright 2019 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"context"
+	"io"
+
+	"agola.io/agola/internal/etcd"
+	"agola.io/agola/internal/services/runservice/common"
+	"agola.io/agola/internal/util"
+
+	errors "golang.org/x/xerrors"
+)
+
+func (h *ActionHandler) MaintenanceMode(ctx context.Context, enable bool) error {
+	resp, err := h.e.Get(ctx, common.EtcdMaintenanceKey, 0)
+	if err != nil && err != etcd.ErrKeyNotFound {
+		return err
+	}
+
+	if enable && len(resp.Kvs) > 0 {
+		return util.NewErrBadRequest(errors.Errorf("maintenance mode already enabled"))
+	}
+	if !enable && len(resp.Kvs) == 0 {
+		return util.NewErrBadRequest(errors.Errorf("maintenance mode already disabled"))
+	}
+
+	if enable {
+		txResp, err := h.e.AtomicPut(ctx, common.EtcdMaintenanceKey, []byte{}, 0, nil)
+		if err != nil {
+			return err
+		}
+		if !txResp.Succeeded {
+			return errors.Errorf("failed to create maintenance mode key due to concurrent update")
+		}
+	}
+
+	if !enable {
+		txResp, err := h.e.AtomicDelete(ctx, common.EtcdMaintenanceKey, resp.Kvs[0].ModRevision)
+		if err != nil {
+			return err
+		}
+		if !txResp.Succeeded {
+			return errors.Errorf("failed to delete maintenance mode key due to concurrent update")
+		}
+	}
+
+	return nil
+}
+
+func (h *ActionHandler) Export(ctx context.Context, w io.Writer) error {
+	return h.dm.Export(ctx, w)
+}
+
+func (h *ActionHandler) Import(ctx context.Context, r io.Reader) error {
+	if !h.maintenanceMode {
+		return util.NewErrBadRequest(errors.Errorf("not in maintenance mode"))
+	}
+	return h.dm.Import(ctx, r)
+}

--- a/internal/services/runservice/api/maintenance.go
+++ b/internal/services/runservice/api/maintenance.go
@@ -1,0 +1,107 @@
+// Copyright 2019 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"net/http"
+
+	"agola.io/agola/internal/etcd"
+	"agola.io/agola/internal/services/runservice/action"
+
+	"go.uber.org/zap"
+)
+
+type MaintenanceModeHandler struct {
+	log *zap.SugaredLogger
+	ah  *action.ActionHandler
+	e   *etcd.Store
+}
+
+func NewMaintenanceModeHandler(logger *zap.Logger, ah *action.ActionHandler, e *etcd.Store) *MaintenanceModeHandler {
+	return &MaintenanceModeHandler{log: logger.Sugar(), ah: ah, e: e}
+}
+
+func (h *MaintenanceModeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	enable := false
+	switch r.Method {
+	case "PUT":
+		enable = true
+	case "DELETE":
+		enable = false
+	}
+
+	err := h.ah.MaintenanceMode(ctx, enable)
+	if err != nil {
+		h.log.Errorf("err: %+v", err)
+		httpError(w, err)
+		return
+	}
+
+	if err := httpResponse(w, http.StatusOK, nil); err != nil {
+		h.log.Errorf("err: %+v", err)
+	}
+
+}
+
+type ExportHandler struct {
+	log *zap.SugaredLogger
+	ah  *action.ActionHandler
+}
+
+func NewExportHandler(logger *zap.Logger, ah *action.ActionHandler) *ExportHandler {
+	return &ExportHandler{log: logger.Sugar(), ah: ah}
+}
+
+func (h *ExportHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	err := h.ah.Export(ctx, w)
+	if err != nil {
+		h.log.Errorf("err: %+v", err)
+		// since we already answered with a 200 we cannot return another error code
+		// So abort the connection and the client will detect the missing ending chunk
+		// and consider this an error
+		//
+		// this is the way to force close a request without logging the panic
+		panic(http.ErrAbortHandler)
+	}
+}
+
+type ImportHandler struct {
+	log *zap.SugaredLogger
+	ah  *action.ActionHandler
+}
+
+func NewImportHandler(logger *zap.Logger, ah *action.ActionHandler) *ImportHandler {
+	return &ImportHandler{log: logger.Sugar(), ah: ah}
+}
+
+func (h *ImportHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	err := h.ah.Import(ctx, r.Body)
+	if err != nil {
+		h.log.Errorf("err: %+v", err)
+		httpError(w, err)
+		return
+	}
+
+	if err := httpResponse(w, http.StatusOK, nil); err != nil {
+		h.log.Errorf("err: %+v", err)
+	}
+
+}

--- a/internal/services/runservice/common/common.go
+++ b/internal/services/runservice/common/common.go
@@ -53,6 +53,8 @@ var (
 	EtcdCompactChangeGroupsLockKey = path.Join(EtcdSchedulerBaseDir, "compactchangegroupslock")
 	EtcdCacheCleanerLockKey        = path.Join(EtcdSchedulerBaseDir, "locks", "cachecleaner")
 	EtcdTaskUpdaterLockKey         = path.Join(EtcdSchedulerBaseDir, "locks", "taskupdater")
+
+	EtcdMaintenanceKey = "maintenance"
 )
 
 func EtcdRunKey(runID string) string       { return path.Join(EtcdRunsDir, runID) }


### PR DESCRIPTION
Implement runservice maintenance mode and export/import.

When runservice is set in maintenance mode it'll start only the maintenance and
export/import handlers.

Setting maintenance mode will set a key in etcd so all the runservice instances
will detect it and enter in maintenance mode. This is done asyncronously so it
could take some time (future improvements will add some api to show all the
runservice states)

Export is always available and will export the datamanager contents. Currently
only datamanager contents are exported (no logs and workspace archives).

Import is available only during maintenance, given a datamanager export will
import it and reset etcd to this import state.
