### PR TITLE
run config: add tty option for run steps

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -165,6 +165,7 @@ type RunStep struct {
 	Environment map[string]Value `json:"environment,omitempty"`
 	WorkingDir  string           `json:"working_dir"`
 	Shell       string           `json:"shell"`
+	Tty         *bool            `json:"tty"`
 }
 
 type SaveToWorkspaceStep struct {
@@ -233,6 +234,9 @@ func (s *Steps) UnmarshalJSON(b []byte) error {
 				var s RunStep
 				if err := json.Unmarshal(stepRaw, &s); err != nil {
 					return err
+				}
+				if s.Tty == nil {
+					s.Tty = util.BoolP(true)
 				}
 				s.Type = stepType
 				step = &s
@@ -890,7 +894,10 @@ func checkConfig(config *Config) error {
 						}
 						step.Name = step.Command[:len]
 					}
-
+					// if tty is omitted its default is true
+					if step.Tty == nil {
+						step.Tty = util.BoolP(true)
+					}
 				case *SaveCacheStep:
 					for _, content := range step.Contents {
 						if len(content.Paths) == 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -337,6 +337,23 @@ func TestParseOutput(t *testing.T) {
                               volumes:
                                 - path: /mnt/tmpfs
                                   tmpfs: {}
+                      - name: task05
+                        runtime:
+                          type: pod
+                          containers:
+                            - image: image01
+                        steps:
+                          - type: run
+                            name: command with default tty
+                            command: command01
+                          - type: run
+                            name: command with tty as true
+                            command: command02
+                            tty: true
+                          - type: run
+                            name: command with tty as false
+                            command: command03
+                            tty: false
           `,
 			out: &Config{
 				Runs: []*Run{
@@ -388,6 +405,7 @@ func TestParseOutput(t *testing.T) {
 											Name: "command01",
 										},
 										Command: "command01",
+										Tty:     util.BoolP(true),
 									},
 									&RunStep{
 										BaseStep: BaseStep{
@@ -395,6 +413,7 @@ func TestParseOutput(t *testing.T) {
 											Name: "name different than command",
 										},
 										Command: "command02",
+										Tty:     util.BoolP(true),
 									},
 									&RunStep{
 										BaseStep: BaseStep{
@@ -406,6 +425,7 @@ func TestParseOutput(t *testing.T) {
 											"ENV01":             Value{Type: ValueTypeString, Value: "ENV01"},
 											"ENVFROMVARIABLE01": Value{Type: ValueTypeFromVariable, Value: "variable01"},
 										},
+										Tty: util.BoolP(true),
 									},
 									&SaveCacheStep{
 										BaseStep: BaseStep{Type: "save_cache"},
@@ -419,6 +439,7 @@ func TestParseOutput(t *testing.T) {
 											Name: "command01",
 										},
 										Command: "command01",
+										Tty:     util.BoolP(true),
 									},
 									&RunStep{
 										BaseStep: BaseStep{
@@ -426,6 +447,7 @@ func TestParseOutput(t *testing.T) {
 											Name: "name different than command",
 										},
 										Command: "command02",
+										Tty:     util.BoolP(true),
 									},
 									&RunStep{
 										BaseStep: BaseStep{
@@ -437,6 +459,7 @@ func TestParseOutput(t *testing.T) {
 											"ENV01":             Value{Type: ValueTypeString, Value: "ENV01"},
 											"ENVFROMVARIABLE01": Value{Type: ValueTypeFromVariable, Value: "variable01"},
 										},
+										Tty: util.BoolP(true),
 									},
 									&SaveCacheStep{
 										BaseStep: BaseStep{Type: "save_cache"},
@@ -520,6 +543,46 @@ func TestParseOutput(t *testing.T) {
 								WorkingDir: defaultWorkingDir,
 								Steps:      nil,
 								Depends:    nil,
+							},
+							&Task{
+								Name: "task05",
+								Runtime: &Runtime{
+									Type: "pod",
+									Arch: "",
+									Containers: []*Container{
+										&Container{
+											Image: "image01",
+										},
+									},
+								},
+								WorkingDir: defaultWorkingDir,
+								Steps: Steps{
+									&RunStep{
+										BaseStep: BaseStep{
+											Type: "run",
+											Name: "command with default tty",
+										},
+										Command: "command01",
+										Tty:     util.BoolP(true),
+									},
+									&RunStep{
+										BaseStep: BaseStep{
+											Type: "run",
+											Name: "command with tty as true",
+										},
+										Command: "command02",
+										Tty:     util.BoolP(true),
+									},
+									&RunStep{
+										BaseStep: BaseStep{
+											Type: "run",
+											Name: "command with tty as false",
+										},
+										Command: "command03",
+										Tty:     util.BoolP(false),
+									},
+								},
+								Depends: nil,
 							},
 						},
 					},

--- a/internal/runconfig/runconfig.go
+++ b/internal/runconfig/runconfig.go
@@ -135,6 +135,7 @@ fi
 		rs.Environment = env
 		rs.WorkingDir = cs.WorkingDir
 		rs.Shell = cs.Shell
+		rs.Tty = cs.Tty
 		return rs
 
 	case *config.SaveToWorkspaceStep:

--- a/internal/services/executor/executor.go
+++ b/internal/services/executor/executor.go
@@ -171,7 +171,7 @@ func (e *Executor) doRunStep(ctx context.Context, s *types.RunStep, t *types.Exe
 		AttachStdin: true,
 		Stdout:      outf,
 		Stderr:      outf,
-		Tty:         true,
+		Tty:         *s.Tty,
 	}
 
 	ce, err := pod.Exec(ctx, execConfig)

--- a/services/runservice/types/types.go
+++ b/services/runservice/types/types.go
@@ -415,6 +415,7 @@ type RunStep struct {
 	Environment map[string]string `json:"environment,omitempty"`
 	WorkingDir  string            `json:"working_dir,omitempty"`
 	Shell       string            `json:"shell,omitempty"`
+	Tty         *bool             `json:"tty,omitempty"`
 }
 
 type SaveContent struct {
@@ -581,6 +582,9 @@ func (et *Steps) UnmarshalJSON(b []byte) error {
 			var s RunStep
 			if err := json.Unmarshal(step, &s); err != nil {
 				return err
+			}
+			if s.Tty == nil {
+				s.Tty = util.BoolP(true)
 			}
 			steps[i] = &s
 		case "save_to_workspace":


### PR DESCRIPTION
A try to fix issue #1 adding "tty" option for run steps (default is true):
```
- run:
    name: test tty
    command: "ps -ef && lsof"
    tty: false
```