### PR TITLE
gateway: fix api used by GetRunTask

### DIFF
--- a/services/gateway/client/client.go
+++ b/services/gateway/client/client.go
@@ -457,7 +457,7 @@ func (c *Client) GetRun(ctx context.Context, runID string) (*gwapitypes.RunRespo
 
 func (c *Client) GetRunTask(ctx context.Context, runID, taskID string) (*gwapitypes.RunTaskResponse, *http.Response, error) {
 	task := new(gwapitypes.RunTaskResponse)
-	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/run/%s/task/%s", runID, taskID), nil, jsonContent, nil, task)
+	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/runs/%s/tasks/%s", runID, taskID), nil, jsonContent, nil, task)
 	return task, resp, err
 }
 

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -1254,6 +1254,9 @@ func TestDirectRunLogs(t *testing.T) {
 				if err != nil {
 					return false, nil
 				}
+				if tt.step >= len(t.Steps) {
+					return true, nil
+				}
 				if !t.Steps[tt.step].LogArchived {
 					return false, nil
 				}


### PR DESCRIPTION
The method GetRunTask, implemented in the gateway client to check if the log exists or not, pointed to wrong URL returned always logArchived even if not found. 
Added a check to verify if the step number is invalid (in this case the log will not exist and logArchived will not checked).