### PR TITLE
executor/docker: pull init image only when needed

### DIFF
--- a/internal/services/executor/registry/registry.go
+++ b/internal/services/executor/registry/registry.go
@@ -76,6 +76,14 @@ var (
 	}
 )
 
+func GetImageTagOrDigest(image string) (string, error) {
+	ref, err := name.ParseReference(image, name.WeakValidation)
+	if err != nil {
+		return "", err
+	}
+	return ref.Identifier(), nil
+}
+
 func GetRegistry(image string) (string, error) {
 	ref, err := name.ParseReference(image, name.WeakValidation)
 	if err != nil {


### PR DESCRIPTION
Use the same logic of k8s and pull init image only when has the latest (or
empty) tag or it doesn't exist.