### PR TITLE
runservice: minimize scheduling of tasks that will be queued by the executor

### DIFF
--- a/internal/services/runservice/action/action.go
+++ b/internal/services/runservice/action/action.go
@@ -615,7 +615,7 @@ func (h *ActionHandler) GetExecutorTask(ctx context.Context, etID string) (*type
 }
 
 func (h *ActionHandler) GetExecutorTasks(ctx context.Context, executorID string) ([]*types.ExecutorTask, error) {
-	ets, err := store.GetExecutorTasks(ctx, h.e, executorID)
+	ets, err := store.GetExecutorTasksForExecutor(ctx, h.e, executorID)
 	if err != nil && err != etcd.ErrKeyNotFound {
 		return nil, err
 	}

--- a/internal/services/runservice/scheduler_test.go
+++ b/internal/services/runservice/scheduler_test.go
@@ -686,7 +686,7 @@ func TestChooseExecutor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := chooseExecutor(tt.executors, tt.rct)
+			e := chooseExecutor(tt.executors, map[string]int{}, tt.rct)
 			if e == nil && tt.out == nil {
 				return
 			}

--- a/internal/services/runservice/store/store.go
+++ b/internal/services/runservice/store/store.go
@@ -211,6 +211,7 @@ func GetExecutor(ctx context.Context, e *etcd.Store, executorID string) (*types.
 }
 
 func GetExecutors(ctx context.Context, e *etcd.Store) ([]*types.Executor, error) {
+	// TODO(sgotti) use paged List
 	resp, err := e.List(ctx, common.EtcdExecutorsDir, "", 0)
 	if err != nil {
 		return nil, err
@@ -298,7 +299,28 @@ func DeleteExecutorTask(ctx context.Context, e *etcd.Store, etID string) error {
 	return e.Delete(ctx, common.EtcdTaskKey(etID))
 }
 
-func GetExecutorTasks(ctx context.Context, e *etcd.Store, executorID string) ([]*types.ExecutorTask, error) {
+func GetExecutorTasksCountByExecutor(ctx context.Context, e *etcd.Store) (map[string]int, error) {
+	// TODO(sgotti) use paged List
+	resp, err := e.List(ctx, common.EtcdTasksDir, "", 0)
+	if err != nil {
+		return nil, err
+	}
+
+	count := map[string]int{}
+
+	for _, kv := range resp.Kvs {
+		var et *types.ExecutorTask
+		if err := json.Unmarshal(kv.Value, &et); err != nil {
+			return nil, err
+		}
+		count[et.Spec.ExecutorID] = count[et.Spec.ExecutorID] + 1
+	}
+
+	return count, nil
+}
+
+func GetExecutorTasksForExecutor(ctx context.Context, e *etcd.Store, executorID string) ([]*types.ExecutorTask, error) {
+	// TODO(sgotti) use paged List
 	resp, err := e.List(ctx, common.EtcdTasksDir, "", 0)
 	if err != nil {
 		return nil, err
@@ -478,6 +500,7 @@ func DeleteRun(ctx context.Context, e *etcd.Store, runID string) error {
 }
 
 func GetRuns(ctx context.Context, e *etcd.Store) ([]*types.Run, error) {
+	// TODO(sgotti) use paged List
 	resp, err := e.List(ctx, common.EtcdRunsDir, "", 0)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Since the executor only periodically updates its state we could end up
scheduling much more tasks than the executor ActiveTasksLimit. This will happen
in the case of many parallel tasks that can all start at the same time.

To avoid this also consider the executor tasks saved in etcd that represent
the real view of scheduled tasks.