### PR TITLE
gitsources: don't set branch value when in a pull request

### DIFF
--- a/internal/gitsources/gitea/parse.go
+++ b/internal/gitsources/gitea/parse.go
@@ -162,7 +162,6 @@ func webhookDataFromPullRequest(hook *pullRequestHook) *types.WebhookData {
 		SSHURL:          hook.Repo.SSHURL,
 		Ref:             fmt.Sprintf("refs/pull/%d/head", hook.Number),
 		CommitLink:      fmt.Sprintf("%s/commit/%s", hook.Repo.URL, hook.PullRequest.Head.Sha),
-		Branch:          hook.PullRequest.Base.Ref,
 		Message:         hook.PullRequest.Title,
 		Sender:          sender,
 		PullRequestID:   strconv.FormatInt(hook.PullRequest.ID, 10),

--- a/internal/gitsources/github/parse.go
+++ b/internal/gitsources/github/parse.go
@@ -123,7 +123,6 @@ func webhookDataFromPullRequest(hook *github.PullRequestEvent) (*types.WebhookDa
 		SSHURL:          *hook.Repo.SSHURL,
 		Ref:             fmt.Sprintf("refs/pull/%d/head", *hook.Number),
 		CommitLink:      fmt.Sprintf("%s/commit/%s", *hook.Repo.HTMLURL, *hook.PullRequest.Head.SHA),
-		Branch:          *hook.PullRequest.Base.Ref,
 		Message:         *hook.PullRequest.Title,
 		Sender:          *sender,
 		PullRequestID:   strconv.Itoa(*hook.PullRequest.Number),

--- a/internal/gitsources/gitlab/parse.go
+++ b/internal/gitsources/gitlab/parse.go
@@ -104,9 +104,7 @@ func webhookDataFromPush(hook *pushHook) (*types.WebhookData, error) {
 		SSHURL:     hook.Project.SSHURL,
 		Ref:        hook.Ref,
 		CommitLink: hook.Commits[0].URL,
-		//CompareLink: hook.Compare,
-		//CommitLink: fmt.Sprintf("%s/commit/%s", hook.Repo.URL, hook.After),
-		Sender: sender,
+		Sender:     sender,
 
 		Repo: types.WebhookDataRepo{
 			Path:   hook.Project.PathWithNamespace,
@@ -142,18 +140,12 @@ func webhookDataFromPullRequest(hook *pullRequestHook) *types.WebhookData {
 	if sender == "" {
 		sender = hook.User.Username
 	}
-	//sender := hook.ObjectAttributes.LastCommit.Author.Name
-	//if sender == "" {
-	//	sender := hook.ObjectAttributes.LastCommit.Author.UserName
-	//}
 	build := &types.WebhookData{
-		Event:     types.WebhookEventPullRequest,
-		CommitSHA: hook.ObjectAttributes.LastCommit.ID,
-		SSHURL:    hook.Project.SSHURL,
-		Ref:       fmt.Sprintf("refs/merge-requests/%d/head", hook.ObjectAttributes.Iid),
-		//CommitLink:      fmt.Sprintf("%s/commit/%s", hook.Repo.URL, hook.PullRequest.Head.Sha),
+		Event:           types.WebhookEventPullRequest,
+		CommitSHA:       hook.ObjectAttributes.LastCommit.ID,
+		SSHURL:          hook.Project.SSHURL,
+		Ref:             fmt.Sprintf("refs/merge-requests/%d/head", hook.ObjectAttributes.Iid),
 		CommitLink:      hook.ObjectAttributes.LastCommit.URL,
-		Branch:          hook.ObjectAttributes.SourceBranch,
 		Message:         hook.ObjectAttributes.Title,
 		Sender:          sender,
 		PullRequestID:   strconv.Itoa(hook.ObjectAttributes.Iid),


### PR DESCRIPTION
We were passing the source branch name as the Branch value in the webhook data.

This patch will just delete this assignment. If in future it's needed let's add
it with a different name to not cause confusion.