### PR TITLE
executor: fix typo in setting task endTime when setup failed

### DIFF
--- a/internal/services/executor/executor.go
+++ b/internal/services/executor/executor.go
@@ -788,8 +788,8 @@ func (e *Executor) executeTask(ctx context.Context, et *types.ExecutorTask) {
 
 	if err := e.setupTask(ctx, rt); err != nil {
 		log.Errorf("err: %+v", err)
-		rt.et.Status.Phase = types.ExecutorTaskPhaseFailed
-		et.Status.SetupStep.EndTime = util.TimePtr(time.Now())
+		et.Status.Phase = types.ExecutorTaskPhaseFailed
+		et.Status.EndTime = util.TimePtr(time.Now())
 		et.Status.SetupStep.Phase = types.ExecutorTaskPhaseFailed
 		et.Status.SetupStep.EndTime = util.TimePtr(time.Now())
 		if err := e.sendExecutorTaskStatus(ctx, et); err != nil {
@@ -812,12 +812,12 @@ func (e *Executor) executeTask(ctx context.Context, et *types.ExecutorTask) {
 	rt.Lock()
 	if err != nil {
 		log.Errorf("err: %+v", err)
-		rt.et.Status.Phase = types.ExecutorTaskPhaseFailed
+		et.Status.Phase = types.ExecutorTaskPhaseFailed
 	} else {
-		rt.et.Status.Phase = types.ExecutorTaskPhaseSuccess
+		et.Status.Phase = types.ExecutorTaskPhaseSuccess
 	}
 
-	rt.et.Status.EndTime = util.TimePtr(time.Now())
+	et.Status.EndTime = util.TimePtr(time.Now())
 
 	if err := e.sendExecutorTaskStatus(ctx, et); err != nil {
 		log.Errorf("err: %+v", err)


### PR DESCRIPTION
There was a typo so we weren't setting the task endTime when the setup step
failed.

Also unify all logic to just use `et` (instead of a mix of `et` or `rt.et`)