### PR TITLE
executor: set task endTime when marking as failed

### DIFF
--- a/internal/services/executor/executor.go
+++ b/internal/services/executor/executor.go
@@ -1162,6 +1162,7 @@ func (e *Executor) taskUpdater(ctx context.Context, et *types.ExecutorTask) {
 		if !ok {
 			log.Infof("marking executor task %s as failed since there's no running task", et.ID)
 			et.Status.Phase = types.ExecutorTaskPhaseFailed
+			et.Status.EndTime = util.TimePtr(time.Now())
 			// mark in progress step as failed too
 			for _, s := range et.Status.Steps {
 				if s.Phase == types.ExecutorTaskPhaseRunning {


### PR DESCRIPTION
Add missing set of task endTime when the executor is marking the task as failed
due to no related running task (usually after executor restart).