### PR TITLE
runservice: fix handling of wrong executortask status

### DIFF
--- a/internal/services/runservice/scheduler.go
+++ b/internal/services/runservice/scheduler.go
@@ -671,11 +671,13 @@ func (s *Runservice) updateRunTaskStatus(ctx context.Context, et *types.Executor
 		}
 	case types.ExecutorTaskPhaseStopped:
 		if rt.Status != types.RunTaskStatusStopped &&
+			rt.Status != types.RunTaskStatusNotStarted &&
 			rt.Status != types.RunTaskStatusRunning {
 			wrongstatus = true
 		}
 	case types.ExecutorTaskPhaseSuccess:
 		if rt.Status != types.RunTaskStatusSuccess &&
+			rt.Status != types.RunTaskStatusNotStarted &&
 			rt.Status != types.RunTaskStatusRunning {
 			wrongstatus = true
 		}
@@ -687,7 +689,7 @@ func (s *Runservice) updateRunTaskStatus(ctx context.Context, et *types.Executor
 		}
 	}
 	if wrongstatus {
-		log.Warnf("wrong executor task %q status: %q, rt status: %q", et.ID, et.Status.Phase, rt.Status)
+		log.Warnf("ignoring wrong executor task %q status: %q, rt status: %q", et.ID, et.Status.Phase, rt.Status)
 		return nil
 	}
 


### PR DESCRIPTION
updateRunTaskStatus should also accept transitions from not started to a
finished state like "success", "failed", "stopped" since we could miss some
status updates from the executor for many reasons.