### PR TITLE
cmd: add --detailed-errors options

### DIFF
--- a/cmd/agola/cmd/agola.go
+++ b/cmd/agola/cmd/agola.go
@@ -46,6 +46,10 @@ var cmdAgola = &cobra.Command{
 		if agolaOpts.debug {
 			level.SetLevel(zapcore.DebugLevel)
 		}
+
+		if agolaOpts.detailedErrors {
+			slog.SetDetailedErrorFormat(true)
+		}
 	},
 	Run: func(c *cobra.Command, args []string) {
 		if err := c.Help(); err != nil {
@@ -55,8 +59,9 @@ var cmdAgola = &cobra.Command{
 }
 
 type agolaOptions struct {
-	gatewayURL string
-	debug      bool
+	gatewayURL     string
+	debug          bool
+	detailedErrors bool
 }
 
 var agolaOpts agolaOptions
@@ -76,6 +81,7 @@ func init() {
 
 	flags.StringVarP(&agolaOpts.gatewayURL, "gateway-url", "u", gatewayURL, "agola gateway exposed url")
 	flags.StringVar(&token, "token", token, "api token")
+	flags.BoolVar(&agolaOpts.detailedErrors, "detailed-errors", false, "show detailed errors output")
 	flags.BoolVarP(&agolaOpts.debug, "debug", "d", false, "debug")
 }
 

--- a/internal/datamanager/changes.go
+++ b/internal/datamanager/changes.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"agola.io/agola/internal/etcd"
+	slog "agola.io/agola/internal/log"
 
 	etcdclientv3rpc "go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
 	"go.etcd.io/etcd/mvcc/mvccpb"
@@ -176,11 +177,11 @@ func (d *DataManager) watcherLoop(ctx context.Context) {
 		initialized := d.changes.initialized
 		if !initialized {
 			if err := d.initializeChanges(ctx); err != nil {
-				d.log.Errorf("watcher err: %+v", err)
+				d.log.Errorf("watcher err: %s", slog.FormatError(err))
 			}
 		} else {
 			if err := d.watcher(ctx); err != nil {
-				d.log.Errorf("watcher err: %+v", err)
+				d.log.Errorf("watcher err: %s", slog.FormatError(err))
 			}
 		}
 

--- a/internal/datamanager/datamanager.go
+++ b/internal/datamanager/datamanager.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"agola.io/agola/internal/etcd"
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/objectstorage"
 	"agola.io/agola/internal/sequence"
 
@@ -237,7 +238,7 @@ func (d *DataManager) Run(ctx context.Context, readyCh chan struct{}) error {
 			if err == nil {
 				break
 			}
-			d.log.Errorf("failed to initialize etcd: %+v", err)
+			d.log.Errorf("failed to initialize etcd: %s", slog.FormatError(err))
 
 			sleepCh := time.NewTimer(1 * time.Second).C
 			select {

--- a/internal/datamanager/wal.go
+++ b/internal/datamanager/wal.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"agola.io/agola/internal/etcd"
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/objectstorage"
 	"agola.io/agola/internal/sequence"
 	"agola.io/agola/internal/util"
@@ -535,7 +536,7 @@ func (d *DataManager) WriteWalAdditionalOps(ctx context.Context, actions []*Acti
 
 	// try to commit storage right now
 	if err := d.sync(ctx); err != nil {
-		d.log.Errorf("wal sync error: %+v", err)
+		d.log.Errorf("wal sync error: %s", slog.FormatError(err))
 	}
 
 	return ncgt, nil
@@ -545,7 +546,7 @@ func (d *DataManager) syncLoop(ctx context.Context) {
 	for {
 		d.log.Debugf("syncer")
 		if err := d.sync(ctx); err != nil {
-			d.log.Errorf("syncer error: %+v", err)
+			d.log.Errorf("syncer error: %s", slog.FormatError(err))
 		}
 
 		sleepCh := time.NewTimer(DefaultSyncInterval).C
@@ -634,7 +635,7 @@ func (d *DataManager) checkpointLoop(ctx context.Context) {
 	for {
 		d.log.Debugf("checkpointer")
 		if err := d.checkpoint(ctx, false); err != nil {
-			d.log.Errorf("checkpoint error: %v", err)
+			d.log.Errorf("checkpoint error: %s", slog.FormatError(err))
 		}
 
 		sleepCh := time.NewTimer(d.checkpointInterval).C
@@ -716,7 +717,7 @@ func (d *DataManager) checkpointCleanLoop(ctx context.Context) {
 	for {
 		d.log.Debugf("checkpointCleanLoop")
 		if err := d.checkpointClean(ctx); err != nil {
-			d.log.Errorf("checkpointClean error: %v", err)
+			d.log.Errorf("checkpointClean error: %s", slog.FormatError(err))
 		}
 
 		sleepCh := time.NewTimer(d.checkpointCleanInterval).C
@@ -756,7 +757,7 @@ func (d *DataManager) etcdWalCleanerLoop(ctx context.Context) {
 	for {
 		d.log.Debugf("etcdwalcleaner")
 		if err := d.etcdWalCleaner(ctx); err != nil {
-			d.log.Errorf("etcdwalcleaner error: %v", err)
+			d.log.Errorf("etcdwalcleaner error: %s", slog.FormatError(err))
 		}
 
 		sleepCh := time.NewTimer(DefaultEtcdWalCleanInterval).C
@@ -831,7 +832,7 @@ func (d *DataManager) storageWalCleanerLoop(ctx context.Context) {
 	for {
 		d.log.Debugf("storagewalcleaner")
 		if err := d.storageWalCleaner(ctx); err != nil {
-			d.log.Errorf("storagewalcleaner error: %v", err)
+			d.log.Errorf("storagewalcleaner error: %s", slog.FormatError(err))
 		}
 
 		sleepCh := time.NewTimer(DefaultStorageWalCleanInterval).C
@@ -942,7 +943,7 @@ func (d *DataManager) storageWalCleaner(ctx context.Context) error {
 func (d *DataManager) compactChangeGroupsLoop(ctx context.Context) {
 	for {
 		if err := d.compactChangeGroups(ctx); err != nil {
-			d.log.Errorf("err: %+v", err)
+			d.log.Errorf("err: %s", slog.FormatError(err))
 		}
 
 		sleepCh := time.NewTimer(DefaultCompactChangeGroupsInterval).C
@@ -1027,7 +1028,7 @@ func (d *DataManager) compactChangeGroups(ctx context.Context) error {
 func (d *DataManager) etcdPingerLoop(ctx context.Context) {
 	for {
 		if err := d.etcdPinger(ctx); err != nil {
-			d.log.Errorf("err: %+v", err)
+			d.log.Errorf("err: %s", slog.FormatError(err))
 		}
 
 		sleepCh := time.NewTimer(DefaultEtcdPingerInterval).C

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -21,6 +21,8 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+var errorFormat = "%v"
+
 func New(level zap.AtomicLevel) *zap.Logger {
 	config := zap.Config{
 		Level:             level,
@@ -40,4 +42,16 @@ func New(level zap.AtomicLevel) *zap.Logger {
 	}
 
 	return logger
+}
+
+func SetDetailedErrorFormat(enable bool) {
+	if enable {
+		errorFormat = "%+v"
+	} else {
+		errorFormat = "%v"
+	}
+}
+
+func FormatError(err error) string {
+	return fmt.Sprintf(errorFormat, err)
 }

--- a/internal/services/configstore/api/maintenance.go
+++ b/internal/services/configstore/api/maintenance.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 
 	"agola.io/agola/internal/etcd"
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/configstore/action"
 
 	"go.uber.org/zap"
@@ -46,13 +47,13 @@ func (h *MaintenanceModeHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	err := h.ah.MaintenanceMode(ctx, enable)
 	if err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		httpError(w, err)
 		return
 	}
 
 	if err := httpResponse(w, http.StatusOK, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 
 }
@@ -71,7 +72,7 @@ func (h *ExportHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	err := h.ah.Export(ctx, w)
 	if err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		// since we already answered with a 200 we cannot return another error code
 		// So abort the connection and the client will detect the missing ending chunk
 		// and consider this an error
@@ -95,13 +96,13 @@ func (h *ImportHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	err := h.ah.Import(ctx, r.Body)
 	if err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		httpError(w, err)
 		return
 	}
 
 	if err := httpResponse(w, http.StatusOK, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 
 }

--- a/internal/services/configstore/api/org.go
+++ b/internal/services/configstore/api/org.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"agola.io/agola/internal/db"
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/configstore/action"
 	"agola.io/agola/internal/services/configstore/readdb"
 	"agola.io/agola/internal/util"
@@ -52,7 +53,7 @@ func (h *OrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return err
 	})
 	if err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		httpError(w, err)
 		return
 	}
@@ -63,7 +64,7 @@ func (h *OrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := httpResponse(w, http.StatusOK, org); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -88,12 +89,12 @@ func (h *CreateOrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	org, err := h.ah.CreateOrg(ctx, &req)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusCreated, org); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -114,11 +115,11 @@ func (h *DeleteOrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	err := h.ah.DeleteOrg(ctx, orgRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -171,13 +172,13 @@ func (h *OrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return err
 	})
 	if err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		httpError(w, err)
 		return
 	}
 
 	if err := httpResponse(w, http.StatusOK, orgs); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -206,12 +207,12 @@ func (h *AddOrgMemberHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	org, err := h.ah.AddOrgMember(ctx, orgRef, userRef, req.Role)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusCreated, org); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -233,12 +234,12 @@ func (h *RemoveOrgMemberHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	err := h.ah.RemoveOrgMember(ctx, orgRef, userRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -265,7 +266,7 @@ func (h *OrgMembersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	orgUsers, err := h.ah.GetOrgMembers(ctx, orgRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -275,6 +276,6 @@ func (h *OrgMembersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := httpResponse(w, http.StatusOK, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }

--- a/internal/services/configstore/api/project.go
+++ b/internal/services/configstore/api/project.go
@@ -22,6 +22,7 @@ import (
 	"path"
 
 	"agola.io/agola/internal/db"
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/configstore/action"
 	"agola.io/agola/internal/services/configstore/readdb"
 	"agola.io/agola/internal/util"
@@ -132,18 +133,18 @@ func (h *ProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	project, err := h.ah.GetProject(ctx, projectRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	resProject, err := projectResponse(ctx, h.readDB, project)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusOK, resProject); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -169,18 +170,18 @@ func (h *CreateProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	project, err := h.ah.CreateProject(ctx, &req)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	resProject, err := projectResponse(ctx, h.readDB, project)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusCreated, resProject); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -217,18 +218,18 @@ func (h *UpdateProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 	project, err = h.ah.UpdateProject(ctx, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	resProject, err := projectResponse(ctx, h.readDB, project)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusCreated, resProject); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -253,10 +254,10 @@ func (h *DeleteProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	err = h.ah.DeleteProject(ctx, projectRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 

--- a/internal/services/configstore/api/projectgroup.go
+++ b/internal/services/configstore/api/projectgroup.go
@@ -22,6 +22,7 @@ import (
 	"path"
 
 	"agola.io/agola/internal/db"
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/configstore/action"
 	"agola.io/agola/internal/services/configstore/readdb"
 	"agola.io/agola/internal/util"
@@ -101,18 +102,18 @@ func (h *ProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	projectGroup, err := h.ah.GetProjectGroup(ctx, projectGroupRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	resProjectGroup, err := projectGroupResponse(ctx, h.readDB, projectGroup)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusOK, resProjectGroup); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -138,18 +139,18 @@ func (h *ProjectGroupProjectsHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 
 	projects, err := h.ah.GetProjectGroupProjects(ctx, projectGroupRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	resProjects, err := projectsResponse(ctx, h.readDB, projects)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusOK, resProjects); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -174,18 +175,18 @@ func (h *ProjectGroupSubgroupsHandler) ServeHTTP(w http.ResponseWriter, r *http.
 
 	projectGroups, err := h.ah.GetProjectGroupSubgroups(ctx, projectGroupRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	resProjectGroups, err := projectGroupsResponse(ctx, h.readDB, projectGroups)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusOK, resProjectGroups); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -211,18 +212,18 @@ func (h *CreateProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 
 	projectGroup, err := h.ah.CreateProjectGroup(ctx, &req)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	resProjectGroup, err := projectGroupResponse(ctx, h.readDB, projectGroup)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusCreated, resProjectGroup); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -259,18 +260,18 @@ func (h *UpdateProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	}
 	projectGroup, err = h.ah.UpdateProjectGroup(ctx, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	resProjectGroup, err := projectGroupResponse(ctx, h.readDB, projectGroup)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusCreated, resProjectGroup); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -295,9 +296,9 @@ func (h *DeleteProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 
 	err = h.ah.DeleteProjectGroup(ctx, projectGroupRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }

--- a/internal/services/configstore/api/remotesource.go
+++ b/internal/services/configstore/api/remotesource.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"agola.io/agola/internal/db"
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/configstore/action"
 	"agola.io/agola/internal/services/configstore/readdb"
 	"agola.io/agola/internal/util"
@@ -51,7 +52,7 @@ func (h *RemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		return err
 	})
 	if err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		httpError(w, err)
 		return
 	}
@@ -62,7 +63,7 @@ func (h *RemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := httpResponse(w, http.StatusOK, remoteSource); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -87,12 +88,12 @@ func (h *CreateRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 
 	remoteSource, err := h.ah.CreateRemoteSource(ctx, &req)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusCreated, remoteSource); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -124,12 +125,12 @@ func (h *UpdateRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	}
 	remoteSource, err := h.ah.UpdateRemoteSource(ctx, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusCreated, remoteSource); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -150,10 +151,10 @@ func (h *DeleteRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 
 	err := h.ah.DeleteRemoteSource(ctx, rsRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -201,12 +202,12 @@ func (h *RemoteSourcesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	remoteSources, err := h.readDB.GetRemoteSources(ctx, start, limit, asc)
 	if err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		httpError(w, err)
 		return
 	}
 
 	if err := httpResponse(w, http.StatusOK, remoteSources); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }

--- a/internal/services/configstore/api/secret.go
+++ b/internal/services/configstore/api/secret.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"agola.io/agola/internal/db"
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/configstore/action"
 	"agola.io/agola/internal/services/configstore/readdb"
 	"agola.io/agola/internal/util"
@@ -46,12 +47,12 @@ func (h *SecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	secret, err := h.ah.GetSecret(ctx, secretID)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusOK, secret); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -72,13 +73,13 @@ func (h *SecretsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	secrets, err := h.ah.GetSecrets(ctx, parentType, parentRef, tree)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -99,13 +100,13 @@ func (h *SecretsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return err
 	})
 	if err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		httpError(w, err)
 		return
 	}
 
 	if err := httpResponse(w, http.StatusOK, resSecrets); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -122,7 +123,7 @@ func (h *CreateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	ctx := r.Context()
 	parentType, parentRef, err := GetConfigTypeRef(r)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -138,12 +139,12 @@ func (h *CreateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	secret, err = h.ah.CreateSecret(ctx, secret)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusCreated, secret); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -163,7 +164,7 @@ func (h *UpdateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -183,12 +184,12 @@ func (h *UpdateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	}
 	secret, err = h.ah.UpdateSecret(ctx, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusOK, secret); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -208,15 +209,15 @@ func (h *DeleteSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	err = h.ah.DeleteSecret(ctx, parentType, parentRef, secretName)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }

--- a/internal/services/configstore/api/user.go
+++ b/internal/services/configstore/api/user.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"agola.io/agola/internal/db"
+	slog "agola.io/agola/internal/log"
 	action "agola.io/agola/internal/services/configstore/action"
 	"agola.io/agola/internal/services/configstore/readdb"
 	"agola.io/agola/internal/util"
@@ -52,7 +53,7 @@ func (h *UserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return err
 	})
 	if err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		httpError(w, err)
 		return
 	}
@@ -63,7 +64,7 @@ func (h *UserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := httpResponse(w, http.StatusOK, user); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -103,12 +104,12 @@ func (h *CreateUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	user, err := h.ah.CreateUser(ctx, creq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusCreated, user); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -141,12 +142,12 @@ func (h *UpdateUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	user, err := h.ah.UpdateUser(ctx, creq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusCreated, user); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -167,10 +168,10 @@ func (h *DeleteUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	err := h.ah.DeleteUser(ctx, userRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -230,7 +231,7 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return err
 		})
 		if err != nil {
-			h.log.Errorf("err: %+v", err)
+			h.log.Errorf("err: %s", slog.FormatError(err))
 			httpError(w, err)
 			return
 		}
@@ -248,7 +249,7 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return err
 		})
 		if err != nil {
-			h.log.Errorf("err: %+v", err)
+			h.log.Errorf("err: %s", slog.FormatError(err))
 			httpError(w, err)
 			return
 		}
@@ -267,7 +268,7 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return err
 		})
 		if err != nil {
-			h.log.Errorf("err: %+v", err)
+			h.log.Errorf("err: %s", slog.FormatError(err))
 			httpError(w, err)
 			return
 		}
@@ -284,14 +285,14 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return err
 		})
 		if err != nil {
-			h.log.Errorf("err: %+v", err)
+			h.log.Errorf("err: %s", slog.FormatError(err))
 			httpError(w, err)
 			return
 		}
 	}
 
 	if err := httpResponse(w, http.StatusOK, users); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -328,12 +329,12 @@ func (h *CreateUserLAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	}
 	user, err := h.ah.CreateUserLA(ctx, creq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusCreated, user); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -354,10 +355,10 @@ func (h *DeleteUserLAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	err := h.ah.DeleteUserLA(ctx, userRef, laID)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -395,12 +396,12 @@ func (h *UpdateUserLAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	}
 	user, err := h.ah.UpdateUserLA(ctx, creq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusOK, user); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -427,7 +428,7 @@ func (h *CreateUserTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	token, err := h.ah.CreateUserToken(ctx, userRef, req.TokenName)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -435,7 +436,7 @@ func (h *CreateUserTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		Token: token,
 	}
 	if err := httpResponse(w, http.StatusCreated, resp); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -456,11 +457,11 @@ func (h *DeleteUserTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	err := h.ah.DeleteUserToken(ctx, userRef, tokenName)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -487,7 +488,7 @@ func (h *UserOrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	userOrgs, err := h.ah.GetUserOrgs(ctx, userRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -497,6 +498,6 @@ func (h *UserOrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := httpResponse(w, http.StatusOK, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }

--- a/internal/services/configstore/api/variable.go
+++ b/internal/services/configstore/api/variable.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"agola.io/agola/internal/db"
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/configstore/action"
 	"agola.io/agola/internal/services/configstore/readdb"
 	"agola.io/agola/internal/util"
@@ -46,13 +47,13 @@ func (h *VariablesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	variables, err := h.ah.GetVariables(ctx, parentType, parentRef, tree)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -72,13 +73,13 @@ func (h *VariablesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return err
 	})
 	if err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		httpError(w, err)
 		return
 	}
 
 	if err := httpResponse(w, http.StatusOK, resVariables); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -95,7 +96,7 @@ func (h *CreateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	ctx := r.Context()
 	parentType, parentRef, err := GetConfigTypeRef(r)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -111,12 +112,12 @@ func (h *CreateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 	variable, err = h.ah.CreateVariable(ctx, variable)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusCreated, variable); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -136,7 +137,7 @@ func (h *UpdateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -156,12 +157,12 @@ func (h *UpdateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	}
 	variable, err = h.ah.UpdateVariable(ctx, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusOK, variable); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -181,15 +182,15 @@ func (h *DeleteVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	err = h.ah.DeleteVariable(ctx, parentType, parentRef, variableName)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }

--- a/internal/services/configstore/configstore.go
+++ b/internal/services/configstore/configstore.go
@@ -52,7 +52,7 @@ func (s *Configstore) maintenanceModeWatcherLoop(ctx context.Context, runCtxCanc
 
 		// at first watch restart from previous processed revision
 		if err := s.maintenanceModeWatcher(ctx, runCtxCancel, maintenanceModeEnabled); err != nil {
-			log.Errorf("err: %+v", err)
+			log.Errorf("err: %s", slog.FormatError(err))
 		}
 
 		sleepCh := time.NewTimer(1 * time.Second).C
@@ -326,7 +326,7 @@ func (s *Configstore) setupMaintenanceRouter() http.Handler {
 func (s *Configstore) Run(ctx context.Context) error {
 	for {
 		if err := s.run(ctx); err != nil {
-			log.Errorf("run error: %+v", err)
+			log.Errorf("run error: %s", slog.FormatError(err))
 		}
 
 		sleepCh := time.NewTimer(1 * time.Second).C
@@ -345,7 +345,7 @@ func (s *Configstore) run(ctx context.Context) error {
 		var err error
 		tlsConfig, err = util.NewTLSConfig(s.c.Web.TLSCertFile, s.c.Web.TLSKeyFile, "", false)
 		if err != nil {
-			log.Errorf("err: %+v")
+			log.Errorf("err: %s", slog.FormatError(err))
 			return err
 		}
 	}
@@ -406,12 +406,12 @@ func (s *Configstore) run(ctx context.Context) error {
 		log.Infof("configstore run exiting")
 	case err := <-lerrCh:
 		if err != nil {
-			log.Errorf("http server listen error: %+v", err)
+			log.Errorf("http server listen error: %s", slog.FormatError(err))
 			return err
 		}
 	case err := <-errCh:
 		if err != nil {
-			log.Errorf("error: %+v", err)
+			log.Errorf("error: %s", slog.FormatError(err))
 			return err
 		}
 	}

--- a/internal/services/configstore/readdb/readdb.go
+++ b/internal/services/configstore/readdb/readdb.go
@@ -27,6 +27,7 @@ import (
 	"agola.io/agola/internal/datamanager"
 	"agola.io/agola/internal/db"
 	"agola.io/agola/internal/etcd"
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/objectstorage"
 	"agola.io/agola/internal/sequence"
 	"agola.io/agola/internal/util"
@@ -412,7 +413,7 @@ func (r *ReadDB) Run(ctx context.Context) error {
 			if err == nil {
 				break
 			}
-			r.log.Errorf("initialize err: %+v", err)
+			r.log.Errorf("initialize err: %s", slog.FormatError(err))
 
 			sleepCh := time.NewTimer(1 * time.Second).C
 			select {
@@ -435,7 +436,7 @@ func (r *ReadDB) Run(ctx context.Context) error {
 				r.SetInitialized(true)
 				break
 			}
-			r.log.Errorf("initialize err: %+v", err)
+			r.log.Errorf("initialize err: %s", slog.FormatError(err))
 
 			sleepCh := time.NewTimer(1 * time.Second).C
 			select {
@@ -454,7 +455,7 @@ func (r *ReadDB) Run(ctx context.Context) error {
 		go func() {
 			r.log.Infof("starting handleEvents")
 			if err := r.handleEvents(hctx); err != nil {
-				r.log.Errorf("handleEvents err: %+v", err)
+				r.log.Errorf("handleEvents err: %s", slog.FormatError(err))
 			}
 			wg.Done()
 			doneCh <- struct{}{}

--- a/internal/services/executor/api.go
+++ b/internal/services/executor/api.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"time"
 
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/services/runservice/types"
 	"go.uber.org/zap"
 	errors "golang.org/x/xerrors"
@@ -97,7 +98,7 @@ func (h *logsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.readTaskLogs(taskID, setup, step, w, follow); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 

--- a/internal/services/executor/driver/k8s.go
+++ b/internal/services/executor/driver/k8s.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/types"
 
@@ -189,7 +190,7 @@ func NewK8sDriver(logger *zap.Logger, executorID, toolboxPath string) (*K8sDrive
 	go func() {
 		for {
 			if err := d.updateLease(ctx); err != nil {
-				d.log.Errorf("failed to update executor lease: %+v", err)
+				d.log.Errorf("failed to update executor lease: %s", slog.FormatError(err))
 			}
 
 			select {
@@ -205,7 +206,7 @@ func NewK8sDriver(logger *zap.Logger, executorID, toolboxPath string) (*K8sDrive
 	go func() {
 		for {
 			if err := d.cleanStaleExecutorsLease(ctx); err != nil {
-				d.log.Errorf("failed to clean stale executors lease: %+v", err)
+				d.log.Errorf("failed to clean stale executors lease: %s", slog.FormatError(err))
 			}
 
 			select {

--- a/internal/services/executor/driver/k8slease.go
+++ b/internal/services/executor/driver/k8slease.go
@@ -19,6 +19,8 @@ import (
 	"encoding/json"
 	"time"
 
+	slog "agola.io/agola/internal/log"
+
 	errors "golang.org/x/xerrors"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -195,7 +197,7 @@ func (d *K8sDriver) cleanStaleExecutorsLease(ctx context.Context) error {
 			if lease.Spec.RenewTime.Add(staleExecutorLeaseInterval).Before(time.Now()) {
 				d.log.Infof("deleting stale lease %q", lease.Name)
 				if err := leaseClient.Delete(lease.Name, nil); err != nil {
-					d.log.Errorf("failed to delete stale lease %q, err: %v", lease.Name, err)
+					d.log.Errorf("failed to delete stale lease %q, err: %s", lease.Name, slog.FormatError(err))
 				}
 			}
 		}
@@ -225,7 +227,7 @@ func (d *K8sDriver) cleanStaleExecutorsLease(ctx context.Context) error {
 			if ld.RenewTime.Add(staleExecutorLeaseInterval).Before(time.Now()) {
 				d.log.Infof("deleting stale configmap lease %q", cm.Name)
 				if err := cmClient.Delete(cm.Name, nil); err != nil {
-					d.log.Errorf("failed to delete stale configmap lease %q, err: %v", cm.Name, err)
+					d.log.Errorf("failed to delete stale configmap lease %q, err: %s", cm.Name, slog.FormatError(err))
 				}
 			}
 		}

--- a/internal/services/gateway/action/run.go
+++ b/internal/services/gateway/action/run.go
@@ -23,6 +23,7 @@ import (
 
 	"agola.io/agola/internal/config"
 	gitsource "agola.io/agola/internal/gitsources"
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/runconfig"
 	"agola.io/agola/internal/services/common"
 	itypes "agola.io/agola/internal/services/types"
@@ -512,7 +513,7 @@ func (h *ActionHandler) CreateRuns(ctx context.Context, req *CreateRunRequest) e
 
 	config, err := config.ParseConfig([]byte(data), configFormat, configContext)
 	if err != nil {
-		h.log.Errorf("failed to parse config: %+v", err)
+		h.log.Errorf("failed to parse config: %s", slog.FormatError(err))
 
 		// create a run (per config file) with a generic error since we cannot parse
 		// it and know how many runs are defined
@@ -527,7 +528,7 @@ func (h *ActionHandler) CreateRuns(ctx context.Context, req *CreateRunRequest) e
 		}
 
 		if _, _, err := h.runserviceClient.CreateRun(ctx, createRunReq); err != nil {
-			h.log.Errorf("failed to create run: %+v", err)
+			h.log.Errorf("failed to create run: %s", slog.FormatError(err))
 			return err
 		}
 		return nil
@@ -557,7 +558,7 @@ func (h *ActionHandler) CreateRuns(ctx context.Context, req *CreateRunRequest) e
 		}
 
 		if _, _, err := h.runserviceClient.CreateRun(ctx, createRunReq); err != nil {
-			h.log.Errorf("failed to create run: %+v", err)
+			h.log.Errorf("failed to create run: %s", slog.FormatError(err))
 			return err
 		}
 	}
@@ -575,7 +576,7 @@ func (h *ActionHandler) fetchConfigFiles(ctx context.Context, gitSource gitsourc
 			if err == nil {
 				return true, nil
 			}
-			h.log.Errorf("get file err: %v", err)
+			h.log.Errorf("get file err: %s", slog.FormatError(err))
 		}
 		return false, nil
 	})

--- a/internal/services/gateway/api/badge.go
+++ b/internal/services/gateway/api/badge.go
@@ -18,8 +18,10 @@ import (
 	"net/http"
 	"net/url"
 
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/util"
+
 	"github.com/gorilla/mux"
 	"go.uber.org/zap"
 )
@@ -47,7 +49,7 @@ func (h *BadgeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	badge, err := h.ah.GetBadge(ctx, projectRef, branch)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -56,6 +58,6 @@ func (h *BadgeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache")
 
 	if _, err := w.Write([]byte(badge)); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }

--- a/internal/services/gateway/api/oauth2.go
+++ b/internal/services/gateway/api/oauth2.go
@@ -17,6 +17,7 @@ package api
 import (
 	"net/http"
 
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/util"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
@@ -41,7 +42,7 @@ func (h *OAuth2CallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 	cresp, err := h.ah.HandleOauth2Callback(ctx, code, state)
 	if err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		httpError(w, util.NewErrBadRequest(err))
 		return
 	}
@@ -87,6 +88,6 @@ func (h *OAuth2CallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		Response:    response,
 	}
 	if err := httpResponse(w, http.StatusOK, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }

--- a/internal/services/gateway/api/org.go
+++ b/internal/services/gateway/api/org.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"strconv"
 
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/util"
 	cstypes "agola.io/agola/services/configstore/types"
@@ -62,13 +63,13 @@ func (h *CreateOrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	org, err := h.ah.CreateOrg(ctx, creq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createOrgResponse(org)
 	if err := httpResponse(w, http.StatusCreated, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -88,12 +89,12 @@ func (h *DeleteOrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	err := h.ah.DeleteOrg(ctx, orgRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -113,13 +114,13 @@ func (h *OrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	org, err := h.ah.GetOrg(ctx, orgRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createOrgResponse(org)
 	if err := httpResponse(w, http.StatusOK, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -176,7 +177,7 @@ func (h *OrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	csorgs, err := h.ah.GetOrgs(ctx, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -185,7 +186,7 @@ func (h *OrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		orgs[i] = createOrgResponse(p)
 	}
 	if err := httpResponse(w, http.StatusOK, orgs); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -213,7 +214,7 @@ func (h *OrgMembersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	ares, err := h.ah.GetOrgMembers(ctx, orgRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -225,7 +226,7 @@ func (h *OrgMembersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		res.Members[i] = createOrgMemberResponse(m.User, m.Role)
 	}
 	if err := httpResponse(w, http.StatusOK, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -264,13 +265,13 @@ func (h *AddOrgMemberHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	ares, err := h.ah.AddOrgMember(ctx, orgRef, userRef, cstypes.MemberRole(req.Role))
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createAddOrgMemberResponse(ares.Org, ares.User, ares.OrganizationMember.MemberRole)
 	if err := httpResponse(w, http.StatusOK, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -292,11 +293,11 @@ func (h *RemoveOrgMemberHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	err := h.ah.RemoveOrgMember(ctx, orgRef, userRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }

--- a/internal/services/gateway/api/project.go
+++ b/internal/services/gateway/api/project.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/url"
 
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/util"
 	csapitypes "agola.io/agola/services/configstore/api/types"
@@ -60,13 +61,13 @@ func (h *CreateProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	project, err := h.ah.CreateProject(ctx, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createProjectResponse(project)
 	if err := httpResponse(w, http.StatusCreated, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -109,13 +110,13 @@ func (h *UpdateProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 	project, err := h.ah.UpdateProject(ctx, projectRef, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createProjectResponse(project)
 	if err := httpResponse(w, http.StatusCreated, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -142,7 +143,7 @@ func (h *ProjectReconfigHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -166,13 +167,13 @@ func (h *ProjectUpdateRepoLinkedAccountHandler) ServeHTTP(w http.ResponseWriter,
 
 	project, err := h.ah.ProjectUpdateRepoLinkedAccount(ctx, projectRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createProjectResponse(project)
 	if err := httpResponse(w, http.StatusOK, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -196,12 +197,12 @@ func (h *DeleteProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	err = h.ah.DeleteProject(ctx, projectRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -225,13 +226,13 @@ func (h *ProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	project, err := h.ah.GetProject(ctx, projectRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createProjectResponse(project)
 	if err := httpResponse(w, http.StatusOK, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -276,11 +277,11 @@ func (h *ProjectCreateRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 
 	err = h.ah.ProjectCreateRun(ctx, projectRef, req.Branch, req.Tag, req.Ref, req.CommitSHA)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusCreated, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }

--- a/internal/services/gateway/api/projectgroup.go
+++ b/internal/services/gateway/api/projectgroup.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/url"
 
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/util"
 	csapitypes "agola.io/agola/services/configstore/api/types"
@@ -65,13 +66,13 @@ func (h *CreateProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 
 	projectGroup, err := h.ah.CreateProjectGroup(ctx, creq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createProjectGroupResponse(projectGroup)
 	if err := httpResponse(w, http.StatusCreated, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -113,13 +114,13 @@ func (h *UpdateProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	}
 	projectGroup, err := h.ah.UpdateProjectGroup(ctx, projectGroupRef, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createProjectGroupResponse(projectGroup)
 	if err := httpResponse(w, http.StatusCreated, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -143,12 +144,12 @@ func (h *DeleteProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 
 	err = h.ah.DeleteProjectGroup(ctx, projectGroupRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -172,13 +173,13 @@ func (h *ProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	projectGroup, err := h.ah.GetProjectGroup(ctx, projectGroupRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createProjectGroupResponse(projectGroup)
 	if err := httpResponse(w, http.StatusOK, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -202,7 +203,7 @@ func (h *ProjectGroupProjectsHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 
 	csprojects, err := h.ah.GetProjectGroupProjects(ctx, projectGroupRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -212,7 +213,7 @@ func (h *ProjectGroupProjectsHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 	}
 
 	if err := httpResponse(w, http.StatusOK, projects); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -236,7 +237,7 @@ func (h *ProjectGroupSubgroupsHandler) ServeHTTP(w http.ResponseWriter, r *http.
 
 	cssubgroups, err := h.ah.GetProjectGroupSubgroups(ctx, projectGroupRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -246,7 +247,7 @@ func (h *ProjectGroupSubgroupsHandler) ServeHTTP(w http.ResponseWriter, r *http.
 	}
 
 	if err := httpResponse(w, http.StatusOK, subgroups); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 

--- a/internal/services/gateway/api/remoterepo.go
+++ b/internal/services/gateway/api/remoterepo.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 
 	gitsource "agola.io/agola/internal/gitsources"
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/util"
 	csclient "agola.io/agola/services/configstore/client"
@@ -62,13 +63,13 @@ func (h *UserRemoteReposHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	user, resp, err := h.configstoreClient.GetUser(ctx, userID)
 	if httpErrorFromRemote(w, resp, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	rs, resp, err := h.configstoreClient.GetRemoteSource(ctx, remoteSourceRef)
 	if httpErrorFromRemote(w, resp, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -82,14 +83,14 @@ func (h *UserRemoteReposHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	if la == nil {
 		err := util.NewErrBadRequest(errors.Errorf("user doesn't have a linked account for remote source %q", rs.Name))
 		httpError(w, err)
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	gitsource, err := h.ah.GetGitSource(ctx, rs, user.Name, la)
 	if err != nil {
 		httpError(w, err)
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -97,7 +98,7 @@ func (h *UserRemoteReposHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	if err != nil {
 		err := util.NewErrBadRequest(errors.Errorf("failed to get user repositories from git source: %w", err))
 		httpError(w, err)
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -106,6 +107,6 @@ func (h *UserRemoteReposHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		repos[i] = createRemoteRepoResponse(r)
 	}
 	if err := httpResponse(w, http.StatusOK, repos); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }

--- a/internal/services/gateway/api/remotesource.go
+++ b/internal/services/gateway/api/remotesource.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"strconv"
 
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/util"
 	cstypes "agola.io/agola/services/configstore/types"
@@ -63,13 +64,13 @@ func (h *CreateRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	}
 	rs, err := h.ah.CreateRemoteSource(ctx, creq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createRemoteSourceResponse(rs)
 	if err := httpResponse(w, http.StatusCreated, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -109,13 +110,13 @@ func (h *UpdateRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	}
 	rs, err := h.ah.UpdateRemoteSource(ctx, creq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createRemoteSourceResponse(rs)
 	if err := httpResponse(w, http.StatusCreated, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -146,13 +147,13 @@ func (h *RemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	rs, err := h.ah.GetRemoteSource(ctx, rsRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createRemoteSourceResponse(rs)
 	if err := httpResponse(w, http.StatusOK, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -200,7 +201,7 @@ func (h *RemoteSourcesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 	csRemoteSources, err := h.ah.GetRemoteSources(ctx, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -210,7 +211,7 @@ func (h *RemoteSourcesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	if err := httpResponse(w, http.StatusOK, remoteSources); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -230,11 +231,11 @@ func (h *DeleteRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 
 	err := h.ah.DeleteRemoteSource(ctx, rsRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }

--- a/internal/services/gateway/api/repos.go
+++ b/internal/services/gateway/api/repos.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/url"
 
+	slog "agola.io/agola/internal/log"
 	"go.uber.org/zap"
 
 	"github.com/gorilla/mux"
@@ -40,7 +41,7 @@ func (h *ReposHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	u, err := url.Parse(h.gitServerURL)
 	if err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		httpError(w, err)
 		return
 	}
@@ -52,7 +53,7 @@ func (h *ReposHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	req, err := http.NewRequest(r.Method, u.String(), r.Body)
 	req = req.WithContext(ctx)
 	if err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		httpError(w, err)
 		return
 	}
@@ -66,7 +67,7 @@ func (h *ReposHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		httpError(w, err)
 		return
 	}
@@ -83,7 +84,7 @@ func (h *ReposHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer resp.Body.Close()
 	// copy response body
 	if _, err := io.Copy(w, resp.Body); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		httpError(w, err)
 		return
 	}

--- a/internal/services/gateway/api/run.go
+++ b/internal/services/gateway/api/run.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"strconv"
 
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/util"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
@@ -165,13 +166,13 @@ func (h *RunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	runResp, err := h.ah.GetRun(ctx, runID)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createRunResponse(runResp.Run, runResp.RunConfig)
 	if err := httpResponse(w, http.StatusOK, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -192,7 +193,7 @@ func (h *RuntaskHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	runResp, err := h.ah.GetRun(ctx, runID)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -208,7 +209,7 @@ func (h *RuntaskHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	res := createRunTaskResponse(rt, rct)
 	if err := httpResponse(w, http.StatusOK, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -299,7 +300,7 @@ func (h *RunsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	runsResp, err := h.ah.GetRuns(ctx, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -308,7 +309,7 @@ func (h *RunsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		runs[i] = createRunsResponse(r)
 	}
 	if err := httpResponse(w, http.StatusOK, runs); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -341,13 +342,13 @@ func (h *RunActionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	runResp, err := h.ah.RunAction(ctx, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createRunResponse(runResp.Run, runResp.RunConfig)
 	if err := httpResponse(w, http.StatusOK, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -381,7 +382,7 @@ func (h *RunTaskActionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 	err := h.ah.RunTaskAction(ctx, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 }
@@ -447,7 +448,7 @@ func (h *LogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := h.ah.GetLogs(ctx, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -466,7 +467,7 @@ func (h *LogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	defer resp.Body.Close()
 	if err := sendLogs(w, resp.Body); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 }
@@ -558,7 +559,7 @@ func (h *LogsDeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	err := h.ah.DeleteLogs(ctx, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 }

--- a/internal/services/gateway/api/secret.go
+++ b/internal/services/gateway/api/secret.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/util"
 	csapitypes "agola.io/agola/services/configstore/api/types"
@@ -53,7 +54,7 @@ func (h *SecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -65,7 +66,7 @@ func (h *SecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	cssecrets, err := h.ah.GetSecrets(ctx, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -75,7 +76,7 @@ func (h *SecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := httpResponse(w, http.StatusOK, secrets); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -113,13 +114,13 @@ func (h *CreateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	}
 	cssecret, err := h.ah.CreateSecret(ctx, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createSecretResponse(cssecret)
 	if err := httpResponse(w, http.StatusCreated, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -139,7 +140,7 @@ func (h *UpdateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -162,13 +163,13 @@ func (h *UpdateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	}
 	cssecret, err := h.ah.UpdateSecret(ctx, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createSecretResponse(cssecret)
 	if err := httpResponse(w, http.StatusOK, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -193,11 +194,11 @@ func (h *DeleteSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	err = h.ah.DeleteSecret(ctx, parentType, parentRef, secretName)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }

--- a/internal/services/gateway/api/user.go
+++ b/internal/services/gateway/api/user.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strconv"
 
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/util"
 	cstypes "agola.io/agola/services/configstore/types"
@@ -56,13 +57,13 @@ func (h *CreateUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	u, err := h.ah.CreateUser(ctx, creq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createUserResponse(u)
 	if err := httpResponse(w, http.StatusCreated, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -82,12 +83,12 @@ func (h *DeleteUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	err := h.ah.DeleteUser(ctx, userRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -112,13 +113,13 @@ func (h *CurrentUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	user, err := h.ah.GetUser(ctx, userID)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createUserResponse(user)
 	if err := httpResponse(w, http.StatusOK, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -138,13 +139,13 @@ func (h *UserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	user, err := h.ah.GetUser(ctx, userRef)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createUserResponse(user)
 	if err := httpResponse(w, http.StatusOK, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -217,7 +218,7 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	csusers, err := h.ah.GetUsers(ctx, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -227,7 +228,7 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := httpResponse(w, http.StatusOK, users); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -254,12 +255,12 @@ func (h *CreateUserLAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	res, err := h.createUserLA(ctx, userRef, req)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusCreated, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -311,12 +312,12 @@ func (h *DeleteUserLAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	err := h.ah.DeleteUserLA(ctx, userRef, laID)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -348,7 +349,7 @@ func (h *CreateUserTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	h.log.Infof("creating user %q token", userRef)
 	token, err := h.ah.CreateUserToken(ctx, creq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -357,7 +358,7 @@ func (h *CreateUserTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	}
 
 	if err := httpResponse(w, http.StatusCreated, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -379,12 +380,12 @@ func (h *DeleteUserTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	h.log.Infof("deleting user %q token %q", userRef, tokenName)
 	err := h.ah.DeleteUserToken(ctx, userRef, tokenName)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -409,12 +410,12 @@ func (h *RegisterUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	res, err := h.registerUser(ctx, req)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusCreated, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -460,12 +461,12 @@ func (h *AuthorizeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	res, err := h.authorize(ctx, req)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusCreated, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -517,12 +518,12 @@ func (h *LoginUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	res, err := h.loginUser(ctx, req)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusCreated, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -582,11 +583,11 @@ func (h *UserCreateRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 	err := h.ah.UserCreateRun(ctx, creq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusCreated, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }

--- a/internal/services/gateway/api/variable.go
+++ b/internal/services/gateway/api/variable.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/common"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/util"
@@ -70,7 +71,7 @@ func (h *VariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -82,7 +83,7 @@ func (h *VariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	csvars, cssecrets, err := h.ah.GetVariables(ctx, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -92,7 +93,7 @@ func (h *VariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := httpResponse(w, http.StatusOK, variables); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -109,7 +110,7 @@ func (h *CreateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	ctx := r.Context()
 	parentType, parentRef, err := GetConfigTypeRef(r)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -127,13 +128,13 @@ func (h *CreateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	}
 	csvar, cssecrets, err := h.ah.CreateVariable(ctx, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createVariableResponse(csvar, cssecrets)
 	if err := httpResponse(w, http.StatusCreated, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -153,7 +154,7 @@ func (h *UpdateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
@@ -174,13 +175,13 @@ func (h *UpdateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	}
 	csvar, cssecrets, err := h.ah.UpdateVariable(ctx, areq)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	res := createVariableResponse(csvar, cssecrets)
 	if err := httpResponse(w, http.StatusOK, res); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 
@@ -200,18 +201,18 @@ func (h *DeleteVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	err = h.ah.DeleteVariable(ctx, parentType, parentRef, variableName)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 

--- a/internal/services/gateway/api/version.go
+++ b/internal/services/gateway/api/version.go
@@ -17,6 +17,7 @@ package api
 import (
 	"net/http"
 
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/gateway/action"
 
 	"go.uber.org/zap"
@@ -36,11 +37,11 @@ func (h *VersionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	version, err := h.ah.GetVersion(ctx)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusOK, version); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }

--- a/internal/services/gateway/api/webhook.go
+++ b/internal/services/gateway/api/webhook.go
@@ -17,6 +17,7 @@ package api
 import (
 	"net/http"
 
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/common"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/services/types"
@@ -49,12 +50,12 @@ func NewWebhooksHandler(logger *zap.Logger, ah *action.ActionHandler, configstor
 func (h *webhooksHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err := h.handleWebhook(r)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusOK, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 

--- a/internal/services/gateway/gateway.go
+++ b/internal/services/gateway/gateway.go
@@ -337,7 +337,7 @@ func (g *Gateway) Run(ctx context.Context) error {
 		var err error
 		tlsConfig, err = util.NewTLSConfig(g.c.Web.TLSCertFile, g.c.Web.TLSKeyFile, "", false)
 		if err != nil {
-			log.Errorf("err: %+v")
+			log.Errorf("err: %s", slog.FormatError(err))
 			return err
 		}
 	}
@@ -359,7 +359,7 @@ func (g *Gateway) Run(ctx context.Context) error {
 		httpServer.Close()
 	case err := <-lerrCh:
 		if err != nil {
-			log.Errorf("http server listen error: %v", err)
+			log.Errorf("http server listen error: %s", slog.FormatError(err))
 			return err
 		}
 	}

--- a/internal/services/gateway/handlers/auth.go
+++ b/internal/services/gateway/handlers/auth.go
@@ -22,6 +22,7 @@ import (
 	"agola.io/agola/internal/services/common"
 	csclient "agola.io/agola/services/configstore/client"
 
+	slog "agola.io/agola/internal/log"
 	jwt "github.com/dgrijalva/jwt-go"
 	jwtrequest "github.com/dgrijalva/jwt-go/request"
 	"go.uber.org/zap"
@@ -105,7 +106,7 @@ func (h *AuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return key, nil
 		})
 		if err != nil {
-			h.log.Errorf("err: %+v", err)
+			h.log.Errorf("err: %s", slog.FormatError(err))
 			http.Error(w, "", http.StatusUnauthorized)
 			return
 		}

--- a/internal/services/gitserver/main.go
+++ b/internal/services/gitserver/main.go
@@ -159,7 +159,7 @@ func (s *Gitserver) Run(ctx context.Context) error {
 		var err error
 		tlsConfig, err = util.NewTLSConfig(s.c.Web.TLSCertFile, s.c.Web.TLSKeyFile, "", false)
 		if err != nil {
-			log.Errorf("err: %+v")
+			log.Errorf("err: %s", slog.FormatError(err))
 			return err
 		}
 	}
@@ -181,7 +181,7 @@ func (s *Gitserver) Run(ctx context.Context) error {
 		httpServer.Close()
 	case err := <-lerrCh:
 		if err != nil {
-			log.Errorf("http server listen error: %v", err)
+			log.Errorf("http server listen error: %s", slog.FormatError(err))
 			return err
 		}
 	}

--- a/internal/services/notification/runevents.go
+++ b/internal/services/notification/runevents.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"agola.io/agola/internal/etcd"
+	slog "agola.io/agola/internal/log"
 	rstypes "agola.io/agola/services/runservice/types"
 
 	"go.etcd.io/etcd/clientv3/concurrency"
@@ -38,7 +39,7 @@ var (
 func (n *NotificationService) runEventsHandlerLoop(ctx context.Context) {
 	for {
 		if err := n.runEventsHandler(ctx); err != nil {
-			log.Errorf("err: %+v", err)
+			log.Errorf("err: %s", slog.FormatError(err))
 		}
 
 		sleepCh := time.NewTimer(1 * time.Second).C
@@ -111,7 +112,7 @@ func (n *NotificationService) runEventsHandler(ctx context.Context) error {
 			// their status to etcd so we can also do more logic like retrying and handle
 			// multiple kind of notifications (email etc...)
 			if err := n.updateCommitStatus(ctx, ev); err != nil {
-				log.Infof("failed to update commit status: %v", err)
+				log.Infof("failed to update commit status: %s", slog.FormatError(err))
 			}
 
 		default:

--- a/internal/services/runservice/action/action.go
+++ b/internal/services/runservice/action/action.go
@@ -23,6 +23,7 @@ import (
 	"agola.io/agola/internal/datamanager"
 	"agola.io/agola/internal/db"
 	"agola.io/agola/internal/etcd"
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/objectstorage"
 	"agola.io/agola/internal/runconfig"
 	"agola.io/agola/internal/sequence"
@@ -193,14 +194,14 @@ func (h *ActionHandler) newRun(ctx context.Context, req *RunCreateRequest) (*typ
 	id := seq.String()
 
 	if err := runconfig.CheckRunConfigTasks(rcts); err != nil {
-		h.log.Errorf("check run config tasks failed: %+v", err)
+		h.log.Errorf("check run config tasks failed: %s", slog.FormatError(err))
 		setupErrors = append(setupErrors, err.Error())
 	}
 
 	// generate tasks levels
 	if len(setupErrors) == 0 {
 		if err := runconfig.GenTasksLevels(rcts); err != nil {
-			h.log.Errorf("gen tasks leveles failed: %+v", err)
+			h.log.Errorf("gen tasks leveles failed: %s", slog.FormatError(err))
 			setupErrors = append(setupErrors, err.Error())
 		}
 	}

--- a/internal/services/runservice/api/executor.go
+++ b/internal/services/runservice/api/executor.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"agola.io/agola/internal/etcd"
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/objectstorage"
 	"agola.io/agola/internal/services/runservice/action"
 	"agola.io/agola/internal/services/runservice/common"
@@ -99,7 +100,7 @@ func (h *ExecutorStatusHandler) deleteStaleExecutors(ctx context.Context, curExe
 		}
 		if !active {
 			if err := h.ah.DeleteExecutor(ctx, executor.ID); err != nil {
-				h.log.Errorf("failed to delete executor %q: %v", executor.ID, err)
+				h.log.Errorf("failed to delete executor %q: %s", executor.ID, slog.FormatError(err))
 			}
 		}
 	}
@@ -159,12 +160,12 @@ func (h *ExecutorTaskHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	et, err := h.ah.GetExecutorTask(ctx, etID)
 	if httpError(w, err) {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		return
 	}
 
 	if err := httpResponse(w, http.StatusOK, et); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 }
 

--- a/internal/services/runservice/api/maintenance.go
+++ b/internal/services/runservice/api/maintenance.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 
 	"agola.io/agola/internal/etcd"
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/services/runservice/action"
 
 	"go.uber.org/zap"
@@ -46,13 +47,13 @@ func (h *MaintenanceModeHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	err := h.ah.MaintenanceMode(ctx, enable)
 	if err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		httpError(w, err)
 		return
 	}
 
 	if err := httpResponse(w, http.StatusOK, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 
 }
@@ -71,7 +72,7 @@ func (h *ExportHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	err := h.ah.Export(ctx, w)
 	if err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		// since we already answered with a 200 we cannot return another error code
 		// So abort the connection and the client will detect the missing ending chunk
 		// and consider this an error
@@ -95,13 +96,13 @@ func (h *ImportHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	err := h.ah.Import(ctx, r.Body)
 	if err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 		httpError(w, err)
 		return
 	}
 
 	if err := httpResponse(w, http.StatusOK, nil); err != nil {
-		h.log.Errorf("err: %+v", err)
+		h.log.Errorf("err: %s", slog.FormatError(err))
 	}
 
 }

--- a/internal/services/runservice/readdb/readdb.go
+++ b/internal/services/runservice/readdb/readdb.go
@@ -31,6 +31,7 @@ import (
 	"agola.io/agola/internal/datamanager"
 	"agola.io/agola/internal/db"
 	"agola.io/agola/internal/etcd"
+	slog "agola.io/agola/internal/log"
 	"agola.io/agola/internal/objectstorage"
 	"agola.io/agola/internal/sequence"
 	"agola.io/agola/internal/services/runservice/common"
@@ -273,7 +274,7 @@ func (r *ReadDB) Run(ctx context.Context) error {
 			if err == nil {
 				break
 			}
-			r.log.Errorf("initialize err: %+v", err)
+			r.log.Errorf("initialize err: %s", slog.FormatError(err))
 
 			sleepCh := time.NewTimer(1 * time.Second).C
 			select {
@@ -296,7 +297,7 @@ func (r *ReadDB) Run(ctx context.Context) error {
 				r.SetInitialized(true)
 				break
 			}
-			r.log.Errorf("initialize err: %+v", err)
+			r.log.Errorf("initialize err: %s", slog.FormatError(err))
 
 			sleepCh := time.NewTimer(1 * time.Second).C
 			select {
@@ -315,7 +316,7 @@ func (r *ReadDB) Run(ctx context.Context) error {
 		go func() {
 			r.log.Infof("starting handleEvents")
 			if err := r.handleEvents(hctx); err != nil {
-				r.log.Errorf("handleEvents err: %+v", err)
+				r.log.Errorf("handleEvents err: %s", slog.FormatError(err))
 			}
 			wg.Done()
 			doneCh <- struct{}{}
@@ -324,7 +325,7 @@ func (r *ReadDB) Run(ctx context.Context) error {
 		go func() {
 			r.log.Infof("starting handleEventsOST")
 			if err := r.handleEventsOST(hctx); err != nil {
-				r.log.Errorf("handleEventsOST err: %+v", err)
+				r.log.Errorf("handleEventsOST err: %s", slog.FormatError(err))
 			}
 			wg.Done()
 			doneCh <- struct{}{}

--- a/internal/services/runservice/runservice.go
+++ b/internal/services/runservice/runservice.go
@@ -54,7 +54,7 @@ var log = logger.Sugar()
 func (s *Runservice) etcdPingerLoop(ctx context.Context) {
 	for {
 		if err := s.etcdPinger(ctx); err != nil {
-			log.Errorf("err: %+v", err)
+			log.Errorf("err: %s", slog.FormatError(err))
 		}
 
 		sleepCh := time.NewTimer(1 * time.Second).C
@@ -79,7 +79,7 @@ func (s *Runservice) maintenanceModeWatcherLoop(ctx context.Context, runCtxCance
 
 		// at first watch restart from previous processed revision
 		if err := s.maintenanceModeWatcher(ctx, runCtxCancel, maintenanceModeEnabled); err != nil {
-			log.Errorf("err: %+v", err)
+			log.Errorf("err: %s", slog.FormatError(err))
 		}
 
 		sleepCh := time.NewTimer(1 * time.Second).C
@@ -305,7 +305,7 @@ func (s *Runservice) setupMaintenanceRouter() http.Handler {
 func (s *Runservice) Run(ctx context.Context) error {
 	for {
 		if err := s.run(ctx); err != nil {
-			log.Errorf("run error: %+v", err)
+			log.Errorf("run error: %s", slog.FormatError(err))
 		}
 
 		sleepCh := time.NewTimer(1 * time.Second).C
@@ -324,7 +324,7 @@ func (s *Runservice) run(ctx context.Context) error {
 		var err error
 		tlsConfig, err = util.NewTLSConfig(s.c.Web.TLSCertFile, s.c.Web.TLSKeyFile, "", false)
 		if err != nil {
-			log.Errorf("err: %+v")
+			log.Errorf("err: %s", slog.FormatError(err))
 			return err
 		}
 	}
@@ -371,7 +371,7 @@ func (s *Runservice) run(ctx context.Context) error {
 			if err == nil {
 				break
 			}
-			log.Errorf("failed to initialize etcd: %+v", err)
+			log.Errorf("failed to initialize etcd: %s", slog.FormatError(err))
 
 			sleepCh := time.NewTimer(1 * time.Second).C
 			select {
@@ -411,11 +411,11 @@ func (s *Runservice) run(ctx context.Context) error {
 		log.Infof("runservice run exiting")
 	case err = <-lerrCh:
 		if err != nil {
-			log.Errorf("http server listen error: %v", err)
+			log.Errorf("http server listen error: %s", slog.FormatError(err))
 		}
 	case err := <-errCh:
 		if err != nil {
-			log.Errorf("error: %+v", err)
+			log.Errorf("error: %s", slog.FormatError(err))
 		}
 	}
 

--- a/internal/services/scheduler/scheduler.go
+++ b/internal/services/scheduler/scheduler.go
@@ -39,7 +39,7 @@ var log = logger.Sugar()
 func (s *Scheduler) scheduleLoop(ctx context.Context) {
 	for {
 		if err := s.schedule(ctx); err != nil {
-			log.Errorf("err: %+v", err)
+			log.Errorf("err: %s", slog.FormatError(err))
 		}
 
 		sleepCh := time.NewTimer(1 * time.Second).C
@@ -75,7 +75,7 @@ func (s *Scheduler) schedule(ctx context.Context) error {
 
 	for groupID := range groups {
 		if err := s.scheduleRun(ctx, groupID); err != nil {
-			log.Errorf("scheduler err: %v", err)
+			log.Errorf("scheduler err: %s", slog.FormatError(err))
 		}
 	}
 
@@ -103,7 +103,7 @@ func (s *Scheduler) scheduleRun(ctx context.Context, groupID string) error {
 		log.Infof("starting run %s", run.ID)
 		log.Debugf("changegroups: %s", runningRunsResponse.ChangeGroupsUpdateToken)
 		if _, err := s.runserviceClient.StartRun(ctx, run.ID, runningRunsResponse.ChangeGroupsUpdateToken); err != nil {
-			log.Errorf("failed to start run %s: %v", run.ID, err)
+			log.Errorf("failed to start run %s: %s", run.ID, slog.FormatError(err))
 		}
 	}
 
@@ -113,7 +113,7 @@ func (s *Scheduler) scheduleRun(ctx context.Context, groupID string) error {
 func (s *Scheduler) approveLoop(ctx context.Context) {
 	for {
 		if err := s.approve(ctx); err != nil {
-			log.Errorf("err: %+v", err)
+			log.Errorf("err: %s", slog.FormatError(err))
 		}
 
 		sleepCh := time.NewTimer(1 * time.Second).C
@@ -140,7 +140,7 @@ func (s *Scheduler) approve(ctx context.Context) error {
 		for _, run := range runningRunsResponse.Runs {
 			if err := s.approveRunTasks(ctx, run.ID); err != nil {
 				// just log error and continue with the other runs
-				log.Errorf("failed to approve run tasks for run %q: %+v", run.ID, err)
+				log.Errorf("failed to approve run tasks for run %q: %s", run.ID, slog.FormatError(err))
 			}
 		}
 


### PR DESCRIPTION
Add a --detailed-errors option (disabled by default).
When enabled error logging will be printed in detailed mode (multi line with
additional stack frames/stack traces and other info based on the underlying logging
library).