### PR TITLE
*: implement ability to add tmpfs volumes to containers

### DIFF
--- a/internal/runconfig/runconfig.go
+++ b/internal/runconfig/runconfig.go
@@ -40,8 +40,24 @@ func genRuntime(c *config.Config, ce *config.Runtime, variables map[string]strin
 			User:        cc.User,
 			Privileged:  cc.Privileged,
 			Entrypoint:  cc.Entrypoint,
+			Volumes:     make([]rstypes.Volume, len(cc.Volumes)),
 		}
 
+		for i, ccVol := range cc.Volumes {
+			container.Volumes[i] = rstypes.Volume{
+				Path: ccVol.Path,
+			}
+
+			if ccVol.TmpFS != nil {
+				var size int64
+				if ccVol.TmpFS.Size != nil {
+					size = ccVol.TmpFS.Size.Value()
+				}
+				container.Volumes[i].TmpFS = &rstypes.VolumeTmpFS{
+					Size: size,
+				}
+			}
+		}
 		containers = append(containers, container)
 	}
 

--- a/internal/runconfig/runconfig_test.go
+++ b/internal/runconfig/runconfig_test.go
@@ -23,6 +23,7 @@ import (
 	"agola.io/agola/internal/util"
 	rstypes "agola.io/agola/services/runservice/types"
 	"agola.io/agola/services/types"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/google/go-cmp/cmp"
 	errors "golang.org/x/xerrors"
@@ -721,6 +722,16 @@ func TestGenRunConfig(t *testing.T) {
 												"ENVFROMVARIABLE01": config.Value{Type: config.ValueTypeFromVariable, Value: "variable01"},
 											},
 											User: "",
+											Volumes: []config.Volume{
+												config.Volume{
+													Path:  "/mnt/vol01",
+													TmpFS: &config.VolumeTmpFS{},
+												},
+												config.Volume{
+													Path:  "/mnt/vol01",
+													TmpFS: &config.VolumeTmpFS{Size: resource.NewQuantity(1024*1024*1024, resource.BinarySI)},
+												},
+											},
 										},
 									},
 								},
@@ -798,6 +809,16 @@ func TestGenRunConfig(t *testing.T) {
 									"ENV01":             "ENV01",
 									"ENVFROMVARIABLE01": "VARVALUE01",
 								},
+								Volumes: []rstypes.Volume{
+									rstypes.Volume{
+										Path:  "/mnt/vol01",
+										TmpFS: &rstypes.VolumeTmpFS{},
+									},
+									rstypes.Volume{
+										Path:  "/mnt/vol01",
+										TmpFS: &rstypes.VolumeTmpFS{Size: 1024 * 1024 * 1024},
+									},
+								},
 							},
 						},
 					},
@@ -874,6 +895,7 @@ func TestGenRunConfig(t *testing.T) {
 							{
 								Image:       "image01",
 								Environment: map[string]string{},
+								Volumes:     []rstypes.Volume{},
 							},
 						},
 					},
@@ -972,6 +994,7 @@ func TestGenRunConfig(t *testing.T) {
 							{
 								Image:       "image01",
 								Environment: map[string]string{},
+								Volumes:     []rstypes.Volume{},
 							},
 						},
 					},
@@ -989,9 +1012,6 @@ func TestGenRunConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			out := GenRunConfigTasks(uuid, tt.in, "run01", tt.variables, "", "", "")
 
-			//if err != nil {
-			//	t.Fatalf("unexpected error: %v", err)
-			//}
 			if diff := cmp.Diff(tt.out, out); diff != "" {
 				t.Error(diff)
 			}

--- a/internal/services/executor/driver/driver.go
+++ b/internal/services/executor/driver/driver.go
@@ -93,6 +93,17 @@ type ContainerConfig struct {
 	Image      string
 	User       string
 	Privileged bool
+	Volumes    []Volume
+}
+
+type Volume struct {
+	Path string
+
+	TmpFS *VolumeTmpFS
+}
+
+type VolumeTmpFS struct {
+	Size int64
 }
 
 type ExecConfig struct {

--- a/internal/services/executor/executor.go
+++ b/internal/services/executor/executor.go
@@ -893,13 +893,27 @@ func (e *Executor) setupTask(ctx context.Context, rt *runningTask) error {
 			cmd = strings.Split(c.Entrypoint, " ")
 		}
 
-		podConfig.Containers[i] = &driver.ContainerConfig{
+		containerConfig := &driver.ContainerConfig{
 			Image:      c.Image,
 			Cmd:        cmd,
 			Env:        c.Environment,
 			User:       c.User,
 			Privileged: c.Privileged,
+			Volumes:    make([]driver.Volume, len(c.Volumes)),
 		}
+
+		for vIndex, cVol := range c.Volumes {
+			containerConfig.Volumes[vIndex] = driver.Volume{
+				Path: cVol.Path,
+			}
+			if cVol.TmpFS != nil {
+				containerConfig.Volumes[vIndex].TmpFS = &driver.VolumeTmpFS{
+					Size: cVol.TmpFS.Size,
+				}
+			}
+		}
+
+		podConfig.Containers[i] = containerConfig
 	}
 
 	_, _ = outf.WriteString("Starting pod.\n")

--- a/services/runservice/types/types.go
+++ b/services/runservice/types/types.go
@@ -543,6 +543,17 @@ type Container struct {
 	User        string            `json:"user,omitempty"`
 	Privileged  bool              `json:"privileged"`
 	Entrypoint  string            `json:"entrypoint"`
+	Volumes     []Volume          `json:"volumes"`
+}
+
+type Volume struct {
+	Path string `json:"path"`
+
+	TmpFS *VolumeTmpFS `json:"tmpfs"`
+}
+
+type VolumeTmpFS struct {
+	Size int64 `json:"size"`
 }
 
 type WorkspaceOperation struct {


### PR DESCRIPTION
* Add a generic container volume option that currently only support tmpfs. In
future it could be expanded to use of host volumes or other kind of volumes (if
supported by the underlying executor)

* Implement creation of tmpfs volumes in docker and k8s drivers.