### PR TITLE
cli: add secret/variable list subcommand

### DIFF
--- a/cmd/agola/cmd/projectgroupsecretlist.go
+++ b/cmd/agola/cmd/projectgroupsecretlist.go
@@ -1,0 +1,41 @@
+// Copyright 2019 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var cmdProjectGroupSecretList = &cobra.Command{
+	Use:   "list",
+	Short: "list project group secrets",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := secretList(cmd, "projectgroup", args); err != nil {
+			log.Fatalf("err: %v", err)
+		}
+	},
+}
+
+func init() {
+	flags := cmdProjectGroupSecretList.Flags()
+
+	flags.StringVar(&secretListOpts.parentRef, "projectgroup", "", "project group id or full path")
+
+	if err := cmdProjectGroupSecretList.MarkFlagRequired("projectgroup"); err != nil {
+		log.Fatal(err)
+	}
+
+	cmdProjectGroupSecret.AddCommand(cmdProjectGroupSecretList)
+}

--- a/cmd/agola/cmd/projectgroupvariablelist.go
+++ b/cmd/agola/cmd/projectgroupvariablelist.go
@@ -1,0 +1,41 @@
+// Copyright 2019 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var cmdProjectGroupVariableList = &cobra.Command{
+	Use:   "list",
+	Short: "list project group variables",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := variableList(cmd, "projectgroup", args); err != nil {
+			log.Fatalf("err: %v", err)
+		}
+	},
+}
+
+func init() {
+	flags := cmdProjectGroupVariableList.Flags()
+
+	flags.StringVar(&variableListOpts.parentRef, "projectgroup", "", "project group id or full path")
+
+	if err := cmdProjectGroupVariableList.MarkFlagRequired("projectgroup"); err != nil {
+		log.Fatal(err)
+	}
+
+	cmdProjectGroupVariable.AddCommand(cmdProjectGroupVariableList)
+}

