### PR TITLE
runservice: remove run step user

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,7 +151,6 @@ type RunStep struct {
 	Environment map[string]Value `json:"environment,omitempty"`
 	WorkingDir  string           `json:"working_dir"`
 	Shell       string           `json:"shell"`
-	User        string           `json:"user"`
 }
 
 type SaveToWorkspaceStep struct {

--- a/internal/runconfig/runconfig.go
+++ b/internal/runconfig/runconfig.go
@@ -115,7 +115,6 @@ fi
 		rs.Environment = env
 		rs.WorkingDir = cs.WorkingDir
 		rs.Shell = cs.Shell
-		rs.User = cs.User
 		return rs
 
 	case *config.SaveToWorkspaceStep:

--- a/internal/services/executor/executor.go
+++ b/internal/services/executor/executor.go
@@ -117,13 +117,10 @@ func (e *Executor) doRunStep(ctx context.Context, s *types.RunStep, t *types.Exe
 		shell = s.Shell
 	}
 
-	// try to use the container specified user
+	// use the container specified user and override with task user if defined
 	user := t.Containers[0].User
 	if t.User != "" {
 		user = t.User
-	}
-	if s.User != "" {
-		user = s.User
 	}
 
 	var cmd []string

--- a/services/runservice/types/types.go
+++ b/services/runservice/types/types.go
@@ -413,7 +413,6 @@ type RunStep struct {
 	Environment map[string]string `json:"environment,omitempty"`
 	WorkingDir  string            `json:"working_dir,omitempty"`
 	Shell       string            `json:"shell,omitempty"`
-	User        string            `json:"user,omitempty"`
 }
 
 type SaveContent struct {


### PR DESCRIPTION
Defining an option to override the user for a run step is too much fine grained
and, for consistency, will require to do the same also for the other steps
(clone, *workspace etc...).

Remove it since it's probably enough to define it at the task level.