### PR TITLE
cmd: fix token create help message

### DIFF
--- a/cmd/agola/cmd/usertokencreate.go
+++ b/cmd/agola/cmd/usertokencreate.go
@@ -27,7 +27,7 @@ import (
 
 var cmdUserTokenCreate = &cobra.Command{
 	Use:   "create",
-	Short: "create a user linkedaccount",
+	Short: "create a user token",
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := userTokenCreate(cmd, args); err != nil {
 			log.Fatalf("err: %v", err)


### PR DESCRIPTION
 `user token create` subcommand has a wrong help message:
```
$ agola user token --help
<...>
Available Commands:
  create      create a user linkedaccount
  delete      delete a user token
<...>
```