### PR TITLE
cmd: add details to run list

### DIFF
--- a/cmd/agola/cmd/runlist.go
+++ b/cmd/agola/cmd/runlist.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"sort"
 
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
@@ -43,6 +44,18 @@ type runListOptions struct {
 	start       string
 }
 
+type runDetails struct {
+	runResponse *gwapitypes.RunResponse
+	tasks       []*taskDetails
+}
+
+type taskDetails struct {
+	name            string
+	level           int
+	runTaskResponse *gwapitypes.RunTaskResponse
+	retrieveError   error
+}
+
 var runListOpts runListOptions
 
 func init() {
@@ -60,11 +73,22 @@ func init() {
 	cmdRun.AddCommand(cmdRunList)
 }
 
-func printRuns(runs []*gwapitypes.RunResponse) {
+func printRuns(runs []*runDetails) {
 	for _, run := range runs {
-		fmt.Printf("%s: Phase: %s, Result: %s\n", run.ID, run.Phase, run.Result)
-		for _, task := range run.Tasks {
-			fmt.Printf("\tTaskName: %s, Status: %s\n", task.Name, task.Status)
+		fmt.Printf("%s: Phase: %s, Result: %s\n", run.runResponse.ID, run.runResponse.Phase, run.runResponse.Result)
+		for _, task := range run.tasks {
+			fmt.Printf("\tTaskName: %s, Status: %s\n", task.runTaskResponse.Name, task.runTaskResponse.Status)
+			if task.retrieveError != nil {
+				fmt.Printf("\t\tfailed to retrieve task information: %v\n", task.retrieveError)
+			} else {
+				for n, step := range task.runTaskResponse.Steps {
+					if step.Phase.IsFinished() && step.Type == "run" {
+						fmt.Printf("\t\tStep: %d, Name: %s, Type: %s, Phase: %s, ExitStatus: %d\n", n, step.Name, step.Type, step.Phase, *step.ExitStatus)
+					} else {
+						fmt.Printf("\t\tStep: %d, Name: %s, Type: %s, Phase: %s\n", n, step.Name, step.Type, step.Phase)
+					}
+				}
+			}
 		}
 	}
 }
@@ -82,13 +106,36 @@ func runList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	runs := make([]*gwapitypes.RunResponse, len(runsResp))
+	runs := make([]*runDetails, len(runsResp))
 	for i, runResponse := range runsResp {
 		run, _, err := gwclient.GetRun(context.TODO(), runResponse.ID)
 		if err != nil {
 			return err
 		}
-		runs[i] = run
+
+		tasks := []*taskDetails{}
+		for _, task := range run.Tasks {
+			runTaskResponse, _, err := gwclient.GetRunTask(context.TODO(), run.ID, task.ID)
+			t := &taskDetails{
+				name:            task.Name,
+				level:           task.Level,
+				runTaskResponse: runTaskResponse,
+				retrieveError:   err,
+			}
+			tasks = append(tasks, t)
+		}
+
+		sort.Slice(tasks, func(i, j int) bool {
+			if tasks[i].level != tasks[j].level {
+				return tasks[i].level < tasks[j].level
+			}
+			return tasks[i].name < tasks[j].name
+		})
+
+		runs[i] = &runDetails{
+			runResponse: run,
+			tasks:       tasks,
+		}
 	}
 
 	printRuns(runs)


### PR DESCRIPTION
Added task details in the output of `agola run list`:
```
0000001et7q3m-000000000000h: Phase: finished, Result: success
        TaskName: build go 1.13, Status: success
                Step: 0, Name: Clone repository and checkout code, Type: run, Phase: success, ExitStatus: 0
                Step: 1, Name: restore cache, Type: restore_cache, Phase: success
                Step: 2, Name: build the program, Type: run, Phase: success, ExitStatus: 0
                Step: 3, Name: save to workspace, Type: save_to_workspace, Phase: success
                Step: 4, Name: save cache, Type: save_cache, Phase: success
                Step: 5, Name: save cache, Type: save_cache, Phase: success
        TaskName: run, Status: success
                Step: 0, Name: restore workspace, Type: restore_workspace, Phase: success
                Step: 1, Name: ./bin/agola-example-go, Type: run, Phase: success, ExitStatus: 0
```