### PR TITLE
docker driver: use toolbox exec

### DIFF
--- a/internal/services/executor/driver/docker_test.go
+++ b/internal/services/executor/driver/docker_test.go
@@ -96,6 +96,10 @@ func TestDockerPod(t *testing.T) {
 
 	ctx := context.Background()
 
+	if err := d.Setup(ctx); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
 	t.Run("create a pod with one container", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
 			ID:     uuid.NewV4().String(),

--- a/internal/services/executor/driver/k8s_test.go
+++ b/internal/services/executor/driver/k8s_test.go
@@ -48,6 +48,10 @@ func TestK8sPod(t *testing.T) {
 
 	ctx := context.Background()
 
+	if err := d.Setup(ctx); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
 	t.Run("create a pod with one container", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
 			ID:     uuid.NewV4().String(),


### PR DESCRIPTION
Older version of docker doesn't support the exec api Env and WorkingDir options.

Support these versions by doing the same we already do with the k8s driver: use
the `toolbox exec` command that will set the provided Env, change the cwd to the
WorkingDir and the exec the wanted command.