### PR TITLE
Add auth type token

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG AGOLAWEB_IMAGE="agola-web"
+ARG AGOLAWEB_IMAGE="sorintlab/agola-web:v0.4.0"
 
 FROM $AGOLAWEB_IMAGE as agola-web
 

--- a/cmd/agola/cmd/remotesourcecreate.go
+++ b/cmd/agola/cmd/remotesourcecreate.go
@@ -40,6 +40,7 @@ type remoteSourceCreateOptions struct {
 	name                string
 	rsType              string
 	authType            string
+	authToken           string
 	apiURL              string
 	skipVerify          bool
 	oauth2ClientID      string
@@ -58,6 +59,7 @@ func init() {
 	flags.StringVarP(&remoteSourceCreateOpts.name, "name", "n", "", "remotesource name")
 	flags.StringVar(&remoteSourceCreateOpts.rsType, "type", "", "remotesource type")
 	flags.StringVar(&remoteSourceCreateOpts.authType, "auth-type", "", "remote source auth type")
+	flags.StringVar(&remoteSourceCreateOpts.authToken, "auth-token", "", "remote source auth token")
 	flags.StringVar(&remoteSourceCreateOpts.apiURL, "api-url", "", `remotesource api url (when type is "github" defaults to "https://api.github.com")`)
 	flags.BoolVarP(&remoteSourceCreateOpts.skipVerify, "skip-verify", "", false, "skip remote source api tls certificate verification")
 	flags.StringVar(&remoteSourceCreateOpts.oauth2ClientID, "clientid", "", "remotesource oauth2 client id")
@@ -103,6 +105,7 @@ func remoteSourceCreate(cmd *cobra.Command, args []string) error {
 		Name:                remoteSourceCreateOpts.name,
 		Type:                remoteSourceCreateOpts.rsType,
 		AuthType:            remoteSourceCreateOpts.authType,
+		AuthToken:           remoteSourceCreateOpts.authToken,
 		APIURL:              remoteSourceCreateOpts.apiURL,
 		SkipVerify:          remoteSourceCreateOpts.skipVerify,
 		Oauth2ClientID:      remoteSourceCreateOpts.oauth2ClientID,

--- a/cmd/agola/cmd/remotesourceupdate.go
+++ b/cmd/agola/cmd/remotesourceupdate.go
@@ -39,6 +39,7 @@ type remoteSourceUpdateOptions struct {
 
 	newName             string
 	apiURL              string
+	authToken           string
 	skipVerify          bool
 	oauth2ClientID      string
 	oauth2ClientSecret  string
@@ -56,6 +57,7 @@ func init() {
 	flags.StringVarP(&remoteSourceUpdateOpts.ref, "ref", "", "", "current remotesource name or id")
 	flags.StringVarP(&remoteSourceUpdateOpts.newName, "new-name", "", "", "remotesource new name")
 	flags.StringVar(&remoteSourceUpdateOpts.apiURL, "api-url", "", "remotesource api url")
+	flags.StringVar(&remoteSourceUpdateOpts.authToken, "auth-token", "", "remotesource auth token")
 	flags.BoolVarP(&remoteSourceUpdateOpts.skipVerify, "skip-verify", "", false, "skip remote source api tls certificate verification")
 	flags.StringVar(&remoteSourceUpdateOpts.oauth2ClientID, "clientid", "", "remotesource oauth2 client id")
 	flags.StringVar(&remoteSourceUpdateOpts.oauth2ClientSecret, "secret", "", "remotesource oauth2 secret")
@@ -82,6 +84,9 @@ func remoteSourceUpdate(cmd *cobra.Command, args []string) error {
 	}
 	if flags.Changed("api-url") {
 		req.APIURL = &remoteSourceUpdateOpts.apiURL
+	}
+	if flags.Changed("auth-token") {
+		req.AuthToken = &remoteSourceUpdateOpts.authToken
 	}
 	if flags.Changed("skip-verify") {
 		req.SkipVerify = &remoteSourceUpdateOpts.skipVerify

--- a/go.mod
+++ b/go.mod
@@ -80,3 +80,5 @@ require (
 )
 
 replace github.com/docker/docker v1.13.1 => github.com/docker/engine v0.0.0-20181106193140-f5749085e9cb
+
+replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,7 @@ code.gitea.io/sdk/gitea v0.11.0/go.mod h1:z3uwDV/b9Ls47NGukYM9XhnHtqPh/J+t40lsUr
 github.com/Azure/azure-sdk-for-go v19.1.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
-github.com/Azure/go-autorest v10.15.5+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
+github.com/Azure/go-autorest v13.3.3+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=
 github.com/Azure/go-autorest/autorest/date v0.1.0/go.mod h1:plvfp3oPSKwf2DNjlBjWF/7vwR+cUD/ELuzDCXwHUVA=

--- a/internal/services/common/gitsource.go
+++ b/internal/services/common/gitsource.go
@@ -145,7 +145,7 @@ func GetTokenSource(rs *cstypes.RemoteSource, accessToken string) (gitsource.Use
 	case cstypes.RemoteSourceTypeGitea:
 		userSource, err = newGitea(rs, accessToken)
 	default:
-		return nil, errors.Errorf("remote source %s isn't a valid token source", rs.Name)
+		return nil, errors.Errorf("remote source %s isn't a valid oauth2 source", rs.Name)
 	}
 
 	return userSource, err

--- a/internal/services/common/gitsource.go
+++ b/internal/services/common/gitsource.go
@@ -56,7 +56,7 @@ func newGithub(rs *cstypes.RemoteSource, accessToken string) (*github.Client, er
 
 func GetAccessToken(rs *cstypes.RemoteSource, userAccessToken, oauth2AccessToken string) (string, error) {
 	switch rs.AuthType {
-	case cstypes.RemoteSourceAuthTypePassword:
+	case cstypes.RemoteSourceAuthTypePassword, cstypes.RemoteSourceAuthTypeToken:
 		return userAccessToken, nil
 	case cstypes.RemoteSourceAuthTypeOauth2:
 		return oauth2AccessToken, nil
@@ -99,6 +99,8 @@ func GetUserSource(rs *cstypes.RemoteSource, accessToken string) (gitsource.User
 		userSource, err = GetOauth2Source(rs, accessToken)
 	case cstypes.RemoteSourceAuthTypePassword:
 		userSource, err = GetPasswordSource(rs, accessToken)
+	case cstypes.RemoteSourceAuthTypeToken:
+		userSource, err = GetTokenSource(rs, accessToken)
 	default:
 		return nil, errors.Errorf("unknown remote source auth type")
 	}
@@ -134,4 +136,17 @@ func GetPasswordSource(rs *cstypes.RemoteSource, accessToken string) (gitsource.
 	}
 
 	return passwordSource, err
+}
+
+func GetTokenSource(rs *cstypes.RemoteSource, accessToken string) (gitsource.UserSource, error) {
+	var userSource gitsource.UserSource
+	var err error
+	switch rs.Type {
+	case cstypes.RemoteSourceTypeGitea:
+		userSource, err = newGitea(rs, accessToken)
+	default:
+		return nil, errors.Errorf("remote source %s isn't a valid oauth2 source", rs.Name)
+	}
+
+	return userSource, err
 }

--- a/internal/services/common/gitsource.go
+++ b/internal/services/common/gitsource.go
@@ -132,7 +132,7 @@ func GetPasswordSource(rs *cstypes.RemoteSource, accessToken string) (gitsource.
 	case cstypes.RemoteSourceTypeGitea:
 		passwordSource, err = newGitea(rs, accessToken)
 	default:
-		return nil, errors.Errorf("remote source %s isn't a valid oauth2 source", rs.Name)
+		return nil, errors.Errorf("remote source %s isn't a valid password source", rs.Name)
 	}
 
 	return passwordSource, err
@@ -145,7 +145,7 @@ func GetTokenSource(rs *cstypes.RemoteSource, accessToken string) (gitsource.Use
 	case cstypes.RemoteSourceTypeGitea:
 		userSource, err = newGitea(rs, accessToken)
 	default:
-		return nil, errors.Errorf("remote source %s isn't a valid oauth2 source", rs.Name)
+		return nil, errors.Errorf("remote source %s isn't a valid token source", rs.Name)
 	}
 
 	return userSource, err

--- a/internal/services/configstore/action/remotesource.go
+++ b/internal/services/configstore/action/remotesource.go
@@ -60,6 +60,11 @@ func (h *ActionHandler) ValidateRemoteSource(ctx context.Context, remoteSource *
 			return util.NewErrBadRequest(errors.Errorf("remotesource oauth2clientsecret required for auth type %q", types.RemoteSourceAuthTypeOauth2))
 		}
 	}
+	if remoteSource.AuthType == types.RemoteSourceAuthTypeToken {
+		if remoteSource.AuthToken == "" {
+			return util.NewErrBadRequest(errors.Errorf("remotesource auth-token required for auth type %q", types.RemoteSourceAuthTypeToken))
+		}
+	}
 
 	return nil
 }

--- a/internal/services/gateway/action/remotesource.go
+++ b/internal/services/gateway/action/remotesource.go
@@ -132,6 +132,7 @@ type UpdateRemoteSourceRequest struct {
 
 	Name                *string
 	APIURL              *string
+	AuthToken           *string
 	SkipVerify          *bool
 	Oauth2ClientID      *string
 	Oauth2ClientSecret  *string
@@ -156,6 +157,9 @@ func (h *ActionHandler) UpdateRemoteSource(ctx context.Context, req *UpdateRemot
 	}
 	if req.APIURL != nil {
 		rs.APIURL = *req.APIURL
+	}
+	if req.AuthToken != nil {
+		rs.AuthToken = *req.AuthToken
 	}
 	if req.SkipVerify != nil {
 		rs.SkipVerify = *req.SkipVerify

--- a/internal/services/gateway/action/remotesource.go
+++ b/internal/services/gateway/action/remotesource.go
@@ -51,6 +51,7 @@ type CreateRemoteSourceRequest struct {
 	SkipVerify          bool
 	Type                string
 	AuthType            string
+	AuthToken           string
 	Oauth2ClientID      string
 	Oauth2ClientSecret  string
 	SSHHostKey          string
@@ -99,6 +100,7 @@ func (h *ActionHandler) CreateRemoteSource(ctx context.Context, req *CreateRemot
 		Name:                req.Name,
 		Type:                cstypes.RemoteSourceType(req.Type),
 		AuthType:            cstypes.RemoteSourceAuthType(req.AuthType),
+		AuthToken:           req.AuthToken,
 		APIURL:              req.APIURL,
 		SkipVerify:          req.SkipVerify,
 		Oauth2ClientID:      req.Oauth2ClientID,

--- a/internal/services/gateway/action/remotesource.go
+++ b/internal/services/gateway/action/remotesource.go
@@ -96,6 +96,12 @@ func (h *ActionHandler) CreateRemoteSource(ctx context.Context, req *CreateRemot
 		}
 	}
 
+	if req.AuthType == string(cstypes.RemoteSourceAuthTypeToken) {
+		if req.AuthToken == "" {
+			return nil, util.NewErrBadRequest(errors.Errorf("remotesource auth token required"))
+		}
+	}
+
 	rs := &cstypes.RemoteSource{
 		Name:                req.Name,
 		Type:                cstypes.RemoteSourceType(req.Type),

--- a/internal/services/gateway/action/user.go
+++ b/internal/services/gateway/action/user.go
@@ -584,6 +584,19 @@ func (h *ActionHandler) HandleRemoteSourceAuth(ctx context.Context, remoteSource
 			Response: cres.Response,
 		}, nil
 
+	case cstypes.RemoteSourceAuthTypeToken:
+		requestj, err := json.Marshal(req)
+		if err != nil {
+			return nil, err
+		}
+		cres, err := h.HandleRemoteSourceAuthRequest(ctx, requestType, string(requestj), rs.AuthToken, "", "", time.Time{})
+		if err != nil {
+			return nil, err
+		}
+		return &RemoteSourceAuthResponse{
+			Response: cres.Response,
+		}, nil
+
 	default:
 		return nil, errors.Errorf("unknown remote source authentication type: %q", rs.AuthType)
 	}

--- a/internal/services/gateway/api/remotesource.go
+++ b/internal/services/gateway/api/remotesource.go
@@ -53,6 +53,7 @@ func (h *CreateRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 		APIURL:              req.APIURL,
 		Type:                req.Type,
 		AuthType:            req.AuthType,
+		AuthToken:           req.AuthToken,
 		SkipVerify:          req.SkipVerify,
 		Oauth2ClientID:      req.Oauth2ClientID,
 		Oauth2ClientSecret:  req.Oauth2ClientSecret,

--- a/internal/services/gateway/api/remotesource.go
+++ b/internal/services/gateway/api/remotesource.go
@@ -100,6 +100,7 @@ func (h *UpdateRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 
 		Name:                req.Name,
 		APIURL:              req.APIURL,
+		AuthToken:           req.AuthToken,
 		SkipVerify:          req.SkipVerify,
 		Oauth2ClientID:      req.Oauth2ClientID,
 		Oauth2ClientSecret:  req.Oauth2ClientSecret,

--- a/services/configstore/types/types.go
+++ b/services/configstore/types/types.go
@@ -154,6 +154,7 @@ type RemoteSourceAuthType string
 const (
 	RemoteSourceAuthTypePassword RemoteSourceAuthType = "password"
 	RemoteSourceAuthTypeOauth2   RemoteSourceAuthType = "oauth2"
+	RemoteSourceAuthTypeToken    RemoteSourceAuthType = "token"
 )
 
 type RemoteSource struct {
@@ -168,8 +169,9 @@ type RemoteSource struct {
 
 	SkipVerify bool `json:"skip_verify,omitempty"`
 
-	Type     RemoteSourceType     `json:"type,omitempty"`
-	AuthType RemoteSourceAuthType `json:"auth_type,omitempty"`
+	Type      RemoteSourceType     `json:"type,omitempty"`
+	AuthType  RemoteSourceAuthType `json:"auth_type,omitempty"`
+	AuthToken string               `json:"auth_token,omitempty"`
 
 	// Oauth2 data
 	Oauth2ClientID     string `json:"client_id,omitempty"`
@@ -205,7 +207,11 @@ func (rs *RemoteSource) UnmarshalJSON(b []byte) error {
 func SourceSupportedAuthTypes(rsType RemoteSourceType) []RemoteSourceAuthType {
 	switch rsType {
 	case RemoteSourceTypeGitea:
-		return []RemoteSourceAuthType{RemoteSourceAuthTypeOauth2, RemoteSourceAuthTypePassword}
+		return []RemoteSourceAuthType{
+			RemoteSourceAuthTypeOauth2,
+			RemoteSourceAuthTypePassword,
+			RemoteSourceAuthTypeToken,
+		}
 	case RemoteSourceTypeGithub:
 		fallthrough
 	case RemoteSourceTypeGitlab:

--- a/services/gateway/api/types/remotesource.go
+++ b/services/gateway/api/types/remotesource.go
@@ -32,6 +32,7 @@ type CreateRemoteSourceRequest struct {
 type UpdateRemoteSourceRequest struct {
 	Name                *string `json:"name"`
 	APIURL              *string `json:"apiurl"`
+	AuthToken           *string `json:"auth_token"`
 	SkipVerify          *bool   `json:"skip_verify"`
 	Oauth2ClientID      *string `json:"oauth_2_client_id"`
 	Oauth2ClientSecret  *string `json:"oauth_2_client_secret"`

--- a/services/gateway/api/types/remotesource.go
+++ b/services/gateway/api/types/remotesource.go
@@ -19,6 +19,7 @@ type CreateRemoteSourceRequest struct {
 	APIURL              string `json:"apiurl"`
 	Type                string `json:"type"`
 	AuthType            string `json:"auth_type"`
+	AuthToken           string `json:"auth_token"`
 	SkipVerify          bool   `json:"skip_verify"`
 	Oauth2ClientID      string `json:"oauth_2_client_id"`
 	Oauth2ClientSecret  string `json:"oauth_2_client_secret"`


### PR DESCRIPTION
This PR add authentication type token to remote source. Basically, it's just the same as auth type password, but use a pre-defined token for authorize instead of doing normal password login step to get token.

This feature is useful in case of integrating agola with git provider transparently for user. The user don't have to go through agola-web to register/login and create project.