### PR TITLE
tests: improve services logging

### DIFF
--- a/cmd/agola/cmd/serve.go
+++ b/cmd/agola/cmd/serve.go
@@ -142,7 +142,7 @@ func serve(cmd *cobra.Command, args []string) error {
 
 	var rs *rsscheduler.Runservice
 	if isComponentEnabled("runservice") {
-		rs, err = rsscheduler.NewRunservice(ctx, &c.Runservice)
+		rs, err = rsscheduler.NewRunservice(ctx, nil, &c.Runservice)
 		if err != nil {
 			return errors.Errorf("failed to start run service scheduler: %w", err)
 		}
@@ -150,7 +150,7 @@ func serve(cmd *cobra.Command, args []string) error {
 
 	var ex *rsexecutor.Executor
 	if isComponentEnabled("executor") {
-		ex, err = executor.NewExecutor(&c.Executor)
+		ex, err = executor.NewExecutor(ctx, nil, &c.Executor)
 		if err != nil {
 			return errors.Errorf("failed to start run service executor: %w", err)
 		}
@@ -158,7 +158,7 @@ func serve(cmd *cobra.Command, args []string) error {
 
 	var cs *configstore.Configstore
 	if isComponentEnabled("configstore") {
-		cs, err = configstore.NewConfigstore(ctx, &c.Configstore)
+		cs, err = configstore.NewConfigstore(ctx, nil, &c.Configstore)
 		if err != nil {
 			return errors.Errorf("failed to start config store: %w", err)
 		}
@@ -166,7 +166,7 @@ func serve(cmd *cobra.Command, args []string) error {
 
 	var sched *scheduler.Scheduler
 	if isComponentEnabled("scheduler") {
-		sched, err = scheduler.NewScheduler(&c.Scheduler)
+		sched, err = scheduler.NewScheduler(ctx, nil, &c.Scheduler)
 		if err != nil {
 			return errors.Errorf("failed to start scheduler: %w", err)
 		}
@@ -174,7 +174,7 @@ func serve(cmd *cobra.Command, args []string) error {
 
 	var ns *notification.NotificationService
 	if isComponentEnabled("notification") {
-		ns, err = notification.NewNotificationService(c)
+		ns, err = notification.NewNotificationService(ctx, nil, c)
 		if err != nil {
 			return errors.Errorf("failed to start notification service: %w", err)
 		}
@@ -182,7 +182,7 @@ func serve(cmd *cobra.Command, args []string) error {
 
 	var gw *gateway.Gateway
 	if isComponentEnabled("gateway") {
-		gw, err = gateway.NewGateway(c)
+		gw, err = gateway.NewGateway(ctx, nil, c)
 		if err != nil {
 			return errors.Errorf("failed to start gateway: %w", err)
 		}
@@ -190,7 +190,7 @@ func serve(cmd *cobra.Command, args []string) error {
 
 	var gs *gitserver.Gitserver
 	if isComponentEnabled("gitserver") {
-		gs, err = gitserver.NewGitserver(&c.Gitserver)
+		gs, err = gitserver.NewGitserver(ctx, nil, &c.Gitserver)
 		if err != nil {
 			return errors.Errorf("failed to start git server: %w", err)
 		}

--- a/internal/services/configstore/configstore.go
+++ b/internal/services/configstore/configstore.go
@@ -120,10 +120,14 @@ type Configstore struct {
 	maintenanceMode bool
 }
 
-func NewConfigstore(ctx context.Context, c *config.Configstore) (*Configstore, error) {
+func NewConfigstore(ctx context.Context, l *zap.Logger, c *config.Configstore) (*Configstore, error) {
+	if l != nil {
+		logger = l
+	}
 	if c.Debug {
 		level.SetLevel(zapcore.DebugLevel)
 	}
+	log = logger.Sugar()
 
 	ost, err := scommon.NewObjectStorage(&c.ObjectStorage)
 	if err != nil {

--- a/internal/services/executor/driver/docker.go
+++ b/internal/services/executor/driver/docker.go
@@ -15,13 +15,13 @@
 package driver
 
 import (
+	"bufio"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -76,7 +76,11 @@ func (d *DockerDriver) createToolboxVolume(ctx context.Context, podID string) (*
 	if err != nil {
 		return nil, err
 	}
-	if _, err := io.Copy(os.Stdout, reader); err != nil {
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		d.log.Infof("create toolbox volume image pull output: %s", scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
 		return nil, err
 	}
 

--- a/internal/services/executor/driver/docker_test.go
+++ b/internal/services/executor/driver/docker_test.go
@@ -22,18 +22,14 @@ import (
 	"testing"
 	"time"
 
-	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/testutil"
+
 	"github.com/docker/docker/api/types"
-	uuid "github.com/satori/go.uuid"
-
 	"github.com/google/go-cmp/cmp"
+	uuid "github.com/satori/go.uuid"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 )
-
-var level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
-var logger = slog.New(level)
 
 func TestDockerPod(t *testing.T) {
 	if os.Getenv("SKIP_DOCKER_TESTS") == "1" {
@@ -43,6 +39,8 @@ func TestDockerPod(t *testing.T) {
 	if toolboxPath == "" {
 		t.Fatalf("env var AGOLA_TOOLBOX_PATH is undefined")
 	}
+
+	logger := zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel))
 
 	d, err := NewDockerDriver(logger, "executorid01", toolboxPath)
 	if err != nil {

--- a/internal/services/executor/driver/k8s_test.go
+++ b/internal/services/executor/driver/k8s_test.go
@@ -26,6 +26,8 @@ import (
 	"agola.io/agola/internal/testutil"
 
 	uuid "github.com/satori/go.uuid"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestK8sPod(t *testing.T) {
@@ -36,6 +38,8 @@ func TestK8sPod(t *testing.T) {
 	if toolboxPath == "" {
 		t.Fatalf("env var AGOLA_TOOLBOX_PATH is undefined")
 	}
+
+	logger := zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel))
 
 	d, err := NewK8sDriver(logger, "executorid01", toolboxPath)
 	if err != nil {

--- a/internal/services/executor/executor.go
+++ b/internal/services/executor/executor.go
@@ -1339,10 +1339,14 @@ type Executor struct {
 	dynamic          bool
 }
 
-func NewExecutor(c *config.Executor) (*Executor, error) {
+func NewExecutor(ctx context.Context, l *zap.Logger, c *config.Executor) (*Executor, error) {
+	if l != nil {
+		logger = l
+	}
 	if c.Debug {
 		level.SetLevel(zapcore.DebugLevel)
 	}
+	log = logger.Sugar()
 
 	var err error
 	c.ToolboxPath, err = filepath.Abs(c.ToolboxPath)

--- a/internal/services/gateway/gateway.go
+++ b/internal/services/gateway/gateway.go
@@ -58,11 +58,16 @@ type Gateway struct {
 	sd                *common.TokenSigningData
 }
 
-func NewGateway(gc *config.Config) (*Gateway, error) {
+func NewGateway(ctx context.Context, l *zap.Logger, gc *config.Config) (*Gateway, error) {
 	c := &gc.Gateway
+
+	if l != nil {
+		logger = l
+	}
 	if c.Debug {
 		level.SetLevel(zapcore.DebugLevel)
 	}
+	log = logger.Sugar()
 
 	if c.Web.ListenAddress == "" {
 		return nil, errors.Errorf("listen address undefined")

--- a/internal/services/gitserver/main.go
+++ b/internal/services/gitserver/main.go
@@ -130,10 +130,14 @@ type Gitserver struct {
 	c *config.Gitserver
 }
 
-func NewGitserver(c *config.Gitserver) (*Gitserver, error) {
+func NewGitserver(ctx context.Context, l *zap.Logger, c *config.Gitserver) (*Gitserver, error) {
+	if l != nil {
+		logger = l
+	}
 	if c.Debug {
 		level.SetLevel(zapcore.DebugLevel)
 	}
+	log = logger.Sugar()
 
 	return &Gitserver{
 		c: c,

--- a/internal/services/notification/notification.go
+++ b/internal/services/notification/notification.go
@@ -42,11 +42,16 @@ type NotificationService struct {
 	configstoreClient *csclient.Client
 }
 
-func NewNotificationService(gc *config.Config) (*NotificationService, error) {
+func NewNotificationService(ctx context.Context, l *zap.Logger, gc *config.Config) (*NotificationService, error) {
 	c := &gc.Notification
+
+	if l != nil {
+		logger = l
+	}
 	if c.Debug {
 		level.SetLevel(zapcore.DebugLevel)
 	}
+	log = logger.Sugar()
 
 	e, err := common.NewEtcd(&c.Etcd, logger, "notification")
 	if err != nil {

--- a/internal/services/runservice/scheduler.go
+++ b/internal/services/runservice/scheduler.go
@@ -25,7 +25,6 @@ import (
 
 	"agola.io/agola/internal/datamanager"
 	"agola.io/agola/internal/etcd"
-	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/objectstorage"
 	"agola.io/agola/internal/runconfig"
 	"agola.io/agola/internal/services/runservice/common"
@@ -35,8 +34,6 @@ import (
 
 	etcdclientv3 "go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/clientv3/concurrency"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	errors "golang.org/x/xerrors"
 )
 
@@ -46,10 +43,6 @@ const (
 
 	defaultExecutorNotAliveInterval = 60 * time.Second
 )
-
-var level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
-var logger = slog.New(level)
-var log = logger.Sugar()
 
 func (s *Runservice) runActiveExecutorTasks(ctx context.Context, runID string) ([]*types.ExecutorTask, error) {
 	// the real source of active tasks is the number of executor tasks in etcd

--- a/internal/services/scheduler/scheduler.go
+++ b/internal/services/scheduler/scheduler.go
@@ -197,10 +197,14 @@ type Scheduler struct {
 	runserviceClient *rsclient.Client
 }
 
-func NewScheduler(c *config.Scheduler) (*Scheduler, error) {
+func NewScheduler(ctx context.Context, l *zap.Logger, c *config.Scheduler) (*Scheduler, error) {
+	if l != nil {
+		logger = l
+	}
 	if c.Debug {
 		level.SetLevel(zapcore.DebugLevel)
 	}
+	log = logger.Sugar()
 
 	return &Scheduler{
 		c:                c,

--- a/internal/testutil/utils.go
+++ b/internal/testutil/utils.go
@@ -167,6 +167,7 @@ func NewTestEmbeddedEtcd(t *testing.T, logger *zap.Logger, dir string, a ...stri
 	cfg.Name = uid
 	cfg.Dir = dataDir
 	cfg.Logger = "zap"
+	cfg.LogLevel = "fatal"
 	cfg.LogOutputs = []string{"stdout"}
 	lcurl, _ := url.Parse(fmt.Sprintf("http://%s:%s", listenAddress, port))
 	lpurl, _ := url.Parse(fmt.Sprintf("http://%s:%s", listenAddress2, port2))
@@ -451,7 +452,7 @@ type TestGitea struct {
 	SSHPort           string
 }
 
-func NewTestGitea(t *testing.T, logger *zap.Logger, dir, dockerBridgeAddress string, a ...string) (*TestGitea, error) {
+func NewTestGitea(t *testing.T, dir, dockerBridgeAddress string, a ...string) (*TestGitea, error) {
 	u := uuid.NewV4()
 	uid := fmt.Sprintf("%x", u[:4])
 


### PR DESCRIPTION
During tests provide a zaptest Logger so all services output will be redirected
to golang testing logger.

When multiple services of the same type are provided add a unique name field to
distinguish them.