### PR TITLE
[WIP] Add initial rbac actions and roles

### DIFF
--- a/cmd/agola/cmd/orgmemberadd.go
+++ b/cmd/agola/cmd/orgmemberadd.go
@@ -63,7 +63,7 @@ func orgMemberAdd(cmd *cobra.Command, args []string) error {
 	gwclient := gwclient.NewClient(gatewayURL, token)
 
 	log.Infof("adding/updating member %q to organization %q with role %q", orgMemberAddOpts.username, orgMemberAddOpts.orgname, orgMemberAddOpts.role)
-	_, _, err := gwclient.AddOrgMember(context.TODO(), orgMemberAddOpts.orgname, orgMemberAddOpts.username, gwapitypes.MemberRole(orgMemberAddOpts.role))
+	_, _, err := gwclient.AddOrgMember(context.TODO(), orgMemberAddOpts.orgname, orgMemberAddOpts.username, gwapitypes.OrgMemberRole(orgMemberAddOpts.role))
 	if err != nil {
 		return errors.Errorf("failed to add/update organization member: %w", err)
 	}

--- a/internal/services/configstore/action/org.go
+++ b/internal/services/configstore/action/org.go
@@ -32,7 +32,7 @@ import (
 
 type OrgMemberResponse struct {
 	User *types.User
-	Role types.MemberRole
+	Role types.OrgMemberRole
 }
 
 func orgMemberResponse(orgUser *readdb.OrgUser) *OrgMemberResponse {
@@ -138,7 +138,7 @@ func (h *ActionHandler) CreateOrg(ctx context.Context, org *types.Organization) 
 			ID:             uuid.NewV4().String(),
 			OrganizationID: org.ID,
 			UserID:         org.CreatorUserID,
-			MemberRole:     types.MemberRoleOwner,
+			MemberRole:     types.OrgMemberRoleOwner,
 		}
 		orgmemberj, err := json.Marshal(orgmember)
 		if err != nil {
@@ -221,8 +221,8 @@ func (h *ActionHandler) DeleteOrg(ctx context.Context, orgRef string) error {
 
 // AddOrgMember add/updates an org member.
 // TODO(sgotti) handle invitation when implemented
-func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string, role types.MemberRole) (*types.OrganizationMember, error) {
-	if !types.IsValidMemberRole(role) {
+func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string, role types.OrgMemberRole) (*types.OrganizationMember, error) {
+	if !types.IsValidOrgMemberRole(role) {
 		return nil, util.NewErrBadRequest(errors.Errorf("invalid role %q", role))
 	}
 

--- a/internal/services/configstore/action/user.go
+++ b/internal/services/configstore/action/user.go
@@ -632,7 +632,7 @@ func (h *ActionHandler) DeleteUserToken(ctx context.Context, userRef, tokenName 
 
 type UserOrgsResponse struct {
 	Organization *types.Organization
-	Role         types.MemberRole
+	Role         types.OrgMemberRole
 }
 
 func userOrgsResponse(userOrg *readdb.UserOrg) *UserOrgsResponse {

--- a/internal/services/configstore/configstore_test.go
+++ b/internal/services/configstore/configstore_test.go
@@ -1206,7 +1206,7 @@ func TestOrgMembers(t *testing.T) {
 		expectedResponse := []*action.UserOrgsResponse{
 			{
 				Organization: org,
-				Role:         types.MemberRoleOwner,
+				Role:         types.OrgMemberRoleOwner,
 			},
 		}
 		res, err := cs.ah.GetUserOrgs(ctx, user.ID)
@@ -1239,13 +1239,13 @@ func TestOrgMembers(t *testing.T) {
 		expectedResponse := []*action.UserOrgsResponse{
 			{
 				Organization: org,
-				Role:         types.MemberRoleOwner,
+				Role:         types.OrgMemberRoleOwner,
 			},
 		}
 		for i := 5; i < 10; i++ {
 			expectedResponse = append(expectedResponse, &action.UserOrgsResponse{
 				Organization: orgs[i],
-				Role:         types.MemberRoleOwner,
+				Role:         types.OrgMemberRoleOwner,
 			})
 		}
 		res, err := cs.ah.GetUserOrgs(ctx, user.ID)

--- a/internal/services/configstore/readdb/org.go
+++ b/internal/services/configstore/readdb/org.go
@@ -297,7 +297,7 @@ func scanOrgMembers(rows *sql.Rows) ([]*types.OrganizationMember, []string, erro
 
 type OrgUser struct {
 	User *types.User
-	Role types.MemberRole
+	Role types.OrgMemberRole
 }
 
 // TODO(sgotti) implement cursor fetching
@@ -348,7 +348,7 @@ func (r *ReadDB) GetOrgUsers(tx *db.Tx, orgID string) ([]*OrgUser, error) {
 
 type UserOrg struct {
 	Organization *types.Organization
-	Role         types.MemberRole
+	Role         types.OrgMemberRole
 }
 
 // TODO(sgotti) implement cursor fetching

--- a/internal/services/gateway/action/auth.go
+++ b/internal/services/gateway/action/auth.go
@@ -68,7 +68,7 @@ func (h *ActionHandler) IsOrgOwner(ctx context.Context, orgID string) (bool, err
 		if userOrg.Organization.ID != orgID {
 			continue
 		}
-		if userOrg.Role == cstypes.MemberRoleOwner {
+		if userOrg.Role == cstypes.OrgMemberRoleOwner {
 			return true, nil
 		}
 	}
@@ -103,7 +103,7 @@ func (h *ActionHandler) IsProjectOwner(ctx context.Context, ownerType cstypes.Co
 			if userOrg.Organization.ID != ownerID {
 				continue
 			}
-			if userOrg.Role == cstypes.MemberRoleOwner {
+			if userOrg.Role == cstypes.OrgMemberRoleOwner {
 				return true, nil
 			}
 		}

--- a/internal/services/gateway/action/org.go
+++ b/internal/services/gateway/action/org.go
@@ -24,6 +24,14 @@ import (
 )
 
 func (h *ActionHandler) GetOrg(ctx context.Context, orgRef string) (*cstypes.Organization, error) {
+	authorized, err := h.CanDoOrgAction(ctx, cstypes.ActionTypeGetOrg, "")
+	if err != nil {
+		return nil, errors.Errorf("failed to determine authorization: %w", err)
+	}
+	if !authorized {
+		return nil, util.NewErrForbidden(errors.Errorf("user not authorized"))
+	}
+
 	org, resp, err := h.configstoreClient.GetOrg(ctx, orgRef)
 	if err != nil {
 		return nil, ErrFromRemote(resp, err)
@@ -38,45 +46,19 @@ type GetOrgsRequest struct {
 }
 
 func (h *ActionHandler) GetOrgs(ctx context.Context, req *GetOrgsRequest) ([]*cstypes.Organization, error) {
+	authorized, err := h.CanDoOrgAction(ctx, cstypes.ActionTypeGetOrg, "")
+	if err != nil {
+		return nil, errors.Errorf("failed to determine authorization: %w", err)
+	}
+	if !authorized {
+		return nil, util.NewErrForbidden(errors.Errorf("user not authorized"))
+	}
+
 	orgs, resp, err := h.configstoreClient.GetOrgs(ctx, req.Start, req.Limit, req.Asc)
 	if err != nil {
 		return nil, ErrFromRemote(resp, err)
 	}
 	return orgs, nil
-}
-
-type OrgMembersResponse struct {
-	Organization *cstypes.Organization
-	Members      []*OrgMemberResponse
-}
-
-type OrgMemberResponse struct {
-	User *cstypes.User
-	Role cstypes.OrgMemberRole
-}
-
-func (h *ActionHandler) GetOrgMembers(ctx context.Context, orgRef string) (*OrgMembersResponse, error) {
-	org, resp, err := h.configstoreClient.GetOrg(ctx, orgRef)
-	if err != nil {
-		return nil, ErrFromRemote(resp, err)
-	}
-
-	orgMembers, resp, err := h.configstoreClient.GetOrgMembers(ctx, orgRef)
-	if err != nil {
-		return nil, ErrFromRemote(resp, err)
-	}
-
-	res := &OrgMembersResponse{
-		Organization: org,
-		Members:      make([]*OrgMemberResponse, len(orgMembers)),
-	}
-	for i, orgMember := range orgMembers {
-		res.Members[i] = &OrgMemberResponse{
-			User: orgMember.User,
-			Role: orgMember.Role,
-		}
-	}
-	return res, nil
 }
 
 type CreateOrgRequest struct {
@@ -87,8 +69,12 @@ type CreateOrgRequest struct {
 }
 
 func (h *ActionHandler) CreateOrg(ctx context.Context, req *CreateOrgRequest) (*cstypes.Organization, error) {
-	if !h.IsUserLoggedOrAdmin(ctx) {
-		return nil, errors.Errorf("user not logged in")
+	authorized, err := h.CanDoOrgAction(ctx, cstypes.ActionTypeCreateOrg, "")
+	if err != nil {
+		return nil, errors.Errorf("failed to determine authorization: %w", err)
+	}
+	if !authorized {
+		return nil, util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
 	if req.Name == "" {
@@ -117,24 +103,61 @@ func (h *ActionHandler) CreateOrg(ctx context.Context, req *CreateOrgRequest) (*
 }
 
 func (h *ActionHandler) DeleteOrg(ctx context.Context, orgRef string) error {
-	org, resp, err := h.configstoreClient.GetOrg(ctx, orgRef)
+	authorized, err := h.CanDoOrgAction(ctx, cstypes.ActionTypeDeleteOrg, orgRef)
 	if err != nil {
-		return ErrFromRemote(resp, err)
+		return errors.Errorf("failed to determine authorization: %w", err)
 	}
-
-	isOrgOwner, err := h.IsOrgOwner(ctx, org.ID)
-	if err != nil {
-		return errors.Errorf("failed to determine ownership: %w", err)
-	}
-	if !isOrgOwner {
+	if !authorized {
 		return util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
-	resp, err = h.configstoreClient.DeleteOrg(ctx, orgRef)
+	resp, err := h.configstoreClient.DeleteOrg(ctx, orgRef)
 	if err != nil {
 		return errors.Errorf("failed to delete org: %w", ErrFromRemote(resp, err))
 	}
 	return nil
+}
+
+type OrgMembersResponse struct {
+	Organization *cstypes.Organization
+	Members      []*OrgMemberResponse
+}
+
+type OrgMemberResponse struct {
+	User *cstypes.User
+	Role cstypes.OrgMemberRole
+}
+
+func (h *ActionHandler) GetOrgMembers(ctx context.Context, orgRef string) (*OrgMembersResponse, error) {
+	authorized, err := h.CanDoOrgAction(ctx, cstypes.ActionTypeGetOrgMembers, orgRef)
+	if err != nil {
+		return nil, errors.Errorf("failed to determine authorization: %w", err)
+	}
+	if !authorized {
+		return nil, util.NewErrForbidden(errors.Errorf("user not authorized"))
+	}
+
+	org, resp, err := h.configstoreClient.GetOrg(ctx, orgRef)
+	if err != nil {
+		return nil, ErrFromRemote(resp, err)
+	}
+
+	orgMembers, resp, err := h.configstoreClient.GetOrgMembers(ctx, orgRef)
+	if err != nil {
+		return nil, ErrFromRemote(resp, err)
+	}
+
+	res := &OrgMembersResponse{
+		Organization: org,
+		Members:      make([]*OrgMemberResponse, len(orgMembers)),
+	}
+	for i, orgMember := range orgMembers {
+		res.Members[i] = &OrgMemberResponse{
+			User: orgMember.User,
+			Role: orgMember.Role,
+		}
+	}
+	return res, nil
 }
 
 type AddOrgMemberResponse struct {
@@ -144,6 +167,14 @@ type AddOrgMemberResponse struct {
 }
 
 func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string, role cstypes.OrgMemberRole) (*AddOrgMemberResponse, error) {
+	authorized, err := h.CanDoOrgAction(ctx, cstypes.ActionTypeAddOrgMembers, orgRef)
+	if err != nil {
+		return nil, errors.Errorf("failed to determine authorization: %w", err)
+	}
+	if !authorized {
+		return nil, util.NewErrForbidden(errors.Errorf("user not authorized"))
+	}
+
 	org, resp, err := h.configstoreClient.GetOrg(ctx, orgRef)
 	if err != nil {
 		return nil, ErrFromRemote(resp, err)
@@ -151,14 +182,6 @@ func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string
 	user, resp, err := h.configstoreClient.GetUser(ctx, userRef)
 	if err != nil {
 		return nil, ErrFromRemote(resp, err)
-	}
-
-	isOrgOwner, err := h.IsOrgOwner(ctx, org.ID)
-	if err != nil {
-		return nil, errors.Errorf("failed to determine ownership: %w", err)
-	}
-	if !isOrgOwner {
-		return nil, util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
 	orgmember, resp, err := h.configstoreClient.AddOrgMember(ctx, orgRef, userRef, role)
@@ -174,20 +197,15 @@ func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string
 }
 
 func (h *ActionHandler) RemoveOrgMember(ctx context.Context, orgRef, userRef string) error {
-	org, resp, err := h.configstoreClient.GetOrg(ctx, orgRef)
+	authorized, err := h.CanDoOrgAction(ctx, cstypes.ActionTypeRemoveOrgMembers, orgRef)
 	if err != nil {
-		return ErrFromRemote(resp, err)
+		return errors.Errorf("failed to determine authorization: %w", err)
 	}
-
-	isOrgOwner, err := h.IsOrgOwner(ctx, org.ID)
-	if err != nil {
-		return errors.Errorf("failed to determine ownership: %w", err)
-	}
-	if !isOrgOwner {
+	if !authorized {
 		return util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
-	resp, err = h.configstoreClient.RemoveOrgMember(ctx, orgRef, userRef)
+	resp, err := h.configstoreClient.RemoveOrgMember(ctx, orgRef, userRef)
 	if err != nil {
 		return errors.Errorf("failed to remove organization member: %w", ErrFromRemote(resp, err))
 	}

--- a/internal/services/gateway/action/org.go
+++ b/internal/services/gateway/action/org.go
@@ -52,7 +52,7 @@ type OrgMembersResponse struct {
 
 type OrgMemberResponse struct {
 	User *cstypes.User
-	Role cstypes.MemberRole
+	Role cstypes.OrgMemberRole
 }
 
 func (h *ActionHandler) GetOrgMembers(ctx context.Context, orgRef string) (*OrgMembersResponse, error) {
@@ -143,7 +143,7 @@ type AddOrgMemberResponse struct {
 	User               *cstypes.User
 }
 
-func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string, role cstypes.MemberRole) (*AddOrgMemberResponse, error) {
+func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string, role cstypes.OrgMemberRole) (*AddOrgMemberResponse, error) {
 	org, resp, err := h.configstoreClient.GetOrg(ctx, orgRef)
 	if err != nil {
 		return nil, ErrFromRemote(resp, err)

--- a/internal/services/gateway/action/remotesource.go
+++ b/internal/services/gateway/action/remotesource.go
@@ -61,7 +61,7 @@ type CreateRemoteSourceRequest struct {
 
 func (h *ActionHandler) CreateRemoteSource(ctx context.Context, req *CreateRemoteSourceRequest) (*cstypes.RemoteSource, error) {
 	if !h.IsUserAdmin(ctx) {
-		return nil, errors.Errorf("user not admin")
+		return nil, util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
 	if !util.ValidateName(req.Name) {
@@ -135,7 +135,7 @@ type UpdateRemoteSourceRequest struct {
 
 func (h *ActionHandler) UpdateRemoteSource(ctx context.Context, req *UpdateRemoteSourceRequest) (*cstypes.RemoteSource, error) {
 	if !h.IsUserAdmin(ctx) {
-		return nil, errors.Errorf("user not admin")
+		return nil, util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
 	rs, resp, err := h.configstoreClient.GetRemoteSource(ctx, req.RemoteSourceRef)
@@ -183,7 +183,7 @@ func (h *ActionHandler) UpdateRemoteSource(ctx context.Context, req *UpdateRemot
 
 func (h *ActionHandler) DeleteRemoteSource(ctx context.Context, rsRef string) error {
 	if !h.IsUserAdmin(ctx) {
-		return errors.Errorf("user not admin")
+		return util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
 	resp, err := h.configstoreClient.DeleteRemoteSource(ctx, rsRef)

--- a/internal/services/gateway/action/run.go
+++ b/internal/services/gateway/action/run.go
@@ -76,11 +76,11 @@ func (h *ActionHandler) GetRun(ctx context.Context, runID string) (*rsapitypes.R
 	if err != nil {
 		return nil, ErrFromRemote(resp, err)
 	}
-	canGetRun, err := h.CanGetRun(ctx, runResp.RunConfig.Group)
+	authorized, err := h.CanDoRunAction(ctx, cstypes.ActionTypeGetRun, runResp.RunConfig.Group)
 	if err != nil {
-		return nil, errors.Errorf("failed to determine permissions: %w", err)
+		return nil, errors.Errorf("failed to determine authorization: %w", err)
 	}
-	if !canGetRun {
+	if !authorized {
 		return nil, util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
@@ -99,11 +99,11 @@ type GetRunsRequest struct {
 }
 
 func (h *ActionHandler) GetRuns(ctx context.Context, req *GetRunsRequest) (*rsapitypes.GetRunsResponse, error) {
-	canGetRun, err := h.CanGetRun(ctx, req.Group)
+	authorized, err := h.CanDoRunAction(ctx, cstypes.ActionTypeGetRun, req.Group)
 	if err != nil {
-		return nil, errors.Errorf("failed to determine permissions: %w", err)
+		return nil, errors.Errorf("failed to determine authorization: %w", err)
 	}
-	if !canGetRun {
+	if !authorized {
 		return nil, util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
@@ -129,11 +129,12 @@ func (h *ActionHandler) GetLogs(ctx context.Context, req *GetLogsRequest) (*http
 	if err != nil {
 		return nil, ErrFromRemote(resp, err)
 	}
-	canGetRun, err := h.CanGetRun(ctx, runResp.RunConfig.Group)
+
+	authorized, err := h.CanDoRunAction(ctx, cstypes.ActionTypeGetLog, runResp.RunConfig.Group)
 	if err != nil {
-		return nil, errors.Errorf("failed to determine permissions: %w", err)
+		return nil, errors.Errorf("failed to determine authorization: %w", err)
 	}
-	if !canGetRun {
+	if !authorized {
 		return nil, util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
@@ -157,11 +158,12 @@ func (h *ActionHandler) DeleteLogs(ctx context.Context, req *DeleteLogsRequest) 
 	if err != nil {
 		return ErrFromRemote(resp, err)
 	}
-	canDoRunActions, err := h.CanDoRunActions(ctx, runResp.RunConfig.Group)
+
+	authorized, err := h.CanDoRunAction(ctx, cstypes.ActionTypeDeleteLog, runResp.RunConfig.Group)
 	if err != nil {
-		return errors.Errorf("failed to determine permissions: %w", err)
+		return errors.Errorf("failed to determine authorization: %w", err)
 	}
-	if !canDoRunActions {
+	if !authorized {
 		return util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
@@ -194,11 +196,24 @@ func (h *ActionHandler) RunAction(ctx context.Context, req *RunActionsRequest) (
 	if err != nil {
 		return nil, ErrFromRemote(resp, err)
 	}
-	canGetRun, err := h.CanDoRunActions(ctx, runResp.RunConfig.Group)
-	if err != nil {
-		return nil, errors.Errorf("failed to determine permissions: %w", err)
+
+	var action cstypes.ActionType
+	switch req.ActionType {
+	case RunActionTypeRestart:
+		action = cstypes.ActionTypeRestartRun
+	case RunActionTypeCancel:
+		action = cstypes.ActionTypeCancelRun
+	case RunActionTypeStop:
+		action = cstypes.ActionTypeStopRun
+	default:
+		return nil, util.NewErrBadRequest(errors.Errorf("wrong run action type %q", req.ActionType))
 	}
-	if !canGetRun {
+
+	authorized, err := h.CanDoRunAction(ctx, action, runResp.RunConfig.Group)
+	if err != nil {
+		return nil, errors.Errorf("failed to determine authorization: %w", err)
+	}
+	if !authorized {
 		return nil, util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
@@ -260,13 +275,23 @@ func (h *ActionHandler) RunTaskAction(ctx context.Context, req *RunTaskActionsRe
 	if err != nil {
 		return ErrFromRemote(resp, err)
 	}
-	canDoRunAction, err := h.CanDoRunActions(ctx, runResp.RunConfig.Group)
-	if err != nil {
-		return errors.Errorf("failed to determine permissions: %w", err)
+
+	var action cstypes.ActionType
+	switch req.ActionType {
+	case RunTaskActionTypeApprove:
+		action = cstypes.ActionTypeApproveTask
+	default:
+		return util.NewErrBadRequest(errors.Errorf("wrong run task action type %q", req.ActionType))
 	}
-	if !canDoRunAction {
+
+	authorized, err := h.CanDoRunAction(ctx, action, runResp.RunConfig.Group)
+	if err != nil {
+		return errors.Errorf("failed to determine authorization: %w", err)
+	}
+	if !authorized {
 		return util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
+
 	curUserID := h.CurrentUserID(ctx)
 	if curUserID == "" {
 		return util.NewErrBadRequest(errors.Errorf("no logged in user"))

--- a/internal/services/gateway/action/user.go
+++ b/internal/services/gateway/action/user.go
@@ -46,8 +46,12 @@ func isAccessTokenExpired(expiresAt time.Time) bool {
 }
 
 func (h *ActionHandler) GetUser(ctx context.Context, userRef string) (*cstypes.User, error) {
-	if !h.IsUserLoggedOrAdmin(ctx) {
-		return nil, errors.Errorf("user not logged in")
+	authorized, err := h.CanDoUserAction(ctx, cstypes.ActionTypeGetUser, userRef)
+	if err != nil {
+		return nil, errors.Errorf("failed to determine authorization: %w", err)
+	}
+	if !authorized {
+		return nil, util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
 	user, resp, err := h.configstoreClient.GetUser(ctx, userRef)
@@ -64,8 +68,12 @@ type GetUsersRequest struct {
 }
 
 func (h *ActionHandler) GetUsers(ctx context.Context, req *GetUsersRequest) ([]*cstypes.User, error) {
-	if !h.IsUserAdmin(ctx) {
-		return nil, errors.Errorf("user not logged in")
+	authorized, err := h.CanDoUserAction(ctx, cstypes.ActionTypeGetUser, "")
+	if err != nil {
+		return nil, errors.Errorf("failed to determine authorization: %w", err)
+	}
+	if !authorized {
+		return nil, util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
 	users, resp, err := h.configstoreClient.GetUsers(ctx, req.Start, req.Limit, req.Asc)
@@ -80,8 +88,12 @@ type CreateUserRequest struct {
 }
 
 func (h *ActionHandler) CreateUser(ctx context.Context, req *CreateUserRequest) (*cstypes.User, error) {
-	if !h.IsUserAdmin(ctx) {
-		return nil, errors.Errorf("user not admin")
+	authorized, err := h.CanDoUserAction(ctx, cstypes.ActionTypeCreateUser, "")
+	if err != nil {
+		return nil, errors.Errorf("failed to determine authorization: %w", err)
+	}
+	if !authorized {
+		return nil, util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
 	if req.UserName == "" {
@@ -111,16 +123,12 @@ type CreateUserTokenRequest struct {
 }
 
 func (h *ActionHandler) CreateUserToken(ctx context.Context, req *CreateUserTokenRequest) (string, error) {
-	var userID string
-	userIDVal := ctx.Value("userid")
-	if userIDVal != nil {
-		userID = userIDVal.(string)
+	authorized, err := h.CanDoUserAction(ctx, cstypes.ActionTypeUpdateUser, "")
+	if err != nil {
+		return "", errors.Errorf("failed to determine authorization: %w", err)
 	}
-
-	isAdmin := false
-	isAdminVal := ctx.Value("admin")
-	if isAdminVal != nil {
-		isAdmin = isAdminVal.(bool)
+	if !authorized {
+		return "", util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
 	userRef := req.UserRef
@@ -129,10 +137,6 @@ func (h *ActionHandler) CreateUserToken(ctx context.Context, req *CreateUserToke
 		return "", errors.Errorf("failed to get user: %w", ErrFromRemote(resp, err))
 	}
 
-	// only admin or the same logged user can create a token
-	if !isAdmin && user.ID != userID {
-		return "", util.NewErrBadRequest(errors.Errorf("logged in user cannot create token for another user"))
-	}
 	if _, ok := user.Tokens[req.TokenName]; ok {
 		return "", util.NewErrBadRequest(errors.Errorf("user %q already have a token with name %q", userRef, req.TokenName))
 	}
@@ -161,6 +165,14 @@ type CreateUserLARequest struct {
 }
 
 func (h *ActionHandler) CreateUserLA(ctx context.Context, req *CreateUserLARequest) (*cstypes.LinkedAccount, error) {
+	authorized, err := h.CanDoUserAction(ctx, cstypes.ActionTypeUpdateUser, req.UserRef)
+	if err != nil {
+		return nil, errors.Errorf("failed to determine authorization: %w", err)
+	}
+	if !authorized {
+		return nil, util.NewErrForbidden(errors.Errorf("user not authorized"))
+	}
+
 	userRef := req.UserRef
 	user, resp, err := h.configstoreClient.GetUser(ctx, userRef)
 	if err != nil {
@@ -219,6 +231,14 @@ func (h *ActionHandler) CreateUserLA(ctx context.Context, req *CreateUserLAReque
 }
 
 func (h *ActionHandler) UpdateUserLA(ctx context.Context, userRef string, la *cstypes.LinkedAccount) error {
+	authorized, err := h.CanDoUserAction(ctx, cstypes.ActionTypeUpdateUser, userRef)
+	if err != nil {
+		return errors.Errorf("failed to determine authorization: %w", err)
+	}
+	if !authorized {
+		return util.NewErrForbidden(errors.Errorf("user not authorized"))
+	}
+
 	user, resp, err := h.configstoreClient.GetUser(ctx, userRef)
 	if err != nil {
 		return errors.Errorf("failed to get user %q: %w", userRef, ErrFromRemote(resp, err))
@@ -253,8 +273,8 @@ func (h *ActionHandler) UpdateUserLA(ctx context.Context, userRef string, la *cs
 	return nil
 }
 
-// RefreshLinkedAccount refreshed the linked account oauth2 access token and update linked account in the configstore
-func (h *ActionHandler) RefreshLinkedAccount(ctx context.Context, rs *cstypes.RemoteSource, userName string, la *cstypes.LinkedAccount) (*cstypes.LinkedAccount, error) {
+// refreshLinkedAccount refreshed the linked account oauth2 access token and update linked account in the configstore
+func (h *ActionHandler) refreshLinkedAccount(ctx context.Context, rs *cstypes.RemoteSource, userName string, la *cstypes.LinkedAccount) (*cstypes.LinkedAccount, error) {
 	switch rs.AuthType {
 	case cstypes.RemoteSourceAuthTypeOauth2:
 		// refresh access token if expired
@@ -285,7 +305,7 @@ func (h *ActionHandler) RefreshLinkedAccount(ctx context.Context, rs *cstypes.Re
 // GetGitSource is a wrapper around common.GetGitSource that will also refresh
 // the oauth2 access token and update the linked account when needed
 func (h *ActionHandler) GetGitSource(ctx context.Context, rs *cstypes.RemoteSource, userName string, la *cstypes.LinkedAccount) (gitsource.GitSource, error) {
-	la, err := h.RefreshLinkedAccount(ctx, rs, userName, la)
+	la, err := h.refreshLinkedAccount(ctx, rs, userName, la)
 	if err != nil {
 		return nil, err
 	}
@@ -753,8 +773,12 @@ func (h *ActionHandler) HandleOauth2Callback(ctx context.Context, code, state st
 }
 
 func (h *ActionHandler) DeleteUser(ctx context.Context, userRef string) error {
-	if !h.IsUserAdmin(ctx) {
-		return errors.Errorf("user not logged in")
+	authorized, err := h.CanDoUserAction(ctx, cstypes.ActionTypeDeleteUser, userRef)
+	if err != nil {
+		return errors.Errorf("failed to determine authorization: %w", err)
+	}
+	if !authorized {
+		return util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
 	resp, err := h.configstoreClient.DeleteUser(ctx, userRef)
@@ -765,24 +789,15 @@ func (h *ActionHandler) DeleteUser(ctx context.Context, userRef string) error {
 }
 
 func (h *ActionHandler) DeleteUserLA(ctx context.Context, userRef, laID string) error {
-	if !h.IsUserLoggedOrAdmin(ctx) {
-		return errors.Errorf("user not logged in")
-	}
-
-	isAdmin := !h.IsUserAdmin(ctx)
-	curUserID := h.CurrentUserID(ctx)
-
-	user, resp, err := h.configstoreClient.GetUser(ctx, userRef)
+	authorized, err := h.CanDoUserAction(ctx, cstypes.ActionTypeUpdateUser, userRef)
 	if err != nil {
-		return errors.Errorf("failed to get user %q: %w", userRef, ErrFromRemote(resp, err))
+		return errors.Errorf("failed to determine authorization: %w", err)
+	}
+	if !authorized {
+		return util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
-	// only admin or the same logged user can create a token
-	if !isAdmin && user.ID != curUserID {
-		return util.NewErrBadRequest(errors.Errorf("logged in user cannot create token for another user"))
-	}
-
-	resp, err = h.configstoreClient.DeleteUserLA(ctx, userRef, laID)
+	resp, err := h.configstoreClient.DeleteUserLA(ctx, userRef, laID)
 	if err != nil {
 		return errors.Errorf("failed to delete user linked account: %w", ErrFromRemote(resp, err))
 	}
@@ -790,24 +805,15 @@ func (h *ActionHandler) DeleteUserLA(ctx context.Context, userRef, laID string) 
 }
 
 func (h *ActionHandler) DeleteUserToken(ctx context.Context, userRef, tokenName string) error {
-	if !h.IsUserLoggedOrAdmin(ctx) {
-		return errors.Errorf("user not logged in")
-	}
-
-	isAdmin := !h.IsUserAdmin(ctx)
-	curUserID := h.CurrentUserID(ctx)
-
-	user, resp, err := h.configstoreClient.GetUser(ctx, userRef)
+	authorized, err := h.CanDoUserAction(ctx, cstypes.ActionTypeUpdateUser, userRef)
 	if err != nil {
-		return errors.Errorf("failed to get user %q: %w", userRef, ErrFromRemote(resp, err))
+		return errors.Errorf("failed to determine authorization: %w", err)
+	}
+	if !authorized {
+		return util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
-	// only admin or the same logged user can create a token
-	if !isAdmin && user.ID != curUserID {
-		return util.NewErrBadRequest(errors.Errorf("logged in user cannot delete token for another user"))
-	}
-
-	resp, err = h.configstoreClient.DeleteUserToken(ctx, userRef, tokenName)
+	resp, err := h.configstoreClient.DeleteUserToken(ctx, userRef, tokenName)
 	if err != nil {
 		return errors.Errorf("failed to delete user token: %w", ErrFromRemote(resp, err))
 	}
@@ -828,6 +834,16 @@ type UserCreateRunRequest struct {
 }
 
 func (h *ActionHandler) UserCreateRun(ctx context.Context, req *UserCreateRunRequest) error {
+	curUserID := h.CurrentUserID(ctx)
+
+	authorized, err := h.CanDoUserAction(ctx, cstypes.ActionTypeCreateRun, curUserID)
+	if err != nil {
+		return errors.Errorf("failed to determine authorization: %w", err)
+	}
+	if !authorized {
+		return util.NewErrForbidden(errors.Errorf("user not authorized"))
+	}
+
 	prRefRegexes := []*regexp.Regexp{}
 	for _, res := range req.PullRequestRefRegexes {
 		re, err := regexp.Compile(res)
@@ -836,8 +852,6 @@ func (h *ActionHandler) UserCreateRun(ctx context.Context, req *UserCreateRunReq
 		}
 		prRefRegexes = append(prRefRegexes, re)
 	}
-
-	curUserID := h.CurrentUserID(ctx)
 
 	user, resp, err := h.configstoreClient.GetUser(ctx, curUserID)
 	if err != nil {
@@ -853,7 +867,7 @@ func (h *ActionHandler) UserCreateRun(ctx context.Context, req *UserCreateRunReq
 		return util.NewErrBadRequest(errors.Errorf("wrong repo path: %q", req.RepoPath))
 	}
 	if repoParts[0] != user.ID {
-		return util.NewErrUnauthorized(errors.Errorf("repo %q not owned", req.RepoPath))
+		return util.NewErrForbidden(errors.Errorf("repo %q not owned", req.RepoPath))
 	}
 
 	branch := req.Branch

--- a/internal/services/gateway/action/variable.go
+++ b/internal/services/gateway/action/variable.go
@@ -34,6 +34,14 @@ type GetVariablesRequest struct {
 }
 
 func (h *ActionHandler) GetVariables(ctx context.Context, req *GetVariablesRequest) ([]*csapitypes.Variable, []*csapitypes.Secret, error) {
+	authorized, err := h.CanDoVariableAction(ctx, cstypes.ActionTypeGetVariable, req.ParentType, req.ParentRef)
+	if err != nil {
+		return nil, nil, errors.Errorf("failed to determine authorization: %w", err)
+	}
+	if !authorized {
+		return nil, nil, util.NewErrForbidden(errors.Errorf("user not authorized"))
+	}
+
 	var csvars []*csapitypes.Variable
 	var cssecrets []*csapitypes.Secret
 
@@ -80,11 +88,11 @@ type CreateVariableRequest struct {
 }
 
 func (h *ActionHandler) CreateVariable(ctx context.Context, req *CreateVariableRequest) (*csapitypes.Variable, []*csapitypes.Secret, error) {
-	isVariableOwner, err := h.IsVariableOwner(ctx, req.ParentType, req.ParentRef)
+	authorized, err := h.CanDoVariableAction(ctx, cstypes.ActionTypeCreateVariable, req.ParentType, req.ParentRef)
 	if err != nil {
-		return nil, nil, errors.Errorf("failed to determine ownership: %w", err)
+		return nil, nil, errors.Errorf("failed to determine authorization: %w", err)
 	}
-	if !isVariableOwner {
+	if !authorized {
 		return nil, nil, util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
@@ -153,11 +161,11 @@ type UpdateVariableRequest struct {
 }
 
 func (h *ActionHandler) UpdateVariable(ctx context.Context, req *UpdateVariableRequest) (*csapitypes.Variable, []*csapitypes.Secret, error) {
-	isVariableOwner, err := h.IsVariableOwner(ctx, req.ParentType, req.ParentRef)
+	authorized, err := h.CanDoVariableAction(ctx, cstypes.ActionTypeUpdateVariable, req.ParentType, req.ParentRef)
 	if err != nil {
-		return nil, nil, errors.Errorf("failed to determine ownership: %w", err)
+		return nil, nil, errors.Errorf("failed to determine authorization: %w", err)
 	}
-	if !isVariableOwner {
+	if !authorized {
 		return nil, nil, util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 
@@ -215,11 +223,11 @@ func (h *ActionHandler) UpdateVariable(ctx context.Context, req *UpdateVariableR
 }
 
 func (h *ActionHandler) DeleteVariable(ctx context.Context, parentType cstypes.ConfigType, parentRef, name string) error {
-	isVariableOwner, err := h.IsVariableOwner(ctx, parentType, parentRef)
+	authorized, err := h.CanDoVariableAction(ctx, cstypes.ActionTypeDeleteVariable, parentType, parentRef)
 	if err != nil {
-		return errors.Errorf("failed to determine ownership: %w", err)
+		return errors.Errorf("failed to determine authorization: %w", err)
 	}
-	if !isVariableOwner {
+	if !authorized {
 		return util.NewErrForbidden(errors.Errorf("user not authorized"))
 	}
 

--- a/internal/services/gateway/api/org.go
+++ b/internal/services/gateway/api/org.go
@@ -189,10 +189,10 @@ func (h *OrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func createOrgMemberResponse(user *cstypes.User, role cstypes.MemberRole) *gwapitypes.OrgMemberResponse {
+func createOrgMemberResponse(user *cstypes.User, role cstypes.OrgMemberRole) *gwapitypes.OrgMemberResponse {
 	return &gwapitypes.OrgMemberResponse{
 		User: createUserResponse(user),
-		Role: gwapitypes.MemberRole(role),
+		Role: gwapitypes.OrgMemberRole(role),
 	}
 }
 
@@ -229,12 +229,12 @@ func (h *OrgMembersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func createAddOrgMemberResponse(org *cstypes.Organization, user *cstypes.User, role cstypes.MemberRole) *gwapitypes.AddOrgMemberResponse {
+func createAddOrgMemberResponse(org *cstypes.Organization, user *cstypes.User, role cstypes.OrgMemberRole) *gwapitypes.AddOrgMemberResponse {
 	return &gwapitypes.AddOrgMemberResponse{
 		Organization: createOrgResponse(org),
 		OrgMemberResponse: gwapitypes.OrgMemberResponse{
 			User: createUserResponse(user),
-			Role: gwapitypes.MemberRole(role),
+			Role: gwapitypes.OrgMemberRole(role),
 		},
 	}
 }
@@ -262,7 +262,7 @@ func (h *AddOrgMemberHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	ares, err := h.ah.AddOrgMember(ctx, orgRef, userRef, cstypes.MemberRole(req.Role))
+	ares, err := h.ah.AddOrgMember(ctx, orgRef, userRef, cstypes.OrgMemberRole(req.Role))
 	if httpError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return

--- a/services/configstore/api/types/org.go
+++ b/services/configstore/api/types/org.go
@@ -19,10 +19,10 @@ import (
 )
 
 type AddOrgMemberRequest struct {
-	Role cstypes.MemberRole
+	Role cstypes.OrgMemberRole
 }
 
 type OrgMemberResponse struct {
 	User *cstypes.User
-	Role cstypes.MemberRole
+	Role cstypes.OrgMemberRole
 }

--- a/services/configstore/api/types/user.go
+++ b/services/configstore/api/types/user.go
@@ -59,5 +59,5 @@ type CreateUserTokenResponse struct {
 
 type UserOrgsResponse struct {
 	Organization *cstypes.Organization
-	Role         cstypes.MemberRole
+	Role         cstypes.OrgMemberRole
 }

--- a/services/configstore/client/client.go
+++ b/services/configstore/client/client.go
@@ -531,7 +531,7 @@ func (c *Client) DeleteOrg(ctx context.Context, orgRef string) (*http.Response, 
 	return c.getResponse(ctx, "DELETE", fmt.Sprintf("/orgs/%s", orgRef), nil, jsonContent, nil)
 }
 
-func (c *Client) AddOrgMember(ctx context.Context, orgRef, userRef string, role cstypes.MemberRole) (*cstypes.OrganizationMember, *http.Response, error) {
+func (c *Client) AddOrgMember(ctx context.Context, orgRef, userRef string, role cstypes.OrgMemberRole) (*cstypes.OrganizationMember, *http.Response, error) {
 	req := &csapitypes.AddOrgMemberRequest{
 		Role: role,
 	}

--- a/services/configstore/types/types.go
+++ b/services/configstore/types/types.go
@@ -55,17 +55,17 @@ func IsValidVisibility(v Visibility) bool {
 	return true
 }
 
-type MemberRole string
+type OrgMemberRole string
 
 const (
-	MemberRoleOwner  MemberRole = "owner"
-	MemberRoleMember MemberRole = "member"
+	OrgMemberRoleOwner  OrgMemberRole = "owner"
+	OrgMemberRoleMember OrgMemberRole = "member"
 )
 
-func IsValidMemberRole(r MemberRole) bool {
+func IsValidOrgMemberRole(r OrgMemberRole) bool {
 	switch r {
-	case MemberRoleOwner:
-	case MemberRoleMember:
+	case OrgMemberRoleOwner:
+	case OrgMemberRoleMember:
 	default:
 		return false
 	}
@@ -126,7 +126,8 @@ type OrganizationMember struct {
 	OrganizationID string `json:"organization_id,omitempty"`
 	UserID         string `json:"user_id,omitempty"`
 
-	MemberRole MemberRole `json:"member_role,omitempty"`
+	// TODO(sgotti) rename to just Role (requires data upgrade)
+	MemberRole OrgMemberRole `json:"member_role,omitempty"`
 }
 
 type ProjectGroup struct {
@@ -355,3 +356,281 @@ type VariableValue struct {
 
 	When *types.When `json:"when,omitempty"`
 }
+
+type ActionType int
+
+const (
+	ActionTypeGetLog ActionType = iota
+	ActionTypeDeleteLog
+
+	ActionTypeGetRun
+	ActionTypeCreateRun
+	ActionTypeCancelRun
+	ActionTypeStopRun
+	ActionTypeRestartRun
+
+	ActionTypeApproveTask
+
+	ActionTypeGetUser
+	ActionTypeCreateUser
+	ActionTypeUpdateUser
+	ActionTypeDeleteUser
+
+	ActionTypeGetOrg
+	ActionTypeCreateOrg
+	ActionTypeUpdateOrg
+	ActionTypeDeleteOrg
+
+	ActionTypeGetOrgMembers
+	ActionTypeAddOrgMembers
+	ActionTypeUpdateOrgMembers
+	ActionTypeRemoveOrgMembers
+
+	ActionTypeGetProjectGroup
+	ActionTypeCreateProjectGroup
+	ActionTypeUpdateProjectGroup
+	ActionTypeDeleteProjectGroup
+
+	ActionTypeGetProject
+	ActionTypeCreateProject
+	ActionTypeUpdateProject
+	ActionTypeDeleteProject
+
+	ActionTypeGetVariable
+	ActionTypeCreateVariable
+	ActionTypeUpdateVariable
+	ActionTypeDeleteVariable
+
+	ActionTypeGetSecret
+	ActionTypeCreateSecret
+	ActionTypeUpdateSecret
+	ActionTypeDeleteSecret
+)
+
+// Predefined Roles
+var (
+	AdminActions = []ActionType{
+		ActionTypeGetLog,
+		ActionTypeDeleteLog,
+
+		ActionTypeGetRun,
+		ActionTypeCreateRun,
+		ActionTypeStopRun,
+		ActionTypeRestartRun,
+
+		ActionTypeApproveTask,
+
+		ActionTypeGetUser,
+		ActionTypeCreateUser,
+		ActionTypeUpdateUser,
+		ActionTypeDeleteUser,
+
+		ActionTypeGetOrg,
+		ActionTypeCreateOrg,
+		ActionTypeUpdateOrg,
+		ActionTypeDeleteOrg,
+
+		ActionTypeGetOrgMembers,
+		ActionTypeAddOrgMembers,
+		ActionTypeUpdateOrgMembers,
+		ActionTypeRemoveOrgMembers,
+
+		ActionTypeGetProjectGroup,
+		ActionTypeCreateProjectGroup,
+		ActionTypeUpdateProjectGroup,
+		ActionTypeDeleteProjectGroup,
+
+		ActionTypeGetProject,
+		ActionTypeCreateProject,
+		ActionTypeUpdateProject,
+		ActionTypeDeleteProject,
+
+		ActionTypeGetVariable,
+		ActionTypeCreateVariable,
+		ActionTypeUpdateVariable,
+		ActionTypeDeleteVariable,
+
+		ActionTypeGetSecret,
+		ActionTypeCreateSecret,
+		ActionTypeUpdateSecret,
+		ActionTypeDeleteSecret,
+	}
+
+	UserOwnerActions = []ActionType{
+		ActionTypeGetLog,
+		ActionTypeDeleteLog,
+
+		ActionTypeGetRun,
+		ActionTypeCreateRun,
+		ActionTypeStopRun,
+		ActionTypeRestartRun,
+
+		ActionTypeApproveTask,
+
+		ActionTypeGetUser,
+		ActionTypeUpdateUser,
+		ActionTypeDeleteUser,
+
+		ActionTypeGetOrg,
+		ActionTypeUpdateOrg,
+		ActionTypeDeleteOrg,
+
+		ActionTypeGetProjectGroup,
+		ActionTypeCreateProjectGroup,
+		ActionTypeUpdateProjectGroup,
+		ActionTypeDeleteProjectGroup,
+
+		ActionTypeGetProject,
+		ActionTypeCreateProject,
+		ActionTypeUpdateProject,
+		ActionTypeDeleteProject,
+
+		ActionTypeGetVariable,
+		ActionTypeCreateVariable,
+		ActionTypeUpdateVariable,
+		ActionTypeDeleteVariable,
+
+		ActionTypeGetSecret,
+		ActionTypeCreateSecret,
+		ActionTypeUpdateSecret,
+		ActionTypeDeleteSecret,
+	}
+
+	OrgOwnerActions = []ActionType{
+		ActionTypeGetLog,
+		ActionTypeDeleteLog,
+
+		ActionTypeGetRun,
+		ActionTypeCreateRun,
+		ActionTypeStopRun,
+		ActionTypeRestartRun,
+
+		ActionTypeApproveTask,
+
+		ActionTypeGetUser,
+
+		ActionTypeGetOrg,
+		ActionTypeUpdateOrg,
+		ActionTypeDeleteOrg,
+
+		ActionTypeGetOrgMembers,
+		ActionTypeAddOrgMembers,
+		ActionTypeUpdateOrgMembers,
+		ActionTypeRemoveOrgMembers,
+
+		ActionTypeGetProjectGroup,
+		ActionTypeCreateProjectGroup,
+		ActionTypeUpdateProjectGroup,
+		ActionTypeDeleteProjectGroup,
+
+		ActionTypeGetProject,
+		ActionTypeCreateProject,
+		ActionTypeUpdateProject,
+		ActionTypeDeleteProject,
+
+		ActionTypeGetVariable,
+		ActionTypeCreateVariable,
+		ActionTypeUpdateVariable,
+		ActionTypeDeleteVariable,
+
+		ActionTypeGetSecret,
+		ActionTypeCreateSecret,
+		ActionTypeUpdateSecret,
+		ActionTypeDeleteSecret,
+	}
+
+	OrgMemberActions = []ActionType{
+		ActionTypeGetLog,
+
+		ActionTypeGetRun,
+
+		ActionTypeGetUser,
+
+		ActionTypeGetOrg,
+
+		ActionTypeGetOrgMembers,
+
+		ActionTypeGetProjectGroup,
+
+		ActionTypeGetProject,
+
+		ActionTypeGetVariable,
+
+		ActionTypeGetSecret,
+	}
+
+	// Applies to both project groups and projects
+	ProjectAdminActions = []ActionType{
+		ActionTypeGetLog,
+		ActionTypeDeleteLog,
+
+		ActionTypeGetRun,
+		ActionTypeCreateRun,
+		ActionTypeStopRun,
+		ActionTypeRestartRun,
+
+		ActionTypeApproveTask,
+
+		ActionTypeGetProjectGroup,
+		ActionTypeCreateProjectGroup,
+		ActionTypeUpdateProjectGroup,
+		ActionTypeDeleteProjectGroup,
+
+		ActionTypeGetProject,
+		ActionTypeCreateProject,
+		ActionTypeUpdateProject,
+		ActionTypeDeleteProject,
+
+		ActionTypeGetVariable,
+		ActionTypeCreateVariable,
+		ActionTypeUpdateVariable,
+		ActionTypeDeleteVariable,
+
+		ActionTypeGetSecret,
+		ActionTypeCreateSecret,
+		ActionTypeUpdateSecret,
+		ActionTypeDeleteSecret,
+	}
+
+	ProjectReadActions = []ActionType{
+		ActionTypeGetLog,
+
+		ActionTypeGetRun,
+
+		ActionTypeGetProjectGroup,
+
+		ActionTypeGetProject,
+
+		ActionTypeGetVariable,
+
+		ActionTypeGetSecret,
+	}
+
+	// Applies to both project groups and projects
+	// Currently like ProjectAdminActions but without ProjectGroup/Project Create/Update/Deletion
+	ProjectMaintainActions = []ActionType{
+		ActionTypeGetLog,
+		ActionTypeDeleteLog,
+
+		ActionTypeGetRun,
+		ActionTypeCreateRun,
+		ActionTypeStopRun,
+		ActionTypeRestartRun,
+
+		ActionTypeApproveTask,
+
+		ActionTypeGetProjectGroup,
+
+		ActionTypeGetProject,
+
+		ActionTypeGetVariable,
+		ActionTypeCreateVariable,
+		ActionTypeUpdateVariable,
+		ActionTypeDeleteVariable,
+
+		ActionTypeGetSecret,
+		ActionTypeCreateSecret,
+		ActionTypeUpdateSecret,
+		ActionTypeDeleteSecret,
+	}
+)

--- a/services/gateway/api/types/org.go
+++ b/services/gateway/api/types/org.go
@@ -14,11 +14,11 @@
 
 package types
 
-type MemberRole string
+type OrgMemberRole string
 
 const (
-	MemberRoleOwner  MemberRole = "owner"
-	MemberRoleMember MemberRole = "member"
+	OrgMemberRoleOwner  OrgMemberRole = "owner"
+	OrgMemberRoleMember OrgMemberRole = "member"
 )
 
 type CreateOrgRequest struct {
@@ -39,7 +39,7 @@ type OrgMembersResponse struct {
 
 type OrgMemberResponse struct {
 	User *UserResponse `json:"user"`
-	Role MemberRole    `json:"role"`
+	Role OrgMemberRole `json:"role"`
 }
 
 type AddOrgMemberResponse struct {
@@ -48,5 +48,5 @@ type AddOrgMemberResponse struct {
 }
 
 type AddOrgMemberRequest struct {
-	Role MemberRole `json:"role"`
+	Role OrgMemberRole `json:"role"`
 }

--- a/services/gateway/client/client.go
+++ b/services/gateway/client/client.go
@@ -582,7 +582,7 @@ func (c *Client) DeleteOrg(ctx context.Context, orgRef string) (*http.Response, 
 	return c.getResponse(ctx, "DELETE", fmt.Sprintf("/orgs/%s", orgRef), nil, jsonContent, nil)
 }
 
-func (c *Client) AddOrgMember(ctx context.Context, orgRef, userRef string, role gwapitypes.MemberRole) (*gwapitypes.AddOrgMemberResponse, *http.Response, error) {
+func (c *Client) AddOrgMember(ctx context.Context, orgRef, userRef string, role gwapitypes.OrgMemberRole) (*gwapitypes.AddOrgMemberResponse, *http.Response, error) {
 	req := &gwapitypes.AddOrgMemberRequest{
 		Role: role,
 	}


### PR DESCRIPTION
**configstore: add actions and roles** 

Add initial actions and roles.
An action represents a specific action on a resource.
Roles are predefined roles (not saved on storage) that can do some actions.

**gateway: initial rbac handling**

For every action check if the current user as a role that con do such action.