### PR TITLE
cmd: project option to disable passing variables to PR from forked repo

### DIFF
--- a/cmd/agola/cmd/projectcreate.go
+++ b/cmd/agola/cmd/projectcreate.go
@@ -41,6 +41,7 @@ type projectCreateOptions struct {
 	remoteSourceName    string
 	skipSSHHostKeyCheck bool
 	visibility          string
+	passVarsToForkedPR  bool
 }
 
 var projectCreateOpts projectCreateOptions
@@ -54,6 +55,7 @@ func init() {
 	flags.BoolVarP(&projectCreateOpts.skipSSHHostKeyCheck, "skip-ssh-host-key-check", "s", false, "skip ssh host key check")
 	flags.StringVar(&projectCreateOpts.parentPath, "parent", "", `parent project group path (i.e "org/org01" for root project group in org01, "user/user01/group01/subgroub01") or project group id where the project should be created`)
 	flags.StringVar(&projectCreateOpts.visibility, "visibility", "public", `project visibility (public or private)`)
+	flags.BoolVar(&projectCreateOpts.passVarsToForkedPR, "pass-vars-to-forked-pr", false, `pass variables to run even if triggered by PR from forked repo`)
 
 	if err := cmdProjectCreate.MarkFlagRequired("name"); err != nil {
 		log.Fatal(err)
@@ -96,6 +98,7 @@ func projectCreate(cmd *cobra.Command, args []string) error {
 		RepoPath:            projectCreateOpts.repoPath,
 		RemoteSourceName:    projectCreateOpts.remoteSourceName,
 		SkipSSHHostKeyCheck: projectCreateOpts.skipSSHHostKeyCheck,
+		PassVarsToForkedPR:  projectCreateOpts.passVarsToForkedPR,
 	}
 
 	log.Infof("creating project")

--- a/cmd/agola/cmd/projectupdate.go
+++ b/cmd/agola/cmd/projectupdate.go
@@ -37,9 +37,10 @@ var cmdProjectUpdate = &cobra.Command{
 type projectUpdateOptions struct {
 	ref string
 
-	name       string
-	parentPath string
-	visibility string
+	name               string
+	parentPath         string
+	visibility         string
+	passVarsToForkedPR bool
 }
 
 var projectUpdateOpts projectUpdateOptions
@@ -51,6 +52,7 @@ func init() {
 	flags.StringVarP(&projectUpdateOpts.name, "name", "n", "", "project name")
 	flags.StringVar(&projectUpdateOpts.parentPath, "parent", "", `parent project group path (i.e "org/org01" for root project group in org01, "user/user01/group01/subgroub01") or project group id where the project should be moved`)
 	flags.StringVar(&projectUpdateOpts.visibility, "visibility", "public", `project visibility (public or private)`)
+	flags.BoolVar(&projectUpdateOpts.passVarsToForkedPR, "pass-vars-to-forked-pr", false, `pass variables to run even if triggered by PR from forked repo`)
 
 	if err := cmdProjectUpdate.MarkFlagRequired("ref"); err != nil {
 		log.Fatal(err)
@@ -77,6 +79,9 @@ func projectUpdate(cmd *cobra.Command, args []string) error {
 		}
 		visibility := gwapitypes.Visibility(projectUpdateOpts.visibility)
 		req.Visibility = &visibility
+	}
+	if flags.Changed("pass-vars-to-forked-pr") {
+		req.PassVarsToForkedPR = &projectUpdateOpts.passVarsToForkedPR
 	}
 
 	log.Infof("updating project")

--- a/internal/gitsources/gitea/parse.go
+++ b/internal/gitsources/gitea/parse.go
@@ -156,6 +156,10 @@ func webhookDataFromPullRequest(hook *pullRequestHook) *types.WebhookData {
 	if sender == "" {
 		sender = hook.Sender.Login
 	}
+	prFromSameRepo := false
+	if hook.PullRequest.Base.Repo.URL == hook.PullRequest.Head.Repo.URL {
+		prFromSameRepo = true
+	}
 	whd := &types.WebhookData{
 		Event:           types.WebhookEventPullRequest,
 		CommitSHA:       hook.PullRequest.Head.Sha,
@@ -166,11 +170,13 @@ func webhookDataFromPullRequest(hook *pullRequestHook) *types.WebhookData {
 		Sender:          sender,
 		PullRequestID:   strconv.FormatInt(hook.PullRequest.ID, 10),
 		PullRequestLink: hook.PullRequest.URL,
+		PRFromSameRepo:  prFromSameRepo,
 
 		Repo: types.WebhookDataRepo{
 			Path:   path.Join(hook.Repo.Owner.Username, hook.Repo.Name),
 			WebURL: hook.Repo.URL,
 		},
 	}
+
 	return whd
 }

--- a/internal/gitsources/github/parse.go
+++ b/internal/gitsources/github/parse.go
@@ -116,6 +116,10 @@ func webhookDataFromPullRequest(hook *github.PullRequestEvent) (*types.WebhookDa
 	if sender == nil {
 		sender = hook.Sender.Login
 	}
+	prFromSameRepo := false
+	if hook.PullRequest.Base.Repo.URL == hook.PullRequest.Head.Repo.URL {
+		prFromSameRepo = true
+	}
 
 	whd := &types.WebhookData{
 		Event:           types.WebhookEventPullRequest,
@@ -127,6 +131,7 @@ func webhookDataFromPullRequest(hook *github.PullRequestEvent) (*types.WebhookDa
 		Sender:          *sender,
 		PullRequestID:   strconv.Itoa(*hook.PullRequest.Number),
 		PullRequestLink: *hook.PullRequest.HTMLURL,
+		PRFromSameRepo:  prFromSameRepo,
 
 		Repo: types.WebhookDataRepo{
 			Path:   path.Join(*hook.Repo.Owner.Login, *hook.Repo.Name),

--- a/internal/gitsources/gitlab/parse.go
+++ b/internal/gitsources/gitlab/parse.go
@@ -140,7 +140,12 @@ func webhookDataFromPullRequest(hook *pullRequestHook) *types.WebhookData {
 	if sender == "" {
 		sender = hook.User.Username
 	}
-	build := &types.WebhookData{
+	prFromSameRepo := false
+	if hook.ObjectAttributes.Source.URL == hook.ObjectAttributes.Target.URL {
+		prFromSameRepo = true
+	}
+
+	whd := &types.WebhookData{
 		Event:           types.WebhookEventPullRequest,
 		CommitSHA:       hook.ObjectAttributes.LastCommit.ID,
 		SSHURL:          hook.Project.SSHURL,
@@ -150,11 +155,12 @@ func webhookDataFromPullRequest(hook *pullRequestHook) *types.WebhookData {
 		Sender:          sender,
 		PullRequestID:   strconv.Itoa(hook.ObjectAttributes.Iid),
 		PullRequestLink: hook.ObjectAttributes.URL,
+		PRFromSameRepo:  prFromSameRepo,
 
 		Repo: types.WebhookDataRepo{
 			Path:   hook.Project.PathWithNamespace,
 			WebURL: hook.Project.WebURL,
 		},
 	}
-	return build
+	return whd
 }

--- a/internal/services/gateway/action/project.go
+++ b/internal/services/gateway/action/project.go
@@ -57,6 +57,7 @@ type CreateProjectRequest struct {
 	RemoteSourceName    string
 	RepoPath            string
 	SkipSSHHostKeyCheck bool
+	PassVarsToForkedPR  bool
 }
 
 func (h *ActionHandler) CreateProject(ctx context.Context, req *CreateProjectRequest) (*csapitypes.Project, error) {
@@ -150,6 +151,7 @@ func (h *ActionHandler) CreateProject(ctx context.Context, req *CreateProjectReq
 		RepositoryPath:             req.RepoPath,
 		SkipSSHHostKeyCheck:        req.SkipSSHHostKeyCheck,
 		SSHPrivateKey:              string(privateKey),
+		PassVarsToForkedPR:         req.PassVarsToForkedPR,
 	}
 
 	h.log.Infof("creating project")
@@ -183,7 +185,8 @@ type UpdateProjectRequest struct {
 	Name      *string
 	ParentRef *string
 
-	Visibility *cstypes.Visibility
+	Visibility         *cstypes.Visibility
+	PassVarsToForkedPR *bool
 }
 
 func (h *ActionHandler) UpdateProject(ctx context.Context, projectRef string, req *UpdateProjectRequest) (*csapitypes.Project, error) {
@@ -208,6 +211,9 @@ func (h *ActionHandler) UpdateProject(ctx context.Context, projectRef string, re
 	}
 	if req.Visibility != nil {
 		p.Visibility = *req.Visibility
+	}
+	if req.PassVarsToForkedPR != nil {
+		p.PassVarsToForkedPR = *req.PassVarsToForkedPR
 	}
 
 	h.log.Infof("updating project")

--- a/internal/services/gateway/action/run.go
+++ b/internal/services/gateway/action/run.go
@@ -338,6 +338,7 @@ type CreateRunRequest struct {
 	Tag                 string
 	Ref                 string
 	PullRequestID       string
+	PRFromSameRepo      bool
 	SSHPrivKey          string
 	SSHHostKey          string
 	SkipSSHHostKeyCheck bool
@@ -429,10 +430,12 @@ func (h *ActionHandler) CreateRuns(ctx context.Context, req *CreateRunRequest) e
 
 	var variables map[string]string
 	if req.RunType == itypes.RunTypeProject {
-		var err error
-		variables, err = h.genRunVariables(ctx, req)
-		if err != nil {
-			return err
+		if req.RefType != itypes.RunRefTypePullRequest || req.PRFromSameRepo || req.Project.PassVarsToForkedPR {
+			var err error
+			variables, err = h.genRunVariables(ctx, req)
+			if err != nil {
+				return err
+			}
 		}
 	} else {
 		variables = req.Variables

--- a/internal/services/gateway/api/project.go
+++ b/internal/services/gateway/api/project.go
@@ -55,6 +55,7 @@ func (h *CreateProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		RepoPath:            req.RepoPath,
 		RemoteSourceName:    req.RemoteSourceName,
 		SkipSSHHostKeyCheck: req.SkipSSHHostKeyCheck,
+		PassVarsToForkedPR:  req.PassVarsToForkedPR,
 	}
 
 	project, err := h.ah.CreateProject(ctx, areq)
@@ -101,9 +102,10 @@ func (h *UpdateProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	areq := &action.UpdateProjectRequest{
-		Name:       req.Name,
-		ParentRef:  req.ParentRef,
-		Visibility: visibility,
+		Name:               req.Name,
+		ParentRef:          req.ParentRef,
+		Visibility:         visibility,
+		PassVarsToForkedPR: req.PassVarsToForkedPR,
 	}
 	project, err := h.ah.UpdateProject(ctx, projectRef, areq)
 	if httpError(w, err) {
@@ -235,12 +237,13 @@ func (h *ProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func createProjectResponse(r *csapitypes.Project) *gwapitypes.ProjectResponse {
 	res := &gwapitypes.ProjectResponse{
-		ID:               r.ID,
-		Name:             r.Name,
-		Path:             r.Path,
-		ParentPath:       r.ParentPath,
-		Visibility:       gwapitypes.Visibility(r.Visibility),
-		GlobalVisibility: string(r.GlobalVisibility),
+		ID:                 r.ID,
+		Name:               r.Name,
+		Path:               r.Path,
+		ParentPath:         r.ParentPath,
+		Visibility:         gwapitypes.Visibility(r.Visibility),
+		GlobalVisibility:   string(r.GlobalVisibility),
+		PassVarsToForkedPR: r.PassVarsToForkedPR,
 	}
 
 	return res

--- a/internal/services/gateway/api/webhook.go
+++ b/internal/services/gateway/api/webhook.go
@@ -127,6 +127,7 @@ func (h *webhooksHandler) handleWebhook(r *http.Request) error {
 		Branch:              webhookData.Branch,
 		Tag:                 webhookData.Tag,
 		PullRequestID:       webhookData.PullRequestID,
+		PRFromSameRepo:      webhookData.PRFromSameRepo,
 		Ref:                 webhookData.Ref,
 		SSHPrivKey:          sshPrivKey,
 		SSHHostKey:          sshHostKey,

--- a/internal/services/types/webhook.go
+++ b/internal/services/types/webhook.go
@@ -43,6 +43,7 @@ type WebhookData struct {
 	// use a string if on some platform (current or future) some PRs id will not be numbers
 	PullRequestID   string `json:"pull_request_id,omitempty"`
 	PullRequestLink string `json:"link,omitempty"` // Link to pull request
+	PRFromSameRepo  bool   `json:"pr_from_same_repo,omitempty"`
 
 	Repo WebhookDataRepo `json:"repo,omitempty"`
 }

--- a/services/configstore/types/types.go
+++ b/services/configstore/types/types.go
@@ -307,6 +307,8 @@ type Project struct {
 	// Webhooksecret is the secret passed to git sources that support a
 	// secret/token for signing or verifying the webhook payload
 	WebhookSecret string `json:"webhook_secret,omitempty"`
+
+	PassVarsToForkedPR bool `json:"pass_vars_to_forked_pr,omitempty"`
 }
 
 type SecretType string

--- a/services/gateway/api/types/project.go
+++ b/services/gateway/api/types/project.go
@@ -21,21 +21,24 @@ type CreateProjectRequest struct {
 	RepoPath            string     `json:"repo_path,omitempty"`
 	RemoteSourceName    string     `json:"remote_source_name,omitempty"`
 	SkipSSHHostKeyCheck bool       `json:"skip_ssh_host_key_check,omitempty"`
+	PassVarsToForkedPR  bool       `json:"pass_vars_to_forked_pr,omitempty"`
 }
 
 type UpdateProjectRequest struct {
-	Name       *string     `json:"name,omitempty"`
-	ParentRef  *string     `json:"parent_ref,omitempty"`
-	Visibility *Visibility `json:"visibility,omitempty"`
+	Name               *string     `json:"name,omitempty"`
+	ParentRef          *string     `json:"parent_ref,omitempty"`
+	Visibility         *Visibility `json:"visibility,omitempty"`
+	PassVarsToForkedPR *bool       `json:"pass_vars_to_forked_pr,omitempty"`
 }
 
 type ProjectResponse struct {
-	ID               string     `json:"id,omitempty"`
-	Name             string     `json:"name,omitempty"`
-	Path             string     `json:"path,omitempty"`
-	ParentPath       string     `json:"parent_path,omitempty"`
-	Visibility       Visibility `json:"visibility,omitempty"`
-	GlobalVisibility string     `json:"global_visibility,omitempty"`
+	ID                 string     `json:"id,omitempty"`
+	Name               string     `json:"name,omitempty"`
+	Path               string     `json:"path,omitempty"`
+	ParentPath         string     `json:"parent_path,omitempty"`
+	Visibility         Visibility `json:"visibility,omitempty"`
+	GlobalVisibility   string     `json:"global_visibility,omitempty"`
+	PassVarsToForkedPR bool       `json:"pass_vars_to_forked_pr,omitempty"`
 }
 
 type ProjectCreateRunRequest struct {


### PR DESCRIPTION
Add boolean parameter  to choose if pass variables to runs even when triggered by PRs (option disabled by default):

`agola project [create|update] --pass-vars-to-pr=true <...>`

Fixes #38 