### PR TITLE
example: fix gitserverURL in example config

### DIFF
--- a/examples/agolademo/config.yml
+++ b/examples/agolademo/config.yml
@@ -3,7 +3,7 @@ gateway:
   webExposedURL: "http://172.17.0.1:8000"
   runserviceURL: "http://localhost:4000"
   configstoreURL: "http://localhost:4002"
-  gitserverURL: "http://172.17.0.1:4003"
+  gitserverURL: "http://localhost:4003"
 
   web:
     listenAddress: ":8000"


### PR DESCRIPTION
The git server needs to be accessed on localhost from the gateway and not from
the host's docker bridge address.