### PR TITLE
makefile: remove test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,6 @@ all: build
 .PHONY: build
 build: agola agola-toolbox
 
-.PHONY: test
-test: gocovmerge
-	@scripts/test.sh
-
 # don't use existing file names and track go sources, let's do this to the go tool
 .PHONY: agola
 agola: $(AGOLA_DEPS)


### PR DESCRIPTION
There's no test script. Full tests can be easily executed inside a local
running agola instance using an agola "direct run".
Single package tests can be executed using a manual go test invocation based on
the kind of package we want to test (since some of them require a running etcd,
a running docker, a running k8s cluster, a gitea binary etc...)