### PR TITLE
Update github.com/opencontainers/runc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/mitchellh/copystructure v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
-	github.com/opencontainers/runc v0.1.1 // indirect
+	github.com/opencontainers/runc v1.0.0-rc8 // indirect
 	github.com/prometheus/client_golang v1.2.1 // indirect
 	github.com/sanity-io/litter v1.2.0
 	github.com/satori/go.uuid v1.2.0


### PR DESCRIPTION
github.com/opencontainers/runc v0.1.1 is vulnerable so suggesting to upgrade the version to secured one. You can check module vulnerability here under security tab and versions : 
https://search.gocenter.io/github.com~2Fopencontainers~2Frunc/info?

CVE-2019-5736(High)

runc through 1.0-rc6, as used in Docker before 18.09.2 and other products, allows attackers to overwrite the host runc binary (and consequently obtain host root access) by leveraging the ability to execute a command as root within one of these types of containers: (1) a new container with an attacker-controlled image, or (2) an existing container, to which the attacker previously had write access, that can be attached with docker exec. This occurs because of file-descriptor mishandling, related to /proc/self/exe.
