### PR TITLE
executor: use busybox:stable as default init image

### DIFF
--- a/internal/services/config/config.go
+++ b/internal/services/config/config.go
@@ -235,7 +235,7 @@ var defaultConfig = Config{
 	},
 	Executor: Executor{
 		InitImage: InitImage{
-			Image: "busybox",
+			Image: "busybox:stable",
 		},
 		ActiveTasksLimit: 2,
 	},

--- a/internal/services/executor/driver/docker_test.go
+++ b/internal/services/executor/driver/docker_test.go
@@ -42,7 +42,7 @@ func TestDockerPod(t *testing.T) {
 
 	logger := zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel))
 
-	initImage := "busybox"
+	initImage := "busybox:stable"
 
 	d, err := NewDockerDriver(logger, "executorid01", toolboxPath, initImage)
 	if err != nil {

--- a/internal/services/executor/driver/k8s_test.go
+++ b/internal/services/executor/driver/k8s_test.go
@@ -41,7 +41,7 @@ func TestK8sPod(t *testing.T) {
 
 	logger := zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel))
 
-	initImage := "busybox"
+	initImage := "busybox:stable"
 
 	d, err := NewK8sDriver(logger, "executorid01", toolboxPath, initImage)
 	if err != nil {

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -265,7 +265,7 @@ func setup(ctx context.Context, t *testing.T, dir string) (*testutil.TestEmbedde
 			Labels:           map[string]string{},
 			ActiveTasksLimit: 2,
 			InitImage: config.InitImage{
-				Image: "busybox",
+				Image: "busybox:stable",
 			},
 		},
 		Configstore: config.Configstore{


### PR DESCRIPTION
Use "busybox:stable" as default init image name so it won't be checked/pulled
any time.