### PR TITLE
executor: use cancellable context in executetask

### DIFF
--- a/internal/services/executor/driver/docker.go
+++ b/internal/services/executor/driver/docker.go
@@ -614,7 +614,11 @@ func (dp *DockerPod) Exec(ctx context.Context, execConfig *ExecConfig) (Containe
 
 func (e *DockerContainerExec) Wait(ctx context.Context) (int, error) {
 	// ignore error, we'll use the exit code of the exec
-	<-e.endCh
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	case <-e.endCh:
+	}
 
 	var exitCode int
 	for {


### PR DESCRIPTION
Use a cancellable context to handle running task stop.
When the context is done the pod will be stopped.