### PR TITLE
tests: add unique name for logs of the third ConfigStore instance

### DIFF
--- a/internal/services/configstore/configstore_test.go
+++ b/internal/services/configstore/configstore_test.go
@@ -274,11 +274,11 @@ func TestResync(t *testing.T) {
 	cs3Config.DataDir = csDir3
 	cs3Config.Web.ListenAddress = net.JoinHostPort(listenAddress3, port3)
 
-	log.Infof("starting cs3")
-	cs3, err := NewConfigstore(ctx, logger, &cs3Config)
+	cs3, err := NewConfigstore(ctx, logger.With(zap.String("name", "cs3")), &cs3Config)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	log.Infof("starting cs3")
 	ctx3 := context.Background()
 	go func() { _ = cs3.Run(ctx3) }()
 


### PR DESCRIPTION
Add "cs3" as unique name for the third ConfigStore instance