### PR TITLE
runconfig: disable password authentication in clone step

### DIFF
--- a/internal/runconfig/runconfig.go
+++ b/internal/runconfig/runconfig.go
@@ -109,6 +109,7 @@ Host $AGOLA_GIT_HOST
 	HostName $AGOLA_GIT_HOST
 	Port $AGOLA_GIT_PORT
 	StrictHostKeyChecking ${STRICT_HOST_KEY_CHECKING}
+	PasswordAuthentication no
 EOF
 )
 


### PR DESCRIPTION
If for some reasons the ssh public key auth fails, avoid the clone step to block
during a git clone waiting for a password.