--- a/cmd/agola/cmd/projectsecretlist.go
+++ b/cmd/agola/cmd/projectsecretlist.go
@@ -1,0 +1,89 @@
+// Copyright 2019 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	gwapitypes "agola.io/agola/services/gateway/api/types"
+	gwclient "agola.io/agola/services/gateway/client"
+
+	"github.com/spf13/cobra"
+	errors "golang.org/x/xerrors"
+)
+
+var cmdProjectSecretList = &cobra.Command{
+	Use:   "list",
+	Short: "list project secrets",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := secretList(cmd, "project", args); err != nil {
+			log.Fatalf("err: %v", err)
+		}
+	},
+}
+
+type secretListOptions struct {
+	parentRef string
+}
+
+var secretListOpts secretListOptions
+
+func init() {
+	flags := cmdProjectSecretList.Flags()
+
+	flags.StringVar(&secretListOpts.parentRef, "project", "", "project id or full path")
+
+	if err := cmdProjectSecretList.MarkFlagRequired("project"); err != nil {
+		log.Fatal(err)
+	}
+
+	cmdProjectSecret.AddCommand(cmdProjectSecretList)
+}
+
+func secretList(cmd *cobra.Command, ownertype string, args []string) error {
+	if err := printSecrets(ownertype, fmt.Sprintf("%s secrets", ownertype), false, false); err != nil {
+		return err
+	}
+	if err := printSecrets(ownertype, "All secrets (local and inherited)", true, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func printSecrets(ownertype, description string, tree, removeoverridden bool) error {
+
+	var err error
+	var secrets []*gwapitypes.SecretResponse
+
+	gwclient := gwclient.NewClient(gatewayURL, token)
+
+	switch ownertype {
+	case "project":
+		secrets, _, err = gwclient.GetProjectSecrets(context.TODO(), secretListOpts.parentRef, tree, removeoverridden)
+	case "projectgroup":
+		secrets, _, err = gwclient.GetProjectGroupSecrets(context.TODO(), secretListOpts.parentRef, tree, removeoverridden)
+	}
+	if err != nil {
+		return errors.Errorf("failed to list %s secrets: %w", ownertype, err)
+	}
+	prettyJSON, err := json.MarshalIndent(secrets, "", "\t")
+	if err != nil {
+		return errors.Errorf("failed to convert %s secrets to json: %w", ownertype, err)
+	}
+	fmt.Printf("%s:\n%s\n", description, string(prettyJSON))
+	return nil
+}

--- a/cmd/agola/cmd/projectvariablelist.go
+++ b/cmd/agola/cmd/projectvariablelist.go
@@ -1,0 +1,89 @@
+// Copyright 2019 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	gwapitypes "agola.io/agola/services/gateway/api/types"
+	gwclient "agola.io/agola/services/gateway/client"
+
+	"github.com/spf13/cobra"
+	errors "golang.org/x/xerrors"
+)
+
+var cmdProjectVariableList = &cobra.Command{
+	Use:   "list",
+	Short: "list project variables",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := variableList(cmd, "project", args); err != nil {
+			log.Fatalf("err: %v", err)
+		}
+	},
+}
+
+type variableListOptions struct {
+	parentRef string
+}
+
+var variableListOpts variableListOptions
+
+func init() {
+	flags := cmdProjectVariableList.Flags()
+
+	flags.StringVar(&variableListOpts.parentRef, "project", "", "project id or full path")
+
+	if err := cmdProjectVariableList.MarkFlagRequired("project"); err != nil {
+		log.Fatal(err)
+	}
+
+	cmdProjectVariable.AddCommand(cmdProjectVariableList)
+}
+
+func variableList(cmd *cobra.Command, ownertype string, args []string) error {
+	if err := printVariables(ownertype, fmt.Sprintf("%s variables", ownertype), false, false); err != nil {
+		return err
+	}
+	if err := printVariables(ownertype, "All variables (local and inherited)", true, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func printVariables(ownertype, description string, tree, removeoverridden bool) error {
+
+	var err error
+	var variables []*gwapitypes.VariableResponse
+
+	gwclient := gwclient.NewClient(gatewayURL, token)
+
+	switch ownertype {
+	case "project":
+		variables, _, err = gwclient.GetProjectVariables(context.TODO(), variableListOpts.parentRef, tree, removeoverridden)
+	case "projectgroup":
+		variables, _, err = gwclient.GetProjectGroupVariables(context.TODO(), variableListOpts.parentRef, tree, removeoverridden)
+	}
+	if err != nil {
+		return errors.Errorf("failed to list %s variables: %w", ownertype, err)
+	}
+	prettyJSON, err := json.MarshalIndent(variables, "", "\t")
+	if err != nil {
+		return errors.Errorf("failed to convert %s variables to json: %w", ownertype, err)
+	}
+	fmt.Printf("%s:\n%s\n", description, string(prettyJSON))
+	return nil
+}

--- a/services/gateway/client/client.go
+++ b/services/gateway/client/client.go
@@ -186,6 +186,19 @@ func (c *Client) DeleteProjectGroupSecret(ctx context.Context, projectGroupRef, 
 	return c.getResponse(ctx, "DELETE", path.Join("/projectgroups", url.PathEscape(projectGroupRef), "secrets", secretName), nil, jsonContent, nil)
 }
 
+func (c *Client) GetProjectGroupSecrets(ctx context.Context, projectRef string, tree, removeoverridden bool) ([]*gwapitypes.SecretResponse, *http.Response, error) {
+	secrets := []*gwapitypes.SecretResponse{}
+	q := url.Values{}
+	if tree {
+		q.Add("tree", "")
+	}
+	if removeoverridden {
+		q.Add("removeoverridden", "")
+	}
+	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/projectgroups/%s/secrets", url.PathEscape(projectRef)), q, jsonContent, nil, &secrets)
+	return secrets, resp, err
+}
+
 func (c *Client) CreateProjectSecret(ctx context.Context, projectRef string, req *gwapitypes.CreateSecretRequest) (*gwapitypes.SecretResponse, *http.Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
@@ -210,6 +223,19 @@ func (c *Client) UpdateProjectSecret(ctx context.Context, projectRef, secretName
 
 func (c *Client) DeleteProjectSecret(ctx context.Context, projectRef, secretName string) (*http.Response, error) {
 	return c.getResponse(ctx, "DELETE", path.Join("/projects", url.PathEscape(projectRef), "secrets", secretName), nil, jsonContent, nil)
+}
+
+func (c *Client) GetProjectSecrets(ctx context.Context, projectRef string, tree, removeoverridden bool) ([]*gwapitypes.SecretResponse, *http.Response, error) {
+	secrets := []*gwapitypes.SecretResponse{}
+	q := url.Values{}
+	if tree {
+		q.Add("tree", "")
+	}
+	if removeoverridden {
+		q.Add("removeoverridden", "")
+	}
+	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/projects/%s/secrets", url.PathEscape(projectRef)), q, jsonContent, nil, &secrets)
+	return secrets, resp, err
 }
 
 func (c *Client) CreateProjectGroupVariable(ctx context.Context, projectGroupRef string, req *gwapitypes.CreateVariableRequest) (*gwapitypes.VariableResponse, *http.Response, error) {
@@ -238,6 +264,19 @@ func (c *Client) DeleteProjectGroupVariable(ctx context.Context, projectGroupRef
 	return c.getResponse(ctx, "DELETE", path.Join("/projectgroups", url.PathEscape(projectGroupRef), "variables", variableName), nil, jsonContent, nil)
 }
 
+func (c *Client) GetProjectGroupVariables(ctx context.Context, projectRef string, tree, removeoverridden bool) ([]*gwapitypes.VariableResponse, *http.Response, error) {
+	variables := []*gwapitypes.VariableResponse{}
+	q := url.Values{}
+	if tree {
+		q.Add("tree", "")
+	}
+	if removeoverridden {
+		q.Add("removeoverridden", "")
+	}
+	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/projectgroups/%s/variables", url.PathEscape(projectRef)), q, jsonContent, nil, &variables)
+	return variables, resp, err
+}
+
 func (c *Client) CreateProjectVariable(ctx context.Context, projectRef string, req *gwapitypes.CreateVariableRequest) (*gwapitypes.VariableResponse, *http.Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
@@ -262,6 +301,19 @@ func (c *Client) UpdateProjectVariable(ctx context.Context, projectRef, variable
 
 func (c *Client) DeleteProjectVariable(ctx context.Context, projectRef, variableName string) (*http.Response, error) {
 	return c.getResponse(ctx, "DELETE", path.Join("/projects", url.PathEscape(projectRef), "variables", variableName), nil, jsonContent, nil)
+}
+
+func (c *Client) GetProjectVariables(ctx context.Context, projectRef string, tree, removeoverridden bool) ([]*gwapitypes.VariableResponse, *http.Response, error) {
+	variables := []*gwapitypes.VariableResponse{}
+	q := url.Values{}
+	if tree {
+		q.Add("tree", "")
+	}
+	if removeoverridden {
+		q.Add("removeoverridden", "")
+	}
+	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/projects/%s/variables", url.PathEscape(projectRef)), q, jsonContent, nil, &variables)
+	return variables, resp, err
 }
 
 func (c *Client) DeleteProject(ctx context.Context, projectRef string) (*http.Response, error) {


### PR DESCRIPTION
I added "list" subcommand to list secret/variable names for projectgroup/project:
```
$ agola projectgroup secret list --projectgroup "user/user01/PG" --token $TOKEN
2882c284-8441-47cc-afce-d3caff74ad3f: Name: pg-secret

$ agola projectgroup variable list --projectgroup "user/user01/PG" --token $TOKEN
6c8fb616-b179-400b-bb56-179b486e838d: Name: pgvar

$ agola project secret list --project "user/user01/agola-example-go" --token $TOKEN
b7c7e8e6-9373-4079-91a0-4a2e8c461a6c: Name: secret-svil

$ agola project variable list --project "user/user01/agola-example-go" --token $TOKEN
1242da30-57a9-4f66-a8c8-f8a799ff9da2: Name: var01
```
I found it useful to update or delete secret/variable objects without the need to use the WUI to get their names.
I took the output format (\<id\>: Name: \<name\>) from "project list" command, not sure if it should better to hide the id.