### PR TITLE
userdirectrun: allow setting destination branch/tag/ref

### DIFF
--- a/.agola/config.jsonnet
+++ b/.agola/config.jsonnet
@@ -92,7 +92,7 @@ local task_build_docker_tests(version, arch) = {
               |||,
             },
             { type: 'restore_workspace', dest_dir: '.' },
-            { type: 'run', name: 'integration tests', command: 'AGOLA_TOOLBOX_PATH="./bin" GITEA_PATH=${PWD}/bin/gitea DOCKER_BRIDGE_ADDRESS="172.18.0.1" ./bin/integration-tests -test.parallel 1 -test.v' },
+            { type: 'run', name: 'integration tests', command: 'AGOLA_BIN_DIR="./bin" GITEA_PATH=${PWD}/bin/gitea DOCKER_BRIDGE_ADDRESS="172.18.0.1" ./bin/integration-tests -test.parallel 1 -test.v' },
           ],
           depends: [
             'build go 1.12 amd64',

--- a/internal/gitsources/gitea/gitea.go
+++ b/internal/gitsources/gitea/gitea.go
@@ -442,7 +442,7 @@ func (c *Client) RefType(ref string) (gitsource.RefType, string, error) {
 
 	case pullRequestRefRegex.MatchString(ref):
 		m := pullRequestRefRegex.FindStringSubmatch(ref)
-		return gitsource.RefTypePullRequest, m[0], nil
+		return gitsource.RefTypePullRequest, m[1], nil
 
 	default:
 		return -1, "", fmt.Errorf("unsupported ref: %s", ref)

--- a/internal/gitsources/github/github.go
+++ b/internal/gitsources/github/github.go
@@ -437,7 +437,7 @@ func (c *Client) RefType(ref string) (gitsource.RefType, string, error) {
 
 	case pullRequestRefRegex.MatchString(ref):
 		m := pullRequestRefRegex.FindStringSubmatch(ref)
-		return gitsource.RefTypePullRequest, m[0], nil
+		return gitsource.RefTypePullRequest, m[1], nil
 
 	default:
 		return -1, "", fmt.Errorf("unsupported ref: %s", ref)

--- a/internal/gitsources/gitlab/gitlab.go
+++ b/internal/gitsources/gitlab/gitlab.go
@@ -336,7 +336,7 @@ func (c *Client) RefType(ref string) (gitsource.RefType, string, error) {
 
 	case pullRequestRefRegex.MatchString(ref):
 		m := pullRequestRefRegex.FindStringSubmatch(ref)
-		return gitsource.RefTypePullRequest, m[0], nil
+		return gitsource.RefTypePullRequest, m[1], nil
 
 	default:
 		return -1, "", fmt.Errorf("unsupported ref: %s", ref)

--- a/internal/services/gateway/action/project.go
+++ b/internal/services/gateway/action/project.go
@@ -528,14 +528,12 @@ func (h *ActionHandler) ProjectCreateRun(ctx context.Context, projectRef, branch
 		refType = types.RunRefTypeBranch
 		message = commit.Message
 		branchLink = gitSource.BranchLink(repoInfo, branch)
-
 	}
 
 	if tag != "" {
-		refType = types.RunRefTypeBranch
+		refType = types.RunRefTypeTag
 		message = fmt.Sprintf("Tag %s", tag)
 		tagLink = gitSource.TagLink(repoInfo, tag)
-
 	}
 
 	// use remotesource skipSSHHostKeyCheck config and override with project config if set to true there

--- a/internal/services/gateway/api/user.go
+++ b/internal/services/gateway/api/user.go
@@ -570,11 +570,14 @@ func (h *UserCreateRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	creq := &action.UserCreateRunRequest{
-		RepoUUID:  req.RepoUUID,
-		RepoPath:  req.RepoPath,
-		Branch:    req.Branch,
-		CommitSHA: req.CommitSHA,
-		Message:   req.Message,
+		RepoUUID:              req.RepoUUID,
+		RepoPath:              req.RepoPath,
+		Branch:                req.Branch,
+		Tag:                   req.Tag,
+		Ref:                   req.Ref,
+		CommitSHA:             req.CommitSHA,
+		Message:               req.Message,
+		PullRequestRefRegexes: req.PullRequestRefRegexes,
 	}
 	err := h.ah.UserCreateRun(ctx, creq)
 	if httpError(w, err) {

--- a/services/gateway/api/types/user.go
+++ b/services/gateway/api/types/user.go
@@ -98,6 +98,10 @@ type UserCreateRunRequest struct {
 	RepoUUID  string `json:"repo_uuid,omitempty"`
 	RepoPath  string `json:"repo_path,omitempty"`
 	Branch    string `json:"branch,omitempty"`
+	Tag       string `json:"tag,omitempty"`
+	Ref       string `json:"ref,omitempty"`
 	CommitSHA string `json:"commit_sha,omitempty"`
 	Message   string `json:"message,omitempty"`
+
+	PullRequestRefRegexes []string
 }


### PR DESCRIPTION
Allow setting the destination branch/tag/ref so users can test the run
conditions based on the branch/tag/ref.

To simulate a pull request an user can define a ref that matches one of these
regular expressions: `refs/pull/(\d+)/head`, `refs/merge-requests/(\d+)/head`