### PR TITLE
cmd: fix variable create/update

### DIFF
--- a/cmd/agola/cmd/projectvariableupdate.go
+++ b/cmd/agola/cmd/projectvariableupdate.go
@@ -94,7 +94,7 @@ func variableUpdate(cmd *cobra.Command, ownertype string, args []string) error {
 		rvalues = append(rvalues, gwapitypes.VariableValueRequest{
 			SecretName: value.SecretName,
 			SecretVar:  value.SecretVar,
-			When:       value.When,
+			When:       fromCsWhen(value.When.ToCSWhen()),
 		})
 	}
 	req := &gwapitypes.UpdateVariableRequest{

--- a/internal/services/executor/driver/docker_test.go
+++ b/internal/services/executor/driver/docker_test.go
@@ -23,9 +23,9 @@ import (
 	"time"
 
 	slog "agola.io/agola/internal/log"
+	"agola.io/agola/internal/testutil"
 	"github.com/docker/docker/api/types"
 	uuid "github.com/satori/go.uuid"
-	"agola.io/agola/internal/testutil"
 
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"

--- a/internal/services/gateway/api/variable.go
+++ b/internal/services/gateway/api/variable.go
@@ -235,6 +235,9 @@ func fromApiWhenCondition(apiwc gwapitypes.WhenCondition) cstypes.WhenCondition 
 }
 
 func fromApiWhenConditions(apiwcs *gwapitypes.WhenConditions) *cstypes.WhenConditions {
+	if apiwcs == nil {
+		return nil
+	}
 	wcs := &cstypes.WhenConditions{
 		Include: make([]cstypes.WhenCondition, len(apiwcs.Include)),
 		Exclude: make([]cstypes.WhenCondition, len(apiwcs.Exclude)),
@@ -265,6 +268,9 @@ func fromCsWhenCondition(apiwc cstypes.WhenCondition) gwapitypes.WhenCondition {
 }
 
 func fromCsWhenConditions(apiwcs *cstypes.WhenConditions) *gwapitypes.WhenConditions {
+	if apiwcs == nil {
+		return nil
+	}
 	wcs := &gwapitypes.WhenConditions{
 		Include: make([]gwapitypes.WhenCondition, len(apiwcs.Include)),
 		Exclude: make([]gwapitypes.WhenCondition, len(apiwcs.Exclude)),


### PR DESCRIPTION
In c1ff28ef9f we exported various types. Unfortunately the types used by cmd
variable create/update are the wrong types and marshalling fails. Fix it using
the right type. In future this internal types should be exported.