### PR TITLE
runservice: add tasks groups

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -88,7 +88,7 @@ func TestParseConfig(t *testing.T) {
                           containers:
                             - image: busybox
                 `,
-			err: fmt.Errorf(`task "task01" runtime: invalid arch "invalidarch"`),
+			err: fmt.Errorf(`run "run01": task "task01" runtime: invalid arch "invalidarch"`),
 		},
 		{
 			name: "test missing task dependency",
@@ -366,9 +366,11 @@ func TestParseOutput(t *testing.T) {
 								Password: Value{Type: ValueTypeFromVariable, Value: "password"},
 							},
 						},
+						TaskGroups: []*TaskGroup{{Name: defaultTaskGroup}},
 						Tasks: []*Task{
-							&Task{
-								Name: "task01",
+							{
+								Name:      "task01",
+								TaskGroup: defaultTaskGroup,
 								DockerRegistriesAuth: map[string]*DockerRegistryAuth{
 									"index.docker.io": {
 										Type:     DockerRegistryAuthTypeBasic,
@@ -380,19 +382,19 @@ func TestParseOutput(t *testing.T) {
 									Type: "pod",
 									Arch: "",
 									Containers: []*Container{
-										&Container{
+										{
 											Image: "image01",
 											Environment: map[string]Value{
-												"ENV01":             Value{Type: ValueTypeString, Value: "ENV01"},
-												"ENVFROMVARIABLE01": Value{Type: ValueTypeFromVariable, Value: "variable01"},
+												"ENV01":             {Type: ValueTypeString, Value: "ENV01"},
+												"ENVFROMVARIABLE01": {Type: ValueTypeFromVariable, Value: "variable01"},
 											},
 											User: "",
 										},
 									},
 								},
 								Environment: map[string]Value{
-									"ENV01":             Value{Type: ValueTypeString, Value: "ENV01"},
-									"ENVFROMVARIABLE01": Value{Type: ValueTypeFromVariable, Value: "variable01"},
+									"ENV01":             {Type: ValueTypeString, Value: "ENV01"},
+									"ENVFROMVARIABLE01": {Type: ValueTypeFromVariable, Value: "variable01"},
 								},
 								WorkingDir: defaultWorkingDir,
 								Shell:      "",
@@ -422,15 +424,15 @@ func TestParseOutput(t *testing.T) {
 										},
 										Command: "command03",
 										Environment: map[string]Value{
-											"ENV01":             Value{Type: ValueTypeString, Value: "ENV01"},
-											"ENVFROMVARIABLE01": Value{Type: ValueTypeFromVariable, Value: "variable01"},
+											"ENV01":             {Type: ValueTypeString, Value: "ENV01"},
+											"ENVFROMVARIABLE01": {Type: ValueTypeFromVariable, Value: "variable01"},
 										},
 										Tty: util.BoolP(true),
 									},
 									&SaveCacheStep{
 										BaseStep: BaseStep{Type: "save_cache"},
 										Key:      "cache-{{ arch }}",
-										Contents: []*SaveContent{&SaveContent{SourceDir: "/go/pkg/mod/cache", Paths: []string{"**"}}},
+										Contents: []*SaveContent{{SourceDir: "/go/pkg/mod/cache", Paths: []string{"**"}}},
 									},
 									&CloneStep{BaseStep: BaseStep{Type: "clone"}},
 									&RunStep{
@@ -456,15 +458,15 @@ func TestParseOutput(t *testing.T) {
 										},
 										Command: "command03",
 										Environment: map[string]Value{
-											"ENV01":             Value{Type: ValueTypeString, Value: "ENV01"},
-											"ENVFROMVARIABLE01": Value{Type: ValueTypeFromVariable, Value: "variable01"},
+											"ENV01":             {Type: ValueTypeString, Value: "ENV01"},
+											"ENVFROMVARIABLE01": {Type: ValueTypeFromVariable, Value: "variable01"},
 										},
 										Tty: util.BoolP(true),
 									},
 									&SaveCacheStep{
 										BaseStep: BaseStep{Type: "save_cache"},
 										Key:      "cache-{{ arch }}",
-										Contents: []*SaveContent{&SaveContent{SourceDir: "/go/pkg/mod/cache", Paths: []string{"**"}}},
+										Contents: []*SaveContent{{SourceDir: "/go/pkg/mod/cache", Paths: []string{"**"}}},
 									},
 								},
 								IgnoreFailure: false,
@@ -491,19 +493,20 @@ func TestParseOutput(t *testing.T) {
 										},
 									},
 								},
-								Depends: []*Depend{
-									&Depend{TaskName: "task02", Conditions: []DependCondition{DependConditionOnSuccess, DependConditionOnFailure}},
-									&Depend{TaskName: "task03", Conditions: nil},
-									&Depend{TaskName: "task04", Conditions: []DependCondition{DependConditionOnSuccess}},
+								Depends: []*TaskDepend{
+									{TaskName: "task02", Conditions: []DependCondition{DependConditionOnSuccess, DependConditionOnFailure}},
+									{TaskName: "task03", Conditions: nil},
+									{TaskName: "task04", Conditions: []DependCondition{DependConditionOnSuccess}},
 								},
 							},
-							&Task{
-								Name: "task02",
+							{
+								Name:      "task02",
+								TaskGroup: defaultTaskGroup,
 								Runtime: &Runtime{
 									Type: "pod",
 									Arch: "",
 									Containers: []*Container{
-										&Container{
+										{
 											Image: "image01",
 										},
 									},
@@ -512,13 +515,14 @@ func TestParseOutput(t *testing.T) {
 								Steps:      nil,
 								Depends:    nil,
 							},
-							&Task{
-								Name: "task03",
+							{
+								Name:      "task03",
+								TaskGroup: defaultTaskGroup,
 								Runtime: &Runtime{
 									Type: "pod",
 									Arch: "",
 									Containers: []*Container{
-										&Container{
+										{
 											Image:   "image01",
 											Volumes: []Volume{{Path: "/mnt/tmpfs", TmpFS: &VolumeTmpFS{Size: resource.NewQuantity(1024*1024*1024, resource.BinarySI)}}},
 										},
@@ -528,13 +532,14 @@ func TestParseOutput(t *testing.T) {
 								Steps:      nil,
 								Depends:    nil,
 							},
-							&Task{
-								Name: "task04",
+							{
+								Name:      "task04",
+								TaskGroup: defaultTaskGroup,
 								Runtime: &Runtime{
 									Type: "pod",
 									Arch: "",
 									Containers: []*Container{
-										&Container{
+										{
 											Image:   "image01",
 											Volumes: []Volume{{Path: "/mnt/tmpfs", TmpFS: &VolumeTmpFS{}}},
 										},
@@ -544,13 +549,14 @@ func TestParseOutput(t *testing.T) {
 								Steps:      nil,
 								Depends:    nil,
 							},
-							&Task{
-								Name: "task05",
+							{
+								Name:      "task05",
+								TaskGroup: defaultTaskGroup,
 								Runtime: &Runtime{
 									Type: "pod",
 									Arch: "",
 									Containers: []*Container{
-										&Container{
+										{
 											Image: "image01",
 										},
 									},

--- a/internal/services/gateway/action/run.go
+++ b/internal/services/gateway/action/run.go
@@ -518,12 +518,13 @@ func (h *ActionHandler) CreateRuns(ctx context.Context, req *CreateRunRequest) e
 		// it and know how many runs are defined
 		setupErrors = append(setupErrors, err.Error())
 		createRunReq := &rsapitypes.RunCreateRequest{
-			RunConfigTasks:    nil,
-			Group:             runGroup,
-			SetupErrors:       setupErrors,
-			Name:              rstypes.RunGenericSetupErrorName,
-			StaticEnvironment: env,
-			Annotations:       annotations,
+			RunConfigTaskGroups: nil,
+			RunConfigTasks:      nil,
+			Group:               runGroup,
+			SetupErrors:         setupErrors,
+			Name:                rstypes.RunGenericSetupErrorName,
+			StaticEnvironment:   env,
+			Annotations:         annotations,
 		}
 
 		if _, _, err := h.runserviceClient.CreateRun(ctx, createRunReq); err != nil {
@@ -544,16 +545,18 @@ func (h *ActionHandler) CreateRuns(ctx context.Context, req *CreateRunRequest) e
 			continue
 		}
 
+		rctgs := runconfig.GenRunConfigTaskGroups(util.DefaultUUIDGenerator{}, config, run.Name)
 		rcts := runconfig.GenRunConfigTasks(util.DefaultUUIDGenerator{}, config, run.Name, variables, req.RefType, req.Branch, req.Tag, req.Ref)
 
 		createRunReq := &rsapitypes.RunCreateRequest{
-			RunConfigTasks:    rcts,
-			Group:             runGroup,
-			SetupErrors:       setupErrors,
-			Name:              run.Name,
-			StaticEnvironment: env,
-			Annotations:       annotations,
-			CacheGroup:        cacheGroup,
+			RunConfigTaskGroups: rctgs,
+			RunConfigTasks:      rcts,
+			Group:               runGroup,
+			SetupErrors:         setupErrors,
+			Name:                run.Name,
+			StaticEnvironment:   env,
+			Annotations:         annotations,
+			CacheGroup:          cacheGroup,
 		}
 
 		if _, _, err := h.runserviceClient.CreateRun(ctx, createRunReq); err != nil {

--- a/internal/services/gateway/api/run.go
+++ b/internal/services/gateway/api/run.go
@@ -73,8 +73,9 @@ func createRunResponseTask(r *rstypes.Run, rt *rstypes.RunTask, rct *rstypes.Run
 		Approved:            rt.Approved,
 		ApprovalAnnotations: rt.Annotations,
 
-		Level:   rct.Level,
-		Depends: rct.Depends,
+		GlobalLevel: rct.GlobalLevel,
+		Level:       rct.Level,
+		Depends:     rct.Depends,
 	}
 
 	return t

--- a/internal/services/runservice/action/action.go
+++ b/internal/services/runservice/action/action.go
@@ -133,12 +133,13 @@ func (h *ActionHandler) StopRun(ctx context.Context, req *RunStopRequest) error 
 }
 
 type RunCreateRequest struct {
-	RunConfigTasks    map[string]*types.RunConfigTask
-	Name              string
-	Group             string
-	SetupErrors       []string
-	StaticEnvironment map[string]string
-	CacheGroup        string
+	RunConfigTaskGroups map[string]*types.RunConfigTaskGroup
+	RunConfigTasks      map[string]*types.RunConfigTask
+	Name                string
+	Group               string
+	SetupErrors         []string
+	StaticEnvironment   map[string]string
+	CacheGroup          string
 
 	// existing run fields
 	RunID      string
@@ -172,6 +173,7 @@ func (h *ActionHandler) CreateRun(ctx context.Context, req *RunCreateRequest) (*
 }
 
 func (h *ActionHandler) newRun(ctx context.Context, req *RunCreateRequest) (*types.RunBundle, error) {
+	rctgs := req.RunConfigTaskGroups
 	rcts := req.RunConfigTasks
 	setupErrors := req.SetupErrors
 
@@ -192,15 +194,15 @@ func (h *ActionHandler) newRun(ctx context.Context, req *RunCreateRequest) (*typ
 	}
 	id := seq.String()
 
-	if err := runconfig.CheckRunConfigTasks(rcts); err != nil {
-		h.log.Errorf("check run config tasks failed: %+v", err)
+	if err := runconfig.CheckRunConfig(rctgs, rcts); err != nil {
+		h.log.Errorf("check run config failed: %+v", err)
 		setupErrors = append(setupErrors, err.Error())
 	}
 
-	// generate tasks levels
+	// generate task groups and tasks levels
 	if len(setupErrors) == 0 {
-		if err := runconfig.GenTasksLevels(rcts); err != nil {
-			h.log.Errorf("gen tasks leveles failed: %+v", err)
+		if err := runconfig.GenLevels(rctgs, rcts); err != nil {
+			h.log.Errorf("gen levels failed: %+v", err)
 			setupErrors = append(setupErrors, err.Error())
 		}
 	}
@@ -210,6 +212,7 @@ func (h *ActionHandler) newRun(ctx context.Context, req *RunCreateRequest) (*typ
 		Name:              req.Name,
 		Group:             req.Group,
 		SetupErrors:       setupErrors,
+		TaskGroups:        rctgs,
 		Tasks:             rcts,
 		StaticEnvironment: req.StaticEnvironment,
 		Environment:       req.Environment,
@@ -326,7 +329,7 @@ func recreateRun(uuid util.UUIDGenerator, run *types.Run, rc *types.RunConfig, n
 	// runconfig task
 	rcTasksToRecreate := map[string]struct{}{}
 	for _, rct := range rc.Tasks {
-		parents := runconfig.GetAllParents(rc.Tasks, rct)
+		parents := runconfig.TaskAllParents(rc.Tasks, rct)
 		for _, parent := range parents {
 			if _, ok := recreatedRCTasks[parent.ID]; ok {
 				rcTasksToRecreate[rct.ID] = struct{}{}

--- a/internal/services/runservice/action/action_test.go
+++ b/internal/services/runservice/action/action_test.go
@@ -53,7 +53,7 @@ func TestRecreateRun(t *testing.T) {
 				ID:   inuuid("task02"),
 				Name: "task02",
 				Depends: map[string]*types.RunConfigTaskDepend{
-					inuuid("task01"): &types.RunConfigTaskDepend{TaskID: inuuid("task01"), Conditions: []types.RunConfigTaskDependCondition{types.RunConfigTaskDependConditionOnSuccess}},
+					inuuid("task01"): &types.RunConfigTaskDepend{TaskID: inuuid("task01"), Conditions: []types.RunConfigDependCondition{types.RunConfigDependConditionOnSuccess}},
 				},
 				Runtime: &types.Runtime{Type: types.RuntimeType("pod"),
 					Containers: []*types.Container{{Image: "image01"}},
@@ -87,8 +87,8 @@ func TestRecreateRun(t *testing.T) {
 				ID:   inuuid("task05"),
 				Name: "task05",
 				Depends: map[string]*types.RunConfigTaskDepend{
-					inuuid("task03"): &types.RunConfigTaskDepend{TaskID: inuuid("task03"), Conditions: []types.RunConfigTaskDependCondition{types.RunConfigTaskDependConditionOnSuccess}},
-					inuuid("task04"): &types.RunConfigTaskDepend{TaskID: inuuid("task04"), Conditions: []types.RunConfigTaskDependCondition{types.RunConfigTaskDependConditionOnSuccess}},
+					inuuid("task03"): &types.RunConfigTaskDepend{TaskID: inuuid("task03"), Conditions: []types.RunConfigDependCondition{types.RunConfigDependConditionOnSuccess}},
+					inuuid("task04"): &types.RunConfigTaskDepend{TaskID: inuuid("task04"), Conditions: []types.RunConfigDependCondition{types.RunConfigDependConditionOnSuccess}},
 				},
 				Runtime: &types.Runtime{Type: types.RuntimeType("pod"),
 					Containers: []*types.Container{{Image: "image01"}},
@@ -118,7 +118,7 @@ func TestRecreateRun(t *testing.T) {
 				ID:   outuuid("task02"),
 				Name: "task02",
 				Depends: map[string]*types.RunConfigTaskDepend{
-					outuuid("task01"): &types.RunConfigTaskDepend{TaskID: outuuid("task01"), Conditions: []types.RunConfigTaskDependCondition{types.RunConfigTaskDependConditionOnSuccess}},
+					outuuid("task01"): &types.RunConfigTaskDepend{TaskID: outuuid("task01"), Conditions: []types.RunConfigDependCondition{types.RunConfigDependConditionOnSuccess}},
 				},
 				Runtime: &types.Runtime{Type: types.RuntimeType("pod"),
 					Containers: []*types.Container{{Image: "image01"}},
@@ -152,8 +152,8 @@ func TestRecreateRun(t *testing.T) {
 				ID:   outuuid("task05"),
 				Name: "task05",
 				Depends: map[string]*types.RunConfigTaskDepend{
-					outuuid("task03"): &types.RunConfigTaskDepend{TaskID: outuuid("task03"), Conditions: []types.RunConfigTaskDependCondition{types.RunConfigTaskDependConditionOnSuccess}},
-					outuuid("task04"): &types.RunConfigTaskDepend{TaskID: outuuid("task04"), Conditions: []types.RunConfigTaskDependCondition{types.RunConfigTaskDependConditionOnSuccess}},
+					outuuid("task03"): &types.RunConfigTaskDepend{TaskID: outuuid("task03"), Conditions: []types.RunConfigDependCondition{types.RunConfigDependConditionOnSuccess}},
+					outuuid("task04"): &types.RunConfigTaskDepend{TaskID: outuuid("task04"), Conditions: []types.RunConfigDependCondition{types.RunConfigDependConditionOnSuccess}},
 				},
 				Runtime: &types.Runtime{Type: types.RuntimeType("pod"),
 					Containers: []*types.Container{{Image: "image01"}},

--- a/internal/services/runservice/api/api.go
+++ b/internal/services/runservice/api/api.go
@@ -641,12 +641,13 @@ func (h *RunCreateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	creq := &action.RunCreateRequest{
-		RunConfigTasks:    req.RunConfigTasks,
-		Name:              req.Name,
-		Group:             req.Group,
-		SetupErrors:       req.SetupErrors,
-		StaticEnvironment: req.StaticEnvironment,
-		CacheGroup:        req.CacheGroup,
+		RunConfigTaskGroups: req.RunConfigTaskGroups,
+		RunConfigTasks:      req.RunConfigTasks,
+		Name:                req.Name,
+		Group:               req.Group,
+		SetupErrors:         req.SetupErrors,
+		StaticEnvironment:   req.StaticEnvironment,
+		CacheGroup:          req.CacheGroup,
 
 		RunID:      req.RunID,
 		FromStart:  req.FromStart,

--- a/internal/services/runservice/common/common.go
+++ b/internal/services/runservice/common/common.go
@@ -133,16 +133,16 @@ func OSTSubGroupTypes(group string) []string {
 	return sg
 }
 
-type parentsByLevelName []*types.RunConfigTask
+type parentsByGlobalLevelName []*types.RunConfigTask
 
-func (p parentsByLevelName) Len() int { return len(p) }
-func (p parentsByLevelName) Less(i, j int) bool {
-	if p[i].Level != p[j].Level {
-		return p[i].Level < p[j].Level
+func (p parentsByGlobalLevelName) Len() int { return len(p) }
+func (p parentsByGlobalLevelName) Less(i, j int) bool {
+	if p[i].GlobalLevel != p[j].GlobalLevel {
+		return p[i].GlobalLevel < p[j].GlobalLevel
 	}
 	return p[i].Name < p[j].Name
 }
-func (p parentsByLevelName) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+func (p parentsByGlobalLevelName) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
 
 func mergeEnv(dest, src map[string]string) {
 	for k, v := range src {
@@ -186,10 +186,10 @@ func GenExecutorTaskSpecData(r *types.Run, rt *types.RunTask, rc *types.RunConfi
 	// TODO(sgotti) right now we don't support duplicated files. So it's not currently possibile to overwrite a file in a upper layer.
 	// this simplifies the workspaces extractions since they could be extracted in any order. We make them ordered just for reproducibility
 	wsops := []types.WorkspaceOperation{}
-	rctAllParents := runconfig.GetAllParents(rc.Tasks, rct)
+	rctAllParents := runconfig.TaskAllGlobalParents(rc.TaskGroups, rc.Tasks, rct)
 
 	// sort parents by level and name just for reproducibility
-	sort.Sort(parentsByLevelName(rctAllParents))
+	sort.Sort(parentsByGlobalLevelName(rctAllParents))
 
 	for _, rctParent := range rctAllParents {
 		for _, archiveStep := range r.Tasks[rctParent.ID].WorkspaceArchives {

--- a/internal/services/runservice/store/store.go
+++ b/internal/services/runservice/store/store.go
@@ -112,7 +112,6 @@ func OSTRunTaskIDFromPath(archivePath string) (string, error) {
 	if len(pl) < 2 {
 		return "", errors.Errorf("wrong archive path %q", archivePath)
 	}
-	fmt.Printf("pl: %q\n", pl)
 	if pl[0] != "workspacearchives" {
 		return "", errors.Errorf("wrong archive path %q", archivePath)
 	}

--- a/services/gateway/api/types/run.go
+++ b/services/gateway/api/types/run.go
@@ -45,8 +45,9 @@ type RunResponse struct {
 	SetupErrors []string          `json:"setup_errors"`
 	Stopping    bool              `json:"stopping"`
 
-	Tasks                map[string]*RunResponseTask `json:"tasks"`
-	TasksWaitingApproval []string                    `json:"tasks_waiting_approval"`
+	TaskGroups           map[string]*RunResponseTaskGroup `json:"task_groups"`
+	Tasks                map[string]*RunResponseTask      `json:"tasks"`
+	TasksWaitingApproval []string                         `json:"tasks_waiting_approval"`
 
 	EnqueueTime *time.Time `json:"enqueue_time"`
 	StartTime   *time.Time `json:"start_time"`
@@ -56,12 +57,20 @@ type RunResponse struct {
 	CanRestartFromFailedTasks bool `json:"can_restart_from_failed_tasks"`
 }
 
+type RunResponseTaskGroup struct {
+	Name    string                                       `json:"name"`
+	Level   int                                          `json:"level"`
+	Depends map[string]*rstypes.RunConfigTaskGroupDepend `json:"depends"`
+}
+
 type RunResponseTask struct {
-	ID      string                                  `json:"id"`
-	Name    string                                  `json:"name"`
-	Status  rstypes.RunTaskStatus                   `json:"status"`
-	Level   int                                     `json:"level"`
-	Depends map[string]*rstypes.RunConfigTaskDepend `json:"depends"`
+	ID          string                                  `json:"id"`
+	TaskGroup   string                                  `json:"task_group"`
+	Name        string                                  `json:"name"`
+	Status      rstypes.RunTaskStatus                   `json:"status"`
+	GlobalLevel int                                     `json:"global_level"`
+	Level       int                                     `json:"level"`
+	Depends     map[string]*rstypes.RunConfigTaskDepend `json:"depends"`
 
 	WaitingApproval     bool              `json:"waiting_approval"`
 	Approved            bool              `json:"approved"`
@@ -72,9 +81,10 @@ type RunResponseTask struct {
 }
 
 type RunTaskResponse struct {
-	ID     string                `json:"id"`
-	Name   string                `json:"name"`
-	Status rstypes.RunTaskStatus `json:"status"`
+	ID        string                `json:"id"`
+	TaskGroup string                `json:"task_group"`
+	Name      string                `json:"name"`
+	Status    rstypes.RunTaskStatus `json:"status"`
 
 	WaitingApproval     bool              `json:"waiting_approval"`
 	Approved            bool              `json:"approved"`

--- a/services/runservice/api/types/run.go
+++ b/services/runservice/api/types/run.go
@@ -31,12 +31,13 @@ type GetRunsResponse struct {
 
 type RunCreateRequest struct {
 	// new run fields
-	RunConfigTasks    map[string]*rstypes.RunConfigTask `json:"run_config_tasks"`
-	Name              string                            `json:"name"`
-	Group             string                            `json:"group"`
-	SetupErrors       []string                          `json:"setup_errors"`
-	StaticEnvironment map[string]string                 `json:"static_environment"`
-	CacheGroup        string                            `json:"cache_group"`
+	RunConfigTaskGroups map[string]*rstypes.RunConfigTaskGroup `json:"run_config_task_groups"`
+	RunConfigTasks      map[string]*rstypes.RunConfigTask      `json:"run_config_tasks"`
+	Name                string                                 `json:"name"`
+	Group               string                                 `json:"group"`
+	SetupErrors         []string                               `json:"setup_errors"`
+	StaticEnvironment   map[string]string                      `json:"static_environment"`
+	CacheGroup          string                                 `json:"cache_group"`
 
 	// existing run fields
 	RunID      string   `json:"run_id"`


### PR DESCRIPTION
Task groups permit to group tasks together. Like tasks they can depend on each
other. A task group is finished when all the tasks inside a task group are
finished. This is required since we want to have reproducible workspaces.
A child task group will start when all the parent task groups are finished.

When a task in a child task group restores a workspace, it'll consider all the
tasks in parent task groups as a dependency of the parent task in this task
group.