### PR TITLE
docker driver: use fixed client api version

### DIFF
--- a/internal/services/executor/driver/docker.go
+++ b/internal/services/executor/driver/docker.go
@@ -51,7 +51,7 @@ type DockerDriver struct {
 }
 
 func NewDockerDriver(logger *zap.Logger, executorID, initVolumeHostDir, toolboxPath string) (*DockerDriver, error) {
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.26"))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Set the client required api version to 1.26. In this way we'll work with docker >= 1.13.1