### PR TITLE
update example in devel doc

### DIFF
--- a/doc/devel.md
+++ b/doc/devel.md
@@ -28,11 +28,11 @@ make
 * Copy the `example/config.yml` where you prefer
 
 ```
-./bin/agola serve --toolbox-path $PWD/bin/agola-toolbox --embedded-etcd --config /path/to/your/config.yml --components all-base,executor
+./bin/agola serve --embedded-etcd --config /path/to/your/config.yml --components all-base,executor
 ```
 
 or use an external etcd (set it in the config.yml):
 
 ```
-./bin/agola serve --toolbox-path $PWD/bin/agola-toolbox --config /path/to/your/config.yml --components all-base,executor
+./bin/agola serve --config /path/to/your/config.yml --components all-base,executor
 ```


### PR DESCRIPTION
"toolbox-path" flag is not available in "serve" command:
```
$ ./bin/agola serve --toolbox-path $PWD/bin/agola-toolbox --embedded-etcd --embedded-etcd-data-dir /tmp/etcd --config /data/agola/config.yml --components all-base,executor
Error: unknown flag: --toolbox-path
Usage:
  agola serve [flags]

Flags:
      --components strings              list of components to start. Specify "all-base" to start all base components (excluding the executor).
      --config string                   config file path (default "./config.yml")
      --embedded-etcd                   start and use an embedded etcd, only for testing purpose
      --embedded-etcd-data-dir string   embedded etcd data dir, only for testing purpose (default "/tmp/agola/etcd")
  -h, --help                            help for serve
      --version                         version for serve

Global Flags:
  -d, --debug                debug
  -u, --gateway-url string   agola gateway exposed url (default "http://localhost:8000")
      --token string         api token
```
The devel document should be updated.