### PR TITLE
objectstorage posix: use limitreader only when size is specified.

### DIFF
--- a/internal/objectstorage/objectstorage.go
+++ b/internal/objectstorage/objectstorage.go
@@ -23,6 +23,11 @@ import (
 type Storage interface {
 	Stat(filepath string) (*types.ObjectInfo, error)
 	ReadObject(filepath string) (types.ReadSeekCloser, error)
+	// WriteObject atomically writes an object. If size is greater or equal to
+	// zero then only size bytes will be read from data and wrote. If size is
+	// less than zero data will be wrote until EOF. When persist is true the
+	// implementation must ensure that data is persisted to the underlying
+	// storage.
 	WriteObject(filepath string, data io.Reader, size int64, persist bool) error
 	DeleteObject(filepath string) error
 	List(prefix, startWith, delimiter string, doneCh <-chan struct{}) <-chan types.ObjectInfo

--- a/internal/objectstorage/posix/posix.go
+++ b/internal/objectstorage/posix/posix.go
@@ -98,9 +98,13 @@ func (s *PosixStorage) WriteObject(p string, data io.Reader, size int64, persist
 	if err := os.MkdirAll(path.Dir(fspath), 0770); err != nil {
 		return err
 	}
-	lr := io.LimitReader(data, size)
+
+	r := data
+	if size >= 0 {
+		r = io.LimitReader(data, size)
+	}
 	return common.WriteFileAtomicFunc(fspath, s.dataDir, s.tmpDir, 0660, persist, func(f io.Writer) error {
-		_, err := io.Copy(f, lr)
+		_, err := io.Copy(f, r)
 		return err
 	})
 }

--- a/internal/objectstorage/posixflat/posixflat.go
+++ b/internal/objectstorage/posixflat/posixflat.go
@@ -274,9 +274,13 @@ func (s *PosixFlatStorage) WriteObject(p string, data io.Reader, size int64, per
 	if err := os.MkdirAll(path.Dir(fspath), 0770); err != nil {
 		return err
 	}
-	lr := io.LimitReader(data, size)
+
+	r := data
+	if size >= 0 {
+		r = io.LimitReader(data, size)
+	}
 	return common.WriteFileAtomicFunc(fspath, s.dataDir, s.tmpDir, 0660, persist, func(f io.Writer) error {
-		_, err := io.Copy(f, lr)
+		_, err := io.Copy(f, r)
 		return err
 	})
 }


### PR DESCRIPTION
Use limitreader only when size is specified (greater or equal to 0).
When size is unknown (less than 0) limitreader will immediately return EOF
instead of writing the whole data.