### PR TITLE
cmd: remotesource create don't force github defaults

### DIFF
--- a/cmd/agola/cmd/remotesourcecreate.go
+++ b/cmd/agola/cmd/remotesourcecreate.go
@@ -83,10 +83,16 @@ func init() {
 func remoteSourceCreate(cmd *cobra.Command, args []string) error {
 	gwclient := gwclient.NewClient(gatewayURL, token)
 
+	flags := cmd.Flags()
+
 	// for github remote source type, set defaults for github.com
 	if remoteSourceCreateOpts.rsType == "github" {
-		remoteSourceCreateOpts.apiURL = github.GitHubAPIURL
-		remoteSourceCreateOpts.sshHostKey = github.GitHubSSHHostKey
+		if !flags.Changed("api-url") {
+			remoteSourceCreateOpts.apiURL = github.GitHubAPIURL
+		}
+		if remoteSourceCreateOpts.apiURL == github.GitHubAPIURL && !flags.Changed("ssh-host-key") {
+			remoteSourceCreateOpts.sshHostKey = github.GitHubSSHHostKey
+		}
 	}
 
 	if remoteSourceCreateOpts.apiURL == "" {


### PR DESCRIPTION
Use default public github api only if no api-url is provided.
Use default public github ssh host key only if the public github api url is
provided and no ssh host key is provided.
