### PR TITLE
*: write and flush header on log handlers

### DIFF
--- a/internal/services/executor/api.go
+++ b/internal/services/executor/api.go
@@ -137,10 +137,17 @@ func (h *logsHandler) readLogs(taskID string, setup bool, step int, logPath stri
 		w.Header().Set("Content-Length", strconv.FormatInt(fi.Size(), 10))
 	}
 
+	// write and flush the headers so the client will receive the response
+	// header also if there're currently no lines to send
+	w.WriteHeader(http.StatusOK)
 	var flusher http.Flusher
 	if fl, ok := w.(http.Flusher); ok {
 		flusher = fl
 	}
+	if flusher != nil {
+		flusher.Flush()
+	}
+
 	stop := false
 	flushstop := false
 	for {

--- a/internal/services/gateway/api/run.go
+++ b/internal/services/gateway/api/run.go
@@ -451,8 +451,18 @@ func (h *LogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// write and flush the headers so the client will receive the response
+	// header also if there're currently no lines to send
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+	var flusher http.Flusher
+	if fl, ok := w.(http.Flusher); ok {
+		flusher = fl
+	}
+	if flusher != nil {
+		flusher.Flush()
+	}
 
 	defer resp.Body.Close()
 	if err := sendLogs(w, resp.Body); err != nil {


### PR DESCRIPTION
Explicitly write and flush the headers in the various services LogHandlers.

Currently the 200 response and the other headers will be automatically written
by the golang http implementation only when we send something in the body. But if
there's nothing to send (no logs yet written) the client will never receive the
headers and cannot know if the request was successful.