### PR TITLE
executor: fix stopping of not running tasks

### DIFF
--- a/internal/services/executor/executor.go
+++ b/internal/services/executor/executor.go
@@ -1168,7 +1168,7 @@ func (e *Executor) taskUpdater(ctx context.Context, et *types.ExecutorTask) {
 		}()
 	}
 
-	if !et.Spec.Stop && et.Status.Phase == types.ExecutorTaskPhaseRunning {
+	if et.Status.Phase == types.ExecutorTaskPhaseRunning {
 		log.Infof("marking executor task %s as failed since there's no running task", et.ID)
 		et.Status.Phase = types.ExecutorTaskPhaseFailed
 		et.Status.EndTime = util.TimeP(time.Now())


### PR DESCRIPTION
When a related runningTask doesn't exist and the executor task status is
running just report it as failed ignoring if it's marked to stop.