### PR TITLE
runservice: don't save executor task data in etcd

### DIFF
--- a/internal/services/runservice/api/api.go
+++ b/internal/services/runservice/api/api.go
@@ -244,12 +244,12 @@ func (h *LogsHandler) readTaskLogs(ctx context.Context, runID, taskID string, se
 	if err != nil {
 		return err, true
 	}
-	executor, err := store.GetExecutor(ctx, h.e, et.Status.ExecutorID)
+	executor, err := store.GetExecutor(ctx, h.e, et.Spec.ExecutorID)
 	if err != nil && err != etcd.ErrKeyNotFound {
 		return err, true
 	}
 	if executor == nil {
-		return common.NewErrNotExist(errors.Errorf("executor with id %q doesn't exist", et.Status.ExecutorID)), true
+		return common.NewErrNotExist(errors.Errorf("executor with id %q doesn't exist", et.Spec.ExecutorID)), true
 	}
 
 	var url string

--- a/internal/services/runservice/common/common.go
+++ b/internal/services/runservice/common/common.go
@@ -15,7 +15,13 @@
 package common
 
 import (
+	"fmt"
 	"path"
+	"sort"
+
+	"agola.io/agola/internal/runconfig"
+	"agola.io/agola/internal/util"
+	"agola.io/agola/services/runservice/types"
 )
 
 const (
@@ -81,3 +87,154 @@ const (
 	DataTypeRunConfig  DataType = "runconfig"
 	DataTypeRunCounter DataType = "runcounter"
 )
+
+func OSTSubGroupsAndGroupTypes(group string) []string {
+	h := util.PathHierarchy(group)
+	if len(h)%2 != 1 {
+		panic(fmt.Errorf("wrong group path %q", group))
+	}
+
+	return h
+}
+
+func OSTRootGroup(group string) string {
+	pl := util.PathList(group)
+	if len(pl) < 2 {
+		panic(fmt.Errorf("cannot determine root group name, wrong group path %q", group))
+	}
+
+	return pl[1]
+}
+
+func OSTSubGroups(group string) []string {
+	h := util.PathHierarchy(group)
+	if len(h)%2 != 1 {
+		panic(fmt.Errorf("wrong group path %q", group))
+	}
+
+	// remove group types
+	sg := []string{}
+	for i, g := range h {
+		if i%2 == 0 {
+			sg = append(sg, g)
+		}
+	}
+
+	return sg
+}
+
+func OSTSubGroupTypes(group string) []string {
+	h := util.PathHierarchy(group)
+	if len(h)%2 != 1 {
+		panic(fmt.Errorf("wrong group path %q", group))
+	}
+
+	// remove group names
+	sg := []string{}
+	for i, g := range h {
+		if i%2 == 1 {
+			sg = append(sg, g)
+		}
+	}
+
+	return sg
+}
+
+type parentsByLevelName []*types.RunConfigTask
+
+func (p parentsByLevelName) Len() int { return len(p) }
+func (p parentsByLevelName) Less(i, j int) bool {
+	if p[i].Level != p[j].Level {
+		return p[i].Level < p[j].Level
+	}
+	return p[i].Name < p[j].Name
+}
+func (p parentsByLevelName) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+
+func mergeEnv(dest, src map[string]string) {
+	for k, v := range src {
+		dest[k] = v
+	}
+}
+
+func GenExecutorTaskSpecData(r *types.Run, rt *types.RunTask, rc *types.RunConfig) *types.ExecutorTaskSpecData {
+	rct := rc.Tasks[rt.ID]
+
+	environment := map[string]string{}
+	if rct.Environment != nil {
+		environment = rct.Environment
+	}
+	mergeEnv(environment, rc.StaticEnvironment)
+	// run config Environment variables ovverride every other environment variable
+	mergeEnv(environment, rc.Environment)
+
+	cachePrefix := OSTRootGroup(r.Group)
+	if rc.CacheGroup != "" {
+		cachePrefix = rc.CacheGroup
+	}
+
+	data := &types.ExecutorTaskSpecData{
+		// The executorTask ID must be the same as the runTask ID so we can detect if
+		// there's already an executorTask scheduled for that run task and we can get
+		// at most once task execution
+		TaskName:             rct.Name,
+		Arch:                 rct.Runtime.Arch,
+		Containers:           rct.Runtime.Containers,
+		Environment:          environment,
+		WorkingDir:           rct.WorkingDir,
+		Shell:                rct.Shell,
+		User:                 rct.User,
+		Steps:                rct.Steps,
+		CachePrefix:          cachePrefix,
+		DockerRegistriesAuth: rct.DockerRegistriesAuth,
+	}
+
+	// calculate workspace operations
+	// TODO(sgotti) right now we don't support duplicated files. So it's not currently possibile to overwrite a file in a upper layer.
+	// this simplifies the workspaces extractions since they could be extracted in any order. We make them ordered just for reproducibility
+	wsops := []types.WorkspaceOperation{}
+	rctAllParents := runconfig.GetAllParents(rc.Tasks, rct)
+
+	// sort parents by level and name just for reproducibility
+	sort.Sort(parentsByLevelName(rctAllParents))
+
+	for _, rctParent := range rctAllParents {
+		for _, archiveStep := range r.Tasks[rctParent.ID].WorkspaceArchives {
+			wsop := types.WorkspaceOperation{TaskID: rctParent.ID, Step: archiveStep}
+			wsops = append(wsops, wsop)
+		}
+	}
+
+	data.WorkspaceOperations = wsops
+
+	return data
+}
+
+func GenExecutorTask(r *types.Run, rt *types.RunTask, rc *types.RunConfig, executor *types.Executor) *types.ExecutorTask {
+	rct := rc.Tasks[rt.ID]
+
+	et := &types.ExecutorTask{
+		// The executorTask ID must be the same as the runTask ID so we can detect if
+		// there's already an executorTask scheduled for that run task and we can get
+		// at most once task execution
+		ID: rt.ID,
+		Spec: types.ExecutorTaskSpec{
+			ExecutorID: executor.ID,
+			RunID:      r.ID,
+			// ExecutorTaskSpecData is not saved in etcd to avoid exceeding the max etcd value
+			// size but is generated everytime the executor task is sent to the executor
+		},
+		Status: types.ExecutorTaskStatus{
+			Phase: types.ExecutorTaskPhaseNotStarted,
+			Steps: make([]*types.ExecutorTaskStepStatus, len(rct.Steps)),
+		},
+	}
+
+	for i := range et.Status.Steps {
+		et.Status.Steps[i] = &types.ExecutorTaskStepStatus{
+			Phase: types.ExecutorTaskPhaseNotStarted,
+		}
+	}
+
+	return et
+}

--- a/internal/services/runservice/runservice.go
+++ b/internal/services/runservice/runservice.go
@@ -211,8 +211,8 @@ func (s *Runservice) setupDefaultRouter(etCh chan *types.ExecutorTask) http.Hand
 	// executor dedicated api, only calls from executor should happen on these handlers
 	executorStatusHandler := api.NewExecutorStatusHandler(logger, s.e, s.ah)
 	executorTaskStatusHandler := api.NewExecutorTaskStatusHandler(s.e, etCh)
-	executorTaskHandler := api.NewExecutorTaskHandler(s.e)
-	executorTasksHandler := api.NewExecutorTasksHandler(s.e)
+	executorTaskHandler := api.NewExecutorTaskHandler(logger, s.ah)
+	executorTasksHandler := api.NewExecutorTasksHandler(logger, s.ah)
 	archivesHandler := api.NewArchivesHandler(logger, s.ost)
 	cacheHandler := api.NewCacheHandler(logger, s.ost)
 	cacheCreateHandler := api.NewCacheCreateHandler(logger, s.ost)

--- a/internal/services/runservice/store/store.go
+++ b/internal/services/runservice/store/store.go
@@ -37,58 +37,6 @@ const (
 	MaxChangegroupNameLength = 256
 )
 
-func OSTSubGroupsAndGroupTypes(group string) []string {
-	h := util.PathHierarchy(group)
-	if len(h)%2 != 1 {
-		panic(fmt.Errorf("wrong group path %q", group))
-	}
-
-	return h
-}
-
-func OSTRootGroup(group string) string {
-	pl := util.PathList(group)
-	if len(pl) < 2 {
-		panic(fmt.Errorf("cannot determine root group name, wrong group path %q", group))
-	}
-
-	return pl[1]
-}
-
-func OSTSubGroups(group string) []string {
-	h := util.PathHierarchy(group)
-	if len(h)%2 != 1 {
-		panic(fmt.Errorf("wrong group path %q", group))
-	}
-
-	// remove group types
-	sg := []string{}
-	for i, g := range h {
-		if i%2 == 0 {
-			sg = append(sg, g)
-		}
-	}
-
-	return sg
-}
-
-func OSTSubGroupTypes(group string) []string {
-	h := util.PathHierarchy(group)
-	if len(h)%2 != 1 {
-		panic(fmt.Errorf("wrong group path %q", group))
-	}
-
-	// remove group names
-	sg := []string{}
-	for i, g := range h {
-		if i%2 == 1 {
-			sg = append(sg, g)
-		}
-	}
-
-	return sg
-}
-
 func OSTUpdateRunCounterAction(ctx context.Context, c uint64, group string) (*datamanager.Action, error) {
 	// use the first group dir after the root
 	pl := util.PathList(group)
@@ -364,7 +312,7 @@ func GetExecutorTasks(ctx context.Context, e *etcd.Store, executorID string) ([]
 			return nil, err
 		}
 		et.Revision = kv.ModRevision
-		if et.Status.ExecutorID == executorID {
+		if et.Spec.ExecutorID == executorID {
 			ets = append(ets, et)
 		}
 	}

--- a/services/runservice/types/types.go
+++ b/services/runservice/types/types.go
@@ -459,9 +459,38 @@ func (s ExecutorTaskPhase) IsFinished() bool {
 }
 
 type ExecutorTask struct {
-	Revision    int64             `json:"revision,omitempty"`
-	ID          string            `json:"id,omitempty"`
-	RunID       string            `json:"run_id,omitempty"`
+	ID string `json:"id,omitempty"`
+
+	Spec ExecutorTaskSpec `json:"spec,omitempty"`
+
+	Status ExecutorTaskStatus `json:"status,omitempty"`
+
+	// internal values not saved
+	Revision int64 `json:"-"`
+}
+
+func (et *ExecutorTask) DeepCopy() *ExecutorTask {
+	net, err := copystructure.Copy(et)
+	if err != nil {
+		panic(err)
+	}
+	return net.(*ExecutorTask)
+}
+
+type ExecutorTaskSpec struct {
+	ExecutorID string `json:"executor_id,omitempty"`
+	RunID      string `json:"run_id,omitempty"`
+
+	// Stop is used to signal from the scheduler when the task must be stopped
+	Stop bool `json:"stop,omitempty"`
+
+	*ExecutorTaskSpecData
+}
+
+// ExecutorTaskSpecData defines the task data required to execute the tasks. These
+// values are not saved in etcd to avoid exceeding the max etcd value size but
+// are generated everytime they are sent to the executor
+type ExecutorTaskSpecData struct {
 	TaskName    string            `json:"task_name,omitempty"`
 	Arch        types.Arch        `json:"arch,omitempty"`
 	Containers  []*Container      `json:"containers,omitempty"`
@@ -471,27 +500,24 @@ type ExecutorTask struct {
 	User        string            `json:"user,omitempty"`
 	Privileged  bool              `json:"privileged"`
 
-	DockerRegistriesAuth map[string]DockerRegistryAuth `json:"docker_registries_auth"`
-
-	Steps Steps `json:"steps,omitempty"`
-
-	Status     ExecutorTaskStatus `json:"status,omitempty"`
-	SetupError string             `fail_reason:"setup_error,omitempty"`
-	FailError  string             `fail_reason:"fail_error,omitempty"`
-
 	WorkspaceOperations []WorkspaceOperation `json:"workspace_operations,omitempty"`
+
+	DockerRegistriesAuth map[string]DockerRegistryAuth `json:"docker_registries_auth"`
 
 	// Cache prefix to use when asking for a cache key. To isolate caches between
 	// groups (projects)
 	CachePrefix string `json:"cache_prefix,omitempty"`
 
-	// Stop is used to signal from the scheduler when the task must be stopped
-	Stop bool `json:"stop,omitempty"`
+	Steps Steps `json:"steps,omitempty"`
 }
 
 type ExecutorTaskStatus struct {
-	ExecutorID string            `json:"executor_id,omitempty"`
-	Phase      ExecutorTaskPhase `json:"phase,omitempty"`
+	ID       string `json:"id,omitempty"`
+	Revision int64  `json:"revision,omitempty"`
+
+	Phase ExecutorTaskPhase `json:"phase,omitempty"`
+
+	FailError string `json:"fail_error,omitempty"`
 
 	SetupStep ExecutorTaskStepStatus    `json:"setup_step,omitempty"`
 	Steps     []*ExecutorTaskStepStatus `json:"steps,omitempty"`


### PR DESCRIPTION
Reorganize ExecutorTask to better distinguish between the task Spec and
the Status.

Split the task Spec in a sub part called ExecutorTaskSpecData that contains
tasks data that don't have to be saved in etcd because it contains data that can
be very big and can be generated starting from the run and the runconfig.