### PR TITLE
*: implement org member adding modes: direct or invitation

### DIFF
--- a/internal/services/configstore/action/org.go
+++ b/internal/services/configstore/action/org.go
@@ -21,6 +21,7 @@ import (
 	"agola.io/agola/internal/services/configstore/db"
 	"agola.io/agola/internal/sql"
 	"agola.io/agola/internal/util"
+	csapitypes "agola.io/agola/services/configstore/api/types"
 	"agola.io/agola/services/configstore/types"
 )
 
@@ -195,7 +196,41 @@ func (h *ActionHandler) DeleteOrg(ctx context.Context, orgRef string) error {
 			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("org %q doesn't exist", orgRef))
 		}
 
-		// TODO(sgotti) delete all project groups, projects etc...
+		orgInvitations, err := h.d.GetOrgInvitations(tx, org.ID)
+		if err != nil {
+			return util.NewAPIError(util.KindFromRemoteError(err), err)
+		}
+		for _, invitation := range orgInvitations {
+			err = h.d.DeleteOrgInvitation(tx, invitation.ID)
+			if err != nil {
+				return util.NewAPIError(util.KindFromRemoteError(err), err)
+			}
+		}
+
+		// delete all projects and groups
+		subgroups, err := h.getAllProjectGroupSubgroups(tx, "org/"+org.Name)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		for _, subgroup := range subgroups {
+			projects, err := h.d.GetProjectGroupProjects(tx, subgroup.ID)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+
+			for _, project := range projects {
+				err = h.d.DeleteProject(tx, project.ID)
+				if err != nil {
+					return errors.WithStack(err)
+				}
+			}
+
+			err = h.d.DeleteProjectGroup(tx, subgroup.ID)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+		}
+
 		if err := h.d.DeleteOrganization(tx, org.ID); err != nil {
 			return errors.WithStack(err)
 		}
@@ -258,6 +293,18 @@ func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string
 			return errors.WithStack(err)
 		}
 
+		//delete org user invitation if exists
+		orgInvitation, err := h.d.GetOrgInvitationByOrgUserID(tx, org.ID, user.ID)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if orgInvitation != nil {
+			err = h.d.DeleteOrgInvitation(tx, orgInvitation.ID)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+		}
+
 		return nil
 	})
 	if err != nil {
@@ -307,4 +354,229 @@ func (h *ActionHandler) RemoveOrgMember(ctx context.Context, orgRef, userRef str
 	}
 
 	return errors.WithStack(err)
+}
+
+func (h *ActionHandler) GetOrgInvitations(ctx context.Context, orgRef string) ([]*types.OrgInvitation, error) {
+	var orgInvitations []*types.OrgInvitation
+	err := h.d.Do(ctx, func(tx *sql.Tx) error {
+		org, err := h.d.GetOrg(tx, orgRef)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if org == nil {
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("org %q doesn't exist", orgRef))
+		}
+
+		orgInvitations, err = h.d.GetOrgInvitations(tx, org.ID)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		return errors.WithStack(err)
+	})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return orgInvitations, errors.WithStack(err)
+}
+
+func (h *ActionHandler) GetOrgInvitationByUserRef(ctx context.Context, orgRef, userRef string) (*types.OrgInvitation, error) {
+	var orgInvitation *types.OrgInvitation
+	err := h.d.Do(ctx, func(tx *sql.Tx) error {
+		// check existing org
+		org, err := h.d.GetOrg(tx, orgRef)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if org == nil {
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("organization %q doesn't exist", orgRef))
+		}
+		// check existing user
+		user, err := h.d.GetUser(tx, userRef)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if user == nil {
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exists", userRef))
+		}
+
+		orgInvitation, err = h.d.GetOrgInvitationByOrgUserID(tx, org.ID, user.ID)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		return errors.WithStack(err)
+	})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return orgInvitation, nil
+}
+
+type CreateOrgInvitationRequest struct {
+	UserRef         string
+	OrganizationRef string
+	Role            types.MemberRole
+}
+
+func (h *ActionHandler) CreateOrgInvitation(ctx context.Context, req *CreateOrgInvitationRequest) (*types.OrgInvitation, error) {
+	if req.OrganizationRef == "" {
+		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("organization ref required"))
+	}
+	if req.UserRef == "" {
+		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user ref required"))
+	}
+	if !types.IsValidMemberRole(req.Role) {
+		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid role"))
+	}
+
+	var orgInvitation *types.OrgInvitation
+	err := h.d.Do(ctx, func(tx *sql.Tx) error {
+		var err error
+
+		org, err := h.d.GetOrg(tx, req.OrganizationRef)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if org == nil {
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("organization %q doesn't exist", req.OrganizationRef))
+		}
+
+		user, err := h.d.GetUser(tx, req.UserRef)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if user == nil {
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exist", req.UserRef))
+		}
+
+		// check duplicate org invitation
+		curOrgInvitation, err := h.d.GetOrgInvitationByOrgUserID(tx, org.ID, user.ID)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if curOrgInvitation != nil {
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invitation already exists"))
+		}
+
+		orgInvitation = types.NewOrgInvitation()
+		orgInvitation.UserID = user.ID
+		orgInvitation.OrganizationID = org.ID
+		orgInvitation.Role = req.Role
+
+		if err := h.d.InsertOrgInvitation(tx, orgInvitation); err != nil {
+			return errors.WithStack(err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return orgInvitation, errors.WithStack(err)
+}
+
+func (h *ActionHandler) DeleteOrgInvitation(ctx context.Context, orgRef string, userRef string) error {
+	err := h.d.Do(ctx, func(tx *sql.Tx) error {
+		org, err := h.d.GetOrg(tx, orgRef)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if org == nil {
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("org %q doesn't exists", orgRef))
+		}
+		// check existing user
+		user, err := h.d.GetUser(tx, userRef)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if user == nil {
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exists", userRef))
+		}
+
+		// check org invitation exists
+		orgInvitation, err := h.d.GetOrgInvitationByOrgUserID(tx, org.ID, user.ID)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if orgInvitation == nil {
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invitation for org %q, user %q doesn't exists", orgRef, userRef))
+		}
+
+		if err := h.d.DeleteOrgInvitation(tx, orgInvitation.ID); err != nil {
+			return errors.WithStack(err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return errors.WithStack(err)
+}
+
+type OrgInvitationActionRequest struct {
+	OrgRef  string
+	UserRef string
+	Action  csapitypes.OrgInvitationActionType
+}
+
+func (h *ActionHandler) OrgInvitationAction(ctx context.Context, req *OrgInvitationActionRequest) error {
+	if !req.Action.IsValid() {
+		return errors.Errorf("action is not valid")
+	}
+
+	err := h.d.Do(ctx, func(tx *sql.Tx) error {
+		org, err := h.d.GetOrg(tx, req.OrgRef)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if org == nil {
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("org %q doesn't exists", req.OrgRef))
+		}
+		// check existing user
+		user, err := h.d.GetUser(tx, req.UserRef)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if user == nil {
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exists", req.UserRef))
+		}
+
+		// check org invitation exists
+		orgInvitation, err := h.d.GetOrgInvitationByOrgUserID(tx, org.ID, user.ID)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if orgInvitation == nil {
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invitation for org %q, user %q doesn't exists", req.OrgRef, req.UserRef))
+		}
+
+		if req.Action == csapitypes.Accept {
+			orgMember := types.NewOrganizationMember()
+			orgMember.OrganizationID = orgInvitation.OrganizationID
+			orgMember.UserID = orgInvitation.UserID
+			orgMember.MemberRole = orgInvitation.Role
+
+			err = h.d.InsertOrganizationMember(tx, orgMember)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+		}
+		err = h.d.DeleteOrgInvitation(tx, orgInvitation.ID)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
 }

--- a/internal/services/configstore/api/user.go
+++ b/internal/services/configstore/api/user.go
@@ -537,3 +537,28 @@ func (h *UserOrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.log.Err(err).Send()
 	}
 }
+
+type UserOrgInvitationsHandler struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewUserOrgInvitationsHandler(log zerolog.Logger, ah *action.ActionHandler) *UserOrgInvitationsHandler {
+	return &UserOrgInvitationsHandler{log: log, ah: ah}
+}
+
+func (h *UserOrgInvitationsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	vars := mux.Vars(r)
+	userRef := vars["userref"]
+
+	userOrgInvitations, err := h.ah.GetUserOrgInvitations(ctx, userRef)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+
+	if err := util.HTTPResponse(w, http.StatusOK, userOrgInvitations); err != nil {
+		h.log.Err(err).Send()
+	}
+}

--- a/internal/services/configstore/configstore.go
+++ b/internal/services/configstore/configstore.go
@@ -163,6 +163,8 @@ func (s *Configstore) setupDefaultRouter() http.Handler {
 	createUserHandler := api.NewCreateUserHandler(s.log, s.ah)
 	updateUserHandler := api.NewUpdateUserHandler(s.log, s.ah)
 	deleteUserHandler := api.NewDeleteUserHandler(s.log, s.ah)
+	userOrgInvitationsHandler := api.NewUserOrgInvitationsHandler(s.log, s.ah)
+	userOrgInvitationActionHandler := api.NewOrgInvitationActionHandler(s.log, s.ah)
 
 	userLinkedAccountsHandler := api.NewUserLinkedAccountsHandler(s.log, s.ah)
 	createUserLAHandler := api.NewCreateUserLAHandler(s.log, s.ah)
@@ -180,6 +182,7 @@ func (s *Configstore) setupDefaultRouter() http.Handler {
 	createOrgHandler := api.NewCreateOrgHandler(s.log, s.ah)
 	updateOrgHandler := api.NewUpdateOrgHandler(s.log, s.ah)
 	deleteOrgHandler := api.NewDeleteOrgHandler(s.log, s.ah)
+	orgInvitationsHandler := api.NewOrgInvitationsHandler(s.log, s.ah)
 
 	orgMembersHandler := api.NewOrgMembersHandler(s.log, s.ah)
 	addOrgMemberHandler := api.NewAddOrgMemberHandler(s.log, s.ah)
@@ -190,6 +193,10 @@ func (s *Configstore) setupDefaultRouter() http.Handler {
 	createRemoteSourceHandler := api.NewCreateRemoteSourceHandler(s.log, s.ah)
 	updateRemoteSourceHandler := api.NewUpdateRemoteSourceHandler(s.log, s.ah)
 	deleteRemoteSourceHandler := api.NewDeleteRemoteSourceHandler(s.log, s.ah)
+
+	createOrgInvitationHandler := api.NewCreateOrgInvitationHandler(s.log, s.ah)
+	deleteOrgInvitationHandler := api.NewDeleteOrgInvitationHandler(s.log, s.ah)
+	orgInvitationHandler := api.NewOrgInvitationHandler(s.log, s.ah)
 
 	router := mux.NewRouter()
 	apirouter := router.PathPrefix("/api/v1alpha").Subrouter().UseEncodedPath()
@@ -229,6 +236,7 @@ func (s *Configstore) setupDefaultRouter() http.Handler {
 	apirouter.Handle("/users", createUserHandler).Methods("POST")
 	apirouter.Handle("/users/{userref}", updateUserHandler).Methods("PUT")
 	apirouter.Handle("/users/{userref}", deleteUserHandler).Methods("DELETE")
+	apirouter.Handle("/users/{userref}/org_invitations", userOrgInvitationsHandler).Methods("GET")
 
 	apirouter.Handle("/users/{userref}/linkedaccounts", userLinkedAccountsHandler).Methods("GET")
 	apirouter.Handle("/users/{userref}/linkedaccounts", createUserLAHandler).Methods("POST")
@@ -248,6 +256,11 @@ func (s *Configstore) setupDefaultRouter() http.Handler {
 	apirouter.Handle("/orgs/{orgref}/members", orgMembersHandler).Methods("GET")
 	apirouter.Handle("/orgs/{orgref}/members/{userref}", addOrgMemberHandler).Methods("PUT")
 	apirouter.Handle("/orgs/{orgref}/members/{userref}", removeOrgMemberHandler).Methods("DELETE")
+	apirouter.Handle("/orgs/{orgref}/invitations", orgInvitationsHandler).Methods("GET")
+	apirouter.Handle("/orgs/{orgref}/invitations", createOrgInvitationHandler).Methods("POST")
+	apirouter.Handle("/orgs/{orgref}/invitations/{userref}", orgInvitationHandler).Methods("GET")
+	apirouter.Handle("/orgs/{orgref}/invitations/{userref}", deleteOrgInvitationHandler).Methods("DELETE")
+	apirouter.Handle("/orgs/{orgref}/invitations/{userref}/actions", userOrgInvitationActionHandler).Methods("PUT")
 
 	apirouter.Handle("/remotesources/{remotesourceref}", remoteSourceHandler).Methods("GET")
 	apirouter.Handle("/remotesources", remoteSourcesHandler).Methods("GET")

--- a/internal/services/configstore/db/objects/objects.go
+++ b/internal/services/configstore/db/objects/objects.go
@@ -15,4 +15,5 @@ var ObjectsInfo = []idb.ObjectInfo{
 	{Name: "Project", Table: "project"},
 	{Name: "Secret", Table: "secret"},
 	{Name: "Variable", Table: "variable"},
+	{Name: "OrgInvitation", Table: "orginvitation"},
 }

--- a/internal/services/gateway/action/action.go
+++ b/internal/services/gateway/action/action.go
@@ -23,23 +23,32 @@ import (
 )
 
 type ActionHandler struct {
-	log               zerolog.Logger
-	sd                *common.TokenSigningData
-	configstoreClient *csclient.Client
-	runserviceClient  *rsclient.Client
-	agolaID           string
-	apiExposedURL     string
-	webExposedURL     string
+	log                          zerolog.Logger
+	sd                           *common.TokenSigningData
+	configstoreClient            *csclient.Client
+	runserviceClient             *rsclient.Client
+	agolaID                      string
+	apiExposedURL                string
+	webExposedURL                string
+	organizationMemberAddingMode OrganizationMemberAddingMode
 }
 
-func NewActionHandler(log zerolog.Logger, sd *common.TokenSigningData, configstoreClient *csclient.Client, runserviceClient *rsclient.Client, agolaID, apiExposedURL, webExposedURL string) *ActionHandler {
+type OrganizationMemberAddingMode string
+
+const (
+	OrganizationMemberAddingModeDirect     OrganizationMemberAddingMode = "direct"
+	OrganizationMemberAddingModeInvitation OrganizationMemberAddingMode = "invitation"
+)
+
+func NewActionHandler(log zerolog.Logger, sd *common.TokenSigningData, configstoreClient *csclient.Client, runserviceClient *rsclient.Client, agolaID, apiExposedURL, webExposedURL string, organizationMemberAddingMode OrganizationMemberAddingMode) *ActionHandler {
 	return &ActionHandler{
-		log:               log,
-		sd:                sd,
-		configstoreClient: configstoreClient,
-		runserviceClient:  runserviceClient,
-		agolaID:           agolaID,
-		apiExposedURL:     apiExposedURL,
-		webExposedURL:     webExposedURL,
+		log:                          log,
+		sd:                           sd,
+		configstoreClient:            configstoreClient,
+		runserviceClient:             runserviceClient,
+		agolaID:                      agolaID,
+		apiExposedURL:                apiExposedURL,
+		webExposedURL:                webExposedURL,
+		organizationMemberAddingMode: organizationMemberAddingMode,
 	}
 }

--- a/internal/services/gateway/action/auth.go
+++ b/internal/services/gateway/action/auth.go
@@ -220,3 +220,22 @@ func (h *ActionHandler) CanDoRunActions(ctx context.Context, groupType scommon.G
 	}
 	return true, refID, nil
 }
+
+func (h *ActionHandler) IsOrgMember(ctx context.Context, userRef, orgRef string) (bool, error) {
+	user, err := h.GetUser(ctx, userRef)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to get user %s:", userRef)
+	}
+
+	orgMembers, err := h.GetOrgMembers(ctx, orgRef)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to get org %s members:", orgRef)
+	}
+	for _, member := range orgMembers.Members {
+		if member.User.ID == user.ID {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/internal/services/gateway/action/user.go
+++ b/internal/services/gateway/action/user.go
@@ -1027,3 +1027,25 @@ func (h *ActionHandler) GetUserGitSource(ctx context.Context, remoteSourceRef, u
 
 	return gitSource, rs, la, nil
 }
+
+func (h *ActionHandler) GetUserOrgInvitations(ctx context.Context, userRef string, limit int) ([]*OrgInvitationResponse, error) {
+	cOrgInvitations, _, err := h.configstoreClient.GetUserOrgInvitations(ctx, userRef, limit)
+	if err != nil {
+		return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
+	}
+
+	res := make([]*OrgInvitationResponse, len(cOrgInvitations))
+	for i, r := range cOrgInvitations {
+		org, _, err := h.configstoreClient.GetOrg(ctx, r.OrganizationID)
+		if err != nil {
+			return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
+		}
+
+		res[i] = &OrgInvitationResponse{
+			OrgInvitation: r,
+			Organization:  org,
+		}
+	}
+
+	return res, nil
+}

--- a/internal/services/gateway/api/org.go
+++ b/internal/services/gateway/api/org.go
@@ -339,3 +339,190 @@ func (h *RemoveOrgMemberHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		h.log.Err(err).Send()
 	}
 }
+
+type CreateOrgInvitationHandler struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewCreateOrgInvitationHandler(log zerolog.Logger, ah *action.ActionHandler) *CreateOrgInvitationHandler {
+	return &CreateOrgInvitationHandler{log: log, ah: ah}
+}
+
+func (h *CreateOrgInvitationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	vars := mux.Vars(r)
+	orgRef := vars["orgref"]
+
+	var req gwapitypes.CreateOrgInvitationRequest
+	d := json.NewDecoder(r.Body)
+	if err := d.Decode(&req); err != nil {
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		return
+	}
+
+	creq := &action.CreateOrgInvitationRequest{
+		UserRef:         req.UserRef,
+		OrganizationRef: orgRef,
+		Role:            req.Role,
+	}
+
+	cOrgInvitation, err := h.ah.CreateOrgInvitation(ctx, creq)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+
+	res := createOrgInvitationResponse(cOrgInvitation.OrgInvitation, cOrgInvitation.Organization)
+	if err := util.HTTPResponse(w, http.StatusCreated, res); err != nil {
+		h.log.Err(err).Send()
+	}
+}
+
+type OrgInvitationsHandler struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewOrgInvitationsHandler(log zerolog.Logger, ah *action.ActionHandler) *OrgInvitationsHandler {
+	return &OrgInvitationsHandler{log: log, ah: ah}
+}
+
+func (h *OrgInvitationsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	vars := mux.Vars(r)
+	query := r.URL.Query()
+
+	orgRef := vars["orgref"]
+
+	limitS := query.Get("limit")
+	limit := DefaultRunsLimit
+	if limitS != "" {
+		var err error
+		limit, err = strconv.Atoi(limitS)
+		if err != nil {
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse limit")))
+			return
+		}
+	}
+	if limit < 0 {
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("limit must be greater or equal than 0")))
+		return
+	}
+	if limit > MaxOrgInvitationsLimit {
+		limit = MaxOrgInvitationsLimit
+	}
+
+	orgInvitations, err := h.ah.GetOrgInvitations(ctx, orgRef, limit)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+
+	if err := util.HTTPResponse(w, http.StatusOK, orgInvitations); err != nil {
+		h.log.Err(err).Send()
+	}
+}
+
+type OrgInvitationHandler struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewOrgInvitationHandler(log zerolog.Logger, ah *action.ActionHandler) *OrgInvitationHandler {
+	return &OrgInvitationHandler{log: log, ah: ah}
+}
+
+func (h *OrgInvitationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	vars := mux.Vars(r)
+	orgRef := vars["orgref"]
+	userRef := vars["userref"]
+
+	orgInvitation, err := h.ah.GetOrgInvitation(ctx, orgRef, userRef)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+
+	resp := createOrgInvitationResponse(orgInvitation.OrgInvitation, orgInvitation.Organization)
+	if err := util.HTTPResponse(w, http.StatusOK, resp); err != nil {
+		h.log.Err(err).Send()
+	}
+}
+
+type UserOrgInvitationActionHandler struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewUserOrgInvitationActionHandler(log zerolog.Logger, ah *action.ActionHandler) *UserOrgInvitationActionHandler {
+	return &UserOrgInvitationActionHandler{log: log, ah: ah}
+}
+
+func (h *UserOrgInvitationActionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	vars := mux.Vars(r)
+	orgRef := vars["orgref"]
+
+	var req gwapitypes.OrgInvitationActionRequest
+	d := json.NewDecoder(r.Body)
+	if err := d.Decode(&req); err != nil {
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		return
+	}
+
+	areq := &action.OrgInvitationActionRequest{
+		OrgRef: orgRef,
+		Action: req.Action,
+	}
+	err := h.ah.OrgInvitationAction(ctx, areq)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+
+	if err := util.HTTPResponse(w, http.StatusOK, nil); err != nil {
+		h.log.Err(err).Send()
+	}
+}
+
+type DeleteOrgInvitationHandler struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewDeleteOrgInvitationHandler(log zerolog.Logger, ah *action.ActionHandler) *DeleteOrgInvitationHandler {
+	return &DeleteOrgInvitationHandler{log: log, ah: ah}
+}
+
+func (h *DeleteOrgInvitationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	vars := mux.Vars(r)
+	orgRef := vars["orgref"]
+	userRef := vars["userref"]
+
+	err := h.ah.DeleteOrgInvitation(ctx, orgRef, userRef)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
+		h.log.Err(err).Send()
+	}
+}
+
+const (
+	DefaultOrgInvitationsLimit = 25
+	MaxOrgInvitationsLimit     = 40
+)
+
+func createOrgInvitationResponse(orgInvitation *cstypes.OrgInvitation, org *cstypes.Organization) *gwapitypes.OrgInvitationResponse {
+	return &gwapitypes.OrgInvitationResponse{
+		ID:               orgInvitation.ID,
+		UserID:           orgInvitation.UserID,
+		OrganizationID:   org.ID,
+		OrganizationName: org.Name,
+	}
+}

--- a/services/configstore/api/types/invitation.go
+++ b/services/configstore/api/types/invitation.go
@@ -1,0 +1,44 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import cstypes "agola.io/agola/services/configstore/types"
+
+type CreateOrgInvitationRequest struct {
+	UserRef string
+	Role    cstypes.MemberRole
+}
+
+type OrgInvitationActionRequest struct {
+	Action OrgInvitationActionType `json:"action_type"`
+}
+
+type OrgInvitationActionType string
+
+const (
+	Accept OrgInvitationActionType = "accept"
+	Reject OrgInvitationActionType = "reject"
+)
+
+func (a OrgInvitationActionType) IsValid() bool {
+	switch a {
+	case Accept:
+	case Reject:
+	default:
+		return false
+	}
+
+	return true
+}

--- a/services/configstore/types/invitation.go
+++ b/services/configstore/types/invitation.go
@@ -1,0 +1,46 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	stypes "agola.io/agola/services/types"
+	"github.com/gofrs/uuid"
+)
+
+const (
+	OrgInvitationKind    = "orginvitation"
+	OrgInvitationVersion = "v0.1.0"
+)
+
+type OrgInvitation struct {
+	stypes.TypeMeta
+	stypes.ObjectMeta
+
+	UserID         string     `json:"userId,omitempty"`
+	OrganizationID string     `json:"organizationId,omitempty"`
+	Role           MemberRole `json:"role,omitempty"`
+}
+
+func NewOrgInvitation() *OrgInvitation {
+	return &OrgInvitation{
+		TypeMeta: stypes.TypeMeta{
+			Kind:    OrgInvitationKind,
+			Version: OrgInvitationVersion,
+		},
+		ObjectMeta: stypes.ObjectMeta{
+			ID: uuid.Must(uuid.NewV4()).String(),
+		},
+	}
+}

--- a/services/configstore/types/types.go
+++ b/services/configstore/types/types.go
@@ -17,14 +17,15 @@ package types
 type ObjectKind string
 
 const (
-	ObjectKindUser         ObjectKind = "user"
-	ObjectKindOrg          ObjectKind = "org"
-	ObjectKindOrgMember    ObjectKind = "orgmember"
-	ObjectKindProjectGroup ObjectKind = "projectgroup"
-	ObjectKindProject      ObjectKind = "project"
-	ObjectKindRemoteSource ObjectKind = "remotesource"
-	ObjectKindSecret       ObjectKind = "secret"
-	ObjectKindVariable     ObjectKind = "variable"
+	ObjectKindUser          ObjectKind = "user"
+	ObjectKindOrg           ObjectKind = "org"
+	ObjectKindOrgMember     ObjectKind = "orgmember"
+	ObjectKindProjectGroup  ObjectKind = "projectgroup"
+	ObjectKindProject       ObjectKind = "project"
+	ObjectKindRemoteSource  ObjectKind = "remotesource"
+	ObjectKindSecret        ObjectKind = "secret"
+	ObjectKindVariable      ObjectKind = "variable"
+	ObjectKindOrgInvitation ObjectKind = "orginvitation"
 )
 
 type Visibility string

--- a/services/gateway/api/types/invitation.go
+++ b/services/gateway/api/types/invitation.go
@@ -1,0 +1,36 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	csapitypes "agola.io/agola/services/configstore/api/types"
+	"agola.io/agola/services/configstore/types"
+)
+
+type CreateOrgInvitationRequest struct {
+	UserRef string           `json:"user_ref"`
+	Role    types.MemberRole `json:"role"`
+}
+
+type OrgInvitationResponse struct {
+	ID               string `json:"id"`
+	UserID           string `json:"user_ref"`
+	OrganizationID   string `json:"organization_id"`
+	OrganizationName string `json:"organization_name"`
+}
+
+type OrgInvitationActionRequest struct {
+	Action csapitypes.OrgInvitationActionType `json:"action_type"`
+}

--- a/services/gateway/client/client.go
+++ b/services/gateway/client/client.go
@@ -660,3 +660,47 @@ func (c *Client) RefreshRemoteRepo(ctx context.Context, projectRef string) (*gwa
 	resp, err := c.getParsedResponse(ctx, "POST", path.Join("/projects", url.PathEscape(projectRef), "/refreshremoterepo"), nil, jsonContent, nil, project)
 	return project, resp, err
 }
+
+func (c *Client) GetOrgInvitations(ctx context.Context, orgRef string) ([]*gwapitypes.OrgInvitationResponse, *http.Response, error) {
+	orgInvitations := []*gwapitypes.OrgInvitationResponse{}
+	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/orgs/%s/invitations", orgRef), nil, jsonContent, nil, &orgInvitations)
+	return orgInvitations, resp, errors.WithStack(err)
+}
+
+func (c *Client) GetUserOrgInvitations(ctx context.Context) ([]*gwapitypes.OrgInvitationResponse, *http.Response, error) {
+	orgInvitations := []*gwapitypes.OrgInvitationResponse{}
+	resp, err := c.getParsedResponse(ctx, "GET", "/user/org_invitations", nil, jsonContent, nil, &orgInvitations)
+	return orgInvitations, resp, errors.WithStack(err)
+}
+
+func (c *Client) GetOrgInvitation(ctx context.Context, orgRef, userRef string) (*gwapitypes.OrgInvitationResponse, *http.Response, error) {
+	orgInvitation := new(gwapitypes.OrgInvitationResponse)
+	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/orgs/%s/invitations/%s", orgRef, userRef), nil, jsonContent, nil, orgInvitation)
+	return orgInvitation, resp, errors.WithStack(err)
+}
+
+func (c *Client) CreateOrgInvitation(ctx context.Context, orgRef string, req *gwapitypes.CreateOrgInvitationRequest) (*gwapitypes.OrgInvitationResponse, *http.Response, error) {
+	reqj, err := json.Marshal(req)
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+
+	orgInvitation := new(gwapitypes.OrgInvitationResponse)
+	resp, err := c.getParsedResponse(ctx, "POST", fmt.Sprintf("/orgs/%s/invitations", orgRef), nil, jsonContent, bytes.NewReader(reqj), orgInvitation)
+	return orgInvitation, resp, errors.WithStack(err)
+}
+
+func (c *Client) DeleteOrgInvitation(ctx context.Context, orgRef string, userRef string) (*http.Response, error) {
+	resp, err := c.getResponse(ctx, "DELETE", fmt.Sprintf("/orgs/%s/invitations/%s", orgRef, userRef), nil, jsonContent, nil)
+	return resp, errors.WithStack(err)
+}
+
+func (c *Client) UserOrgInvitationAction(ctx context.Context, orgRef string, req *gwapitypes.OrgInvitationActionRequest) (*http.Response, error) {
+	reqj, err := json.Marshal(req)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	resp, err := c.getResponse(ctx, "PUT", fmt.Sprintf("/user/org_invitations/%s/actions", orgRef), nil, jsonContent, bytes.NewReader(reqj))
+	return resp, errors.WithStack(err)
+}


### PR DESCRIPTION
FIX #42

This allow users owner to create invitation to an organization.
When create an invitation is is possible to choose the user role.
If the user accept the invitation he will be added to the organization with the specified role;
if he refuse the invitation will be deleted.

Add Invitation type with the following fields:
- UserID string 
- OrganizationID string
- Role MemberRole
- CreatorUserID string
- CreatedAt time.Time

The user owner can create an invitation with api:
POST /orgs/{orgref}/invitations

An user owner can get org invitations with api:
GET /orgs/{orgref}/invitations

The current user can give the invitations wiith api:
GET /user/invitations

The current user can accept or refuse the invitation, the user owner can cancel it with api:
PUT /invitations/{invitationid}/actions

To get a specific invitation use the api:
GET /invitations/{invitationid} 

In the Gateway config I add the field enableInvitation: if false it disable invitation creation and actions.