### PR TITLE
cmd: add version command

### DIFF
--- a/cmd/agola/cmd/serve.go
+++ b/cmd/agola/cmd/serve.go
@@ -125,7 +125,7 @@ func serve(cmd *cobra.Command, args []string) error {
 	}
 	for _, ec := range serveOpts.components {
 		if !util.StringInSlice(componentsNames, ec) {
-			return errors.Errorf("unkown component name %q", ec)
+			return errors.Errorf("unknown component name %q", ec)
 		}
 	}
 

--- a/cmd/agola/cmd/version.go
+++ b/cmd/agola/cmd/version.go
@@ -1,0 +1,52 @@
+// Copyright 2019 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	gwclient "agola.io/agola/services/gateway/client"
+
+	"github.com/spf13/cobra"
+)
+
+var cmdVersion = &cobra.Command{
+	Use:   "version",
+	Short: "version",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := printVersions(cmd, args); err != nil {
+			log.Fatalf("err: %v", err)
+		}
+	},
+}
+
+func init() {
+	cmdAgola.AddCommand(cmdVersion)
+}
+
+func printVersions(cmd *cobra.Command, args []string) error {
+	gwclient := gwclient.NewClient(gatewayURL, token)
+
+	gwversion, _, err := gwclient.GetVersion(context.TODO())
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Gateway version:\t%s\n", gwversion.Version)
+	fmt.Printf("Client version: \t%s\n", cmdAgola.Version)
+
+	return nil
+}

--- a/internal/services/gateway/action/version.go
+++ b/internal/services/gateway/action/version.go
@@ -1,0 +1,32 @@
+// Copyright 2019 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"context"
+
+	"agola.io/agola/cmd"
+	gwapitypes "agola.io/agola/services/gateway/api/types"
+)
+
+func (h *ActionHandler) GetVersion(ctx context.Context) (*gwapitypes.VersionResponse, error) {
+
+	v := &gwapitypes.VersionResponse{
+		Service: "gateway",
+		Version: cmd.Version,
+	}
+
+	return v, nil
+}

--- a/internal/services/gateway/api/version.go
+++ b/internal/services/gateway/api/version.go
@@ -1,0 +1,46 @@
+// Copyright 2019 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"net/http"
+
+	"agola.io/agola/internal/services/gateway/action"
+
+	"go.uber.org/zap"
+)
+
+type VersionHandler struct {
+	log *zap.SugaredLogger
+	ah  *action.ActionHandler
+}
+
+func NewVersionHandler(logger *zap.Logger, ah *action.ActionHandler) *VersionHandler {
+	return &VersionHandler{log: logger.Sugar(), ah: ah}
+}
+
+func (h *VersionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	version, err := h.ah.GetVersion(ctx)
+	if httpError(w, err) {
+		h.log.Errorf("err: %+v", err)
+		return
+	}
+
+	if err := httpResponse(w, http.StatusOK, version); err != nil {
+		h.log.Errorf("err: %+v", err)
+	}
+}

--- a/internal/services/gateway/gateway.go
+++ b/internal/services/gateway/gateway.go
@@ -215,6 +215,8 @@ func (g *Gateway) Run(ctx context.Context) error {
 
 	badgeHandler := api.NewBadgeHandler(logger, g.ah)
 
+	versionHandler := api.NewVersionHandler(logger, g.ah)
+
 	reposHandler := api.NewReposHandler(logger, g.c.GitserverURL)
 
 	loginUserHandler := api.NewLoginUserHandler(logger, g.ah)
@@ -303,6 +305,8 @@ func (g *Gateway) Run(ctx context.Context) error {
 	apirouter.Handle("/user/remoterepos/{remotesourceref}", authForcedHandler(userRemoteReposHandler)).Methods("GET")
 
 	apirouter.Handle("/badges/{projectref}", badgeHandler).Methods("GET")
+
+	apirouter.Handle("/version", versionHandler).Methods("GET")
 
 	// TODO(sgotti) add auth to these requests
 	reposRouter.Handle("/repos/{rest:.*}", reposHandler).Methods("GET", "POST")

--- a/services/gateway/api/types/version.go
+++ b/services/gateway/api/types/version.go
@@ -1,0 +1,20 @@
+// Copyright 2019 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+type VersionResponse struct {
+	Service string `json:"service"`
+	Version string `json:"version"`
+}

--- a/services/gateway/client/client.go
+++ b/services/gateway/client/client.go
@@ -584,3 +584,9 @@ func (c *Client) GetOrgMembers(ctx context.Context, orgRef string) (*gwapitypes.
 	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/orgs/%s/members", orgRef), nil, jsonContent, nil, &res)
 	return res, resp, err
 }
+
+func (c *Client) GetVersion(ctx context.Context) (*gwapitypes.VersionResponse, *http.Response, error) {
+	res := &gwapitypes.VersionResponse{}
+	resp, err := c.getParsedResponse(ctx, "GET", "/version", nil, jsonContent, nil, &res)
+	return res, resp, err
+}


### PR DESCRIPTION
Implementation of version endpoint and command (#33):
```
$ curl http://localhost:8000/api/v1alpha/version
{"service":"gateway","version":"6cdd5bb108b682f0bca5b1c8a86c90c066a7c09d-dirty"}

$ agola version
Gateway version:	6cdd5bb108b682f0bca5b1c8a86c90c066a7c09d-dirty
Client version: 	6cdd5bb108b682f0bca5b1c8a86c90c066a7c09d-dirty
```