### PR TITLE
*: update to go 1.13

### DIFF
--- a/.agola/config.jsonnet
+++ b/.agola/config.jsonnet
@@ -3,7 +3,7 @@ local go_runtime(version, arch) = {
   arch: arch,
   containers: [
     {
-      image: 'golang:' + version + '-stretch',
+      image: 'golang:' + version + '-buster',
     },
   ],
 };
@@ -32,7 +32,7 @@ local task_build_go(version, arch) = {
     { type: 'run', command: 'make' },
     { type: 'save_cache', key: 'cache-sum-{{ md5sum "go.sum" }}', contents: [{ source_dir: '/go/pkg/mod/cache' }] },
     { type: 'save_cache', key: 'cache-date-{{ year }}-{{ month }}-{{ day }}', contents: [{ source_dir: '/go/pkg/mod/cache' }] },
-    { type: 'run', name: 'install golangci-lint', command: 'curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1' },
+    { type: 'run', name: 'install golangci-lint', command: 'curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.18.0' },
     { type: 'run', command: 'golangci-lint run --deadline 5m' },
     { type: 'run', name: 'build docker/k8s drivers tests binary', command: 'CGO_ENABLED=0 go test -c ./internal/services/executor/driver -o ./bin/docker-tests' },
     { type: 'run', name: 'build integration tests binary', command: 'go test -tags "sqlite_unlock_notify" -c ./tests -o ./bin/integration-tests' },
@@ -107,7 +107,7 @@ local task_build_push_images(name, target, push) =
         [
           task_build_go(version, arch),
         ]
-        for version in ['1.11', '1.12']
+        for version in ['1.12', '1.13']
         for arch in ['amd64' /*, 'arm64' */]
       ]) + [
         {
@@ -118,7 +118,7 @@ local task_build_push_images(name, target, push) =
             { type: 'run', command: 'SKIP_K8S_TESTS=1 AGOLA_TOOLBOX_PATH="./bin" ./bin/docker-tests -test.parallel 1 -test.v' },
           ],
           depends: [
-            'build go 1.12 amd64',
+            'build go 1.13 amd64',
           ],
         },
         {
@@ -140,7 +140,7 @@ local task_build_push_images(name, target, push) =
             { type: 'run', name: 'integration tests', command: 'AGOLA_BIN_DIR="./bin" GITEA_PATH=${PWD}/bin/gitea DOCKER_BRIDGE_ADDRESS="172.18.0.1" ./bin/integration-tests -test.parallel 1 -test.v' },
           ],
           depends: [
-            'build go 1.12 amd64',
+            'build go 1.13 amd64',
           ],
         },
         {

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM $AGOLAWEB_IMAGE as agola-web
 #######
 
 # base build image
-FROM golang:1.12-buster AS build_base
+FROM golang:1.13-buster AS build_base
 
 WORKDIR /agola
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module agola.io/agola
 
+go 1.12
+
 require (
 	code.gitea.io/gitea v1.9.0-dev.0.20190511102134-34eee25bd42d
 	code.gitea.io/sdk/gitea v0.0.0-20190602153954-7e711e06b588


### PR DESCRIPTION
* agola run: Remove go 1.11 and use go 1.12 and go 1.13 with debian buster image.

* Dockerfile: Use go 1.13 debian buster image.