### PR TITLE
cmd: add completion command

### DIFF
--- a/cmd/agola/cmd/completion.go
+++ b/cmd/agola/cmd/completion.go
@@ -1,0 +1,44 @@
+// Copyright 2019 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var cmdCompletion = &cobra.Command{
+	Use:   "completion",
+	Short: "completion",
+}
+
+func init() {
+	cmdAgola.AddCommand(cmdCompletion)
+}
+
+func completionShell(cmd *cobra.Command, args []string, shell string) error {
+	switch shell {
+	case "bash":
+		if err := cmdAgola.GenBashCompletion(os.Stdout); err != nil {
+			return err
+		}
+	case "zsh":
+		if err := cmdAgola.GenZshCompletion(os.Stdout); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/agola/cmd/completionbash.go
+++ b/cmd/agola/cmd/completionbash.go
@@ -1,0 +1,49 @@
+// Copyright 2019 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var cmdCompletionBash = &cobra.Command{
+	Use: "bash",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := completionShell(cmd, args, "bash"); err != nil {
+			log.Fatalf("err: %v", err)
+		}
+	},
+	Short: "generates bash completion scripts",
+	Long: `generates bash completion scripts
+
+To load bash completion in the current session run:
+
+  source <(agola completion bash)
+
+To configure your bash shell to load completions for each session add the scripts to your ~/.bashrc file:
+
+  echo 'source <(agola completion bash)' >> ~/.bashrc
+
+or add the scripts to the /etc/bash_completion.d directory:
+
+  agola completion bash > /etc/bash_completion.d/agola
+
+NOTE: the agola command must be in the user command search paths (PATH environment variable) or it is necessary to specify the absolute path of the agola binary (e.g. /your/path/agola).
+`,
+}
+
+func init() {
+	cmdCompletion.AddCommand(cmdCompletionBash)
+}

--- a/cmd/agola/cmd/completionzsh.go
+++ b/cmd/agola/cmd/completionzsh.go
@@ -1,0 +1,45 @@
+// Copyright 2019 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var cmdCompletionZsh = &cobra.Command{
+	Use: "zsh",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := completionShell(cmd, args, "zsh"); err != nil {
+			log.Fatalf("err: %v", err)
+		}
+	},
+	Short: "generates zsh completion scripts",
+	Long: `generates zsh completion scripts
+
+To load zsh completion in the current session run:
+
+  source <(agola completion zsh)
+
+To configure your zsh shell to load completions for each session add the scripts to your ~/.zshrc file:
+
+  echo 'source <(agola completion zsh)' >> ~/.zshrc
+
+NOTE: the agola command must be in the user command search paths (PATH environment variable) or it is necessary to specify the absolute path of the agola binary (e.g. /your/path/agola).
+`,
+}
+
+func init() {
+	cmdCompletion.AddCommand(cmdCompletionZsh)
+}


### PR DESCRIPTION
Added "completion" command to generate scripts for shell auto-completion (bash and zsh).
Example:
```
agola completion bash >/etc/bash_completion.d/agola
```


