### PR TITLE
github: add issue templates config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Agola Community Forum
+    url: https://talk.agola.io
+    about: For general discussion about using and developing Agola


### PR DESCRIPTION
Add a config to disable blank issues and show a reference to the Agola community
forum.