### PR TITLE
cmd: fix typos in online help

### DIFF
--- a/cmd/agola/cmd/projectgroupsecretcreate.go
+++ b/cmd/agola/cmd/projectgroupsecretcreate.go
@@ -40,7 +40,7 @@ func init() {
 
 	flags.StringVar(&secretCreateOpts.parentRef, "projectgroup", "", "project group id or full path")
 	flags.StringVarP(&secretCreateOpts.name, "name", "n", "", "secret name")
-	flags.StringVarP(&secretCreateOpts.file, "file", "f", "", `yaml file containing the secret data (use "-" to read from stdin`)
+	flags.StringVarP(&secretCreateOpts.file, "file", "f", "", `yaml file containing the secret data (use "-" to read from stdin)`)
 
 	if err := cmdProjectGroupSecretCreate.MarkFlagRequired("projectgroup"); err != nil {
 		log.Fatal(err)

--- a/cmd/agola/cmd/projectgroupsecretupdate.go
+++ b/cmd/agola/cmd/projectgroupsecretupdate.go
@@ -41,7 +41,7 @@ func init() {
 	flags.StringVar(&secretUpdateOpts.parentRef, "projectgroup", "", "project group id or full path")
 	flags.StringVarP(&secretUpdateOpts.name, "name", "n", "", "secret name")
 	flags.StringVarP(&secretUpdateOpts.newName, "new-name", "", "", "secret new name")
-	flags.StringVarP(&secretUpdateOpts.file, "file", "f", "", `yaml file containing the secret data (use "-" to read from stdin`)
+	flags.StringVarP(&secretUpdateOpts.file, "file", "f", "", `yaml file containing the secret data (use "-" to read from stdin)`)
 
 	if err := cmdProjectGroupSecretUpdate.MarkFlagRequired("projectgroup"); err != nil {
 		log.Fatal(err)

--- a/cmd/agola/cmd/projectgroupvariablecreate.go
+++ b/cmd/agola/cmd/projectgroupvariablecreate.go
@@ -55,7 +55,7 @@ func init() {
 
 	flags.StringVar(&variableCreateOpts.parentRef, "projectgroup", "", "project group id or full path")
 	flags.StringVarP(&variableCreateOpts.name, "name", "n", "", "variable name")
-	flags.StringVarP(&variableCreateOpts.file, "file", "f", "", `yaml file containing the variable definition (use "-" to read from stdin`)
+	flags.StringVarP(&variableCreateOpts.file, "file", "f", "", `yaml file containing the variable definition (use "-" to read from stdin)`)
 
 	if err := cmdProjectGroupVariableCreate.MarkFlagRequired("projectgroup"); err != nil {
 		log.Fatal(err)

--- a/cmd/agola/cmd/projectgroupvariableupdate.go
+++ b/cmd/agola/cmd/projectgroupvariableupdate.go
@@ -34,7 +34,7 @@ func init() {
 	flags.StringVar(&variableUpdateOpts.parentRef, "projectgroup", "", "project group id or full path")
 	flags.StringVarP(&variableUpdateOpts.name, "name", "n", "", "variable name")
 	flags.StringVarP(&variableUpdateOpts.newName, "new-name", "", "", "variable new name")
-	flags.StringVarP(&variableUpdateOpts.file, "file", "f", "", `yaml file containing the variable definition (use "-" to read from stdin`)
+	flags.StringVarP(&variableUpdateOpts.file, "file", "f", "", `yaml file containing the variable definition (use "-" to read from stdin)`)
 
 	if err := cmdProjectGroupVariableUpdate.MarkFlagRequired("projectgroup"); err != nil {
 		log.Fatal(err)

--- a/cmd/agola/cmd/projectlist.go
+++ b/cmd/agola/cmd/projectlist.go
@@ -43,7 +43,7 @@ var projectListOpts projectListOptions
 func init() {
 	flags := cmdProjectList.Flags()
 
-	flags.StringVar(&projectListOpts.parentPath, "parent", "", `project group path (i.e "org/org01" for root project group in org01, "/user/user01/group01/subgroub01") or project group id`)
+	flags.StringVar(&projectListOpts.parentPath, "parent", "", `project group path (i.e "org/org01" for root project group in org01, "user/user01/group01/subgroub01") or project group id`)
 
 	if err := cmdProjectList.MarkFlagRequired("parent"); err != nil {
 		log.Fatal(err)

--- a/cmd/agola/cmd/projectreconfig.go
+++ b/cmd/agola/cmd/projectreconfig.go
@@ -25,7 +25,7 @@ import (
 
 var cmdProjectReconfig = &cobra.Command{
 	Use:   "reconfig",
-	Short: "reconfigures a project remote (reinstalls ssh deploy key and webhooks",
+	Short: "reconfigures a project remote (reinstalls ssh deploy key and webhooks)",
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := projectReconfig(cmd, args); err != nil {
 			log.Fatalf("err: %v", err)

--- a/cmd/agola/cmd/projectsecretcreate.go
+++ b/cmd/agola/cmd/projectsecretcreate.go
@@ -29,8 +29,8 @@ import (
 
 var cmdProjectSecretCreate = &cobra.Command{
 	Use:   "create",
-	Short: "create a project local secret",
-	Long: `create a project local secret
+	Short: "create a project secret",
+	Long: `create a project secret
 
 The secret data should be provided by a yaml document. Examples:
 
@@ -57,7 +57,7 @@ func init() {
 
 	flags.StringVar(&secretCreateOpts.parentRef, "project", "", "project id or full path")
 	flags.StringVarP(&secretCreateOpts.name, "name", "n", "", "secret name")
-	flags.StringVarP(&secretCreateOpts.file, "file", "f", "", `yaml file containing the secret data (use "-" to read from stdin`)
+	flags.StringVarP(&secretCreateOpts.file, "file", "f", "", `yaml file containing the secret data (use "-" to read from stdin)`)
 
 	if err := cmdProjectSecretCreate.MarkFlagRequired("project"); err != nil {
 		log.Fatal(err)

--- a/cmd/agola/cmd/projectsecretupdate.go
+++ b/cmd/agola/cmd/projectsecretupdate.go
@@ -59,7 +59,7 @@ func init() {
 	flags.StringVar(&secretUpdateOpts.parentRef, "project", "", "project id or full path")
 	flags.StringVarP(&secretUpdateOpts.name, "name", "n", "", "secret name")
 	flags.StringVarP(&secretUpdateOpts.newName, "new-name", "", "", "secret new name")
-	flags.StringVarP(&secretUpdateOpts.file, "file", "f", "", `yaml file containing the secret data (use "-" to read from stdin`)
+	flags.StringVarP(&secretUpdateOpts.file, "file", "f", "", `yaml file containing the secret data (use "-" to read from stdin)`)
 
 	if err := cmdProjectSecretUpdate.MarkFlagRequired("project"); err != nil {
 		log.Fatal(err)

--- a/cmd/agola/cmd/projectvariablecreate.go
+++ b/cmd/agola/cmd/projectvariablecreate.go
@@ -30,8 +30,8 @@ import (
 
 var cmdProjectVariableCreate = &cobra.Command{
 	Use:   "create",
-	Short: "create a project group variable",
-	Long: `create a project group variable
+	Short: "create a project variable",
+	Long: `create a project variable
 
 The variable values should be provided by a yaml document. Examples:
 
@@ -73,7 +73,7 @@ func init() {
 
 	flags.StringVar(&variableCreateOpts.parentRef, "project", "", "project id or full path")
 	flags.StringVarP(&variableCreateOpts.name, "name", "n", "", "variable name")
-	flags.StringVarP(&variableCreateOpts.file, "file", "f", "", `yaml file containing the variable definition (use "-" to read from stdin`)
+	flags.StringVarP(&variableCreateOpts.file, "file", "f", "", `yaml file containing the variable definition (use "-" to read from stdin)`)
 
 	if err := cmdProjectVariableCreate.MarkFlagRequired("project"); err != nil {
 		log.Fatal(err)

--- a/cmd/agola/cmd/projectvariableupdate.go
+++ b/cmd/agola/cmd/projectvariableupdate.go
@@ -52,7 +52,7 @@ func init() {
 	flags.StringVar(&variableUpdateOpts.parentRef, "project", "", "project id or full path")
 	flags.StringVarP(&variableUpdateOpts.name, "name", "n", "", "variable name")
 	flags.StringVarP(&variableUpdateOpts.newName, "new-name", "", "", "variable new name")
-	flags.StringVarP(&variableUpdateOpts.file, "file", "f", "", `yaml file containing the variable definition (use "-" to read from stdin`)
+	flags.StringVarP(&variableUpdateOpts.file, "file", "f", "", `yaml file containing the variable definition (use "-" to read from stdin)`)
 
 	if err := cmdProjectVariableUpdate.MarkFlagRequired("project"); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Fixed typos (mainly missed brackets) in online help messages.