### PR TITLE
cmd: fix version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ REPO_PATH=agola.io/agola
 
 VERSION ?= $(shell scripts/git-version.sh)
 
-LD_FLAGS="-w -X $(REPO_PATH)/version.Version=$(VERSION)"
+LD_FLAGS="-w -X $(REPO_PATH)/cmd.Version=$(VERSION)"
 
 $(shell mkdir -p bin )
 $(shell mkdir -p tools/bin )


### PR DESCRIPTION
"X" parameter in LD_FLAGS pointed to an non existing package so Version was always undefined:
```
$ agola --version
agola version No version defined at build time
```
Modified to use cmd package to get the correct output:
```
$ agola --version
agola version 1244973c5554d50c55f095fc45e63d3b7e0f74d3-dirty
```