### PR TITLE
docker: create a toolbox volume for every pod

### DIFF
--- a/internal/services/executor/driver/docker_test.go
+++ b/internal/services/executor/driver/docker_test.go
@@ -44,13 +44,7 @@ func TestDockerPod(t *testing.T) {
 		t.Fatalf("env var AGOLA_TOOLBOX_PATH is undefined")
 	}
 
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
-	d, err := NewDockerDriver(logger, "executorid01", dir, toolboxPath)
+	d, err := NewDockerDriver(logger, "executorid01", toolboxPath)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}

--- a/internal/services/executor/driver/k8s_test.go
+++ b/internal/services/executor/driver/k8s_test.go
@@ -37,12 +37,6 @@ func TestK8sPod(t *testing.T) {
 		t.Fatalf("env var AGOLA_TOOLBOX_PATH is undefined")
 	}
 
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
 	d, err := NewK8sDriver(logger, "executorid01", toolboxPath)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)

--- a/internal/services/executor/executor.go
+++ b/internal/services/executor/executor.go
@@ -1400,7 +1400,7 @@ func NewExecutor(c *config.Executor) (*Executor, error) {
 	var d driver.Driver
 	switch c.Driver.Type {
 	case config.DriverTypeDocker:
-		d, err = driver.NewDockerDriver(logger, e.id, "/tmp/agola/bin", e.c.ToolboxPath)
+		d, err = driver.NewDockerDriver(logger, e.id, e.c.ToolboxPath)
 		if err != nil {
 			return nil, errors.Errorf("failed to create docker driver: %w", err)
 		}


### PR DESCRIPTION
Instead of doing the current hack of copying the agola toolbox inside the host
tmp dir (always done but only needed when running the executor inside a docker
container) that has different issues (like tmp file removal done by
tmpwatch/systemd-tmpfiles), use a solution similar to the k8s driver: for every
pod create a volume containing the agola-toolbox and remove it at pod removal.

We could also use a single "global" volume but we should handle cases like
volume removal (i.e. a docker volume prune command). So for now just create a
dedicated per pod volume.