### PR TITLE
cmd: add TaskID to run list output

### DIFF
--- a/cmd/agola/cmd/runlist.go
+++ b/cmd/agola/cmd/runlist.go
@@ -77,7 +77,7 @@ func printRuns(runs []*runDetails) {
 	for _, run := range runs {
 		fmt.Printf("%s: Phase: %s, Result: %s\n", run.runResponse.ID, run.runResponse.Phase, run.runResponse.Result)
 		for _, task := range run.tasks {
-			fmt.Printf("\tTaskName: %s, Status: %s\n", task.runTaskResponse.Name, task.runTaskResponse.Status)
+			fmt.Printf("\tTaskName: %s, TaskID: %s, Status: %s\n", task.runTaskResponse.Name, task.runTaskResponse.ID, task.runTaskResponse.Status)
 			if task.retrieveError != nil {
 				fmt.Printf("\t\tfailed to retrieve task information: %v\n", task.retrieveError)
 			} else {


### PR DESCRIPTION
Add `TaskID` field to the `run list` output (this information can be used to get/delete logs with `--taskid` option):
```
0000001et7q3m-000000000000n: Phase: finished, Result: success
        TaskName: build go 1.13, TaskID: e2590e10-ef22-4e38-b558-415ec5498957, Status: success
        <...>
```