### PR TITLE
cmd: fix project visibility switch

### DIFF
--- a/cmd/agola/cmd/projectupdate.go
+++ b/cmd/agola/cmd/projectupdate.go
@@ -75,7 +75,8 @@ func projectUpdate(cmd *cobra.Command, args []string) error {
 		if !IsValidVisibility(projectUpdateOpts.visibility) {
 			return errors.Errorf("invalid visibility %q", projectUpdateOpts.visibility)
 		}
-		req.Name = &projectUpdateOpts.visibility
+		visibility := gwapitypes.Visibility(projectUpdateOpts.visibility)
+		req.Visibility = &visibility
 	}
 
 	log.Infof("updating project")


### PR DESCRIPTION
Trying to modify the project visibility from CLI ended up with a new project name (and visibility did not change):
```
$ agola project  list --parent "user/user01" --token $TOKEN
xxxxxx: Name: test
$ agola project update --ref "user/user01/test" --visibility private --token $TOKEN
    INFO    cmd/projectupdate.go:82 updating project
    INFO    cmd/projectupdate.go:87 project test update, ID: xxxxxx
$ agola project  list --parent "user/user01" --token $TOKEN
xxxxx: Name: private
```
Fixed assigning the passed value to the req.Visibility field.