### PR TITLE
go.mod: replace https://github.com/satori/go.uuid

### DIFF
--- a/cmd/agola/cmd/directrunstart.go
+++ b/cmd/agola/cmd/directrunstart.go
@@ -29,7 +29,7 @@ import (
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/ghodss/yaml"
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"github.com/spf13/cobra"
 	errors "golang.org/x/xerrors"
 )
@@ -163,7 +163,7 @@ func directRunStart(cmd *cobra.Command, args []string) error {
 	git := &util.Git{}
 	repoUUID, _ := git.ConfigGet(context.Background(), "agola.repouuid")
 	if repoUUID == "" {
-		repoUUID = uuid.NewV4().String()
+		repoUUID = uuid.Must(uuid.NewV4()).String()
 		if _, err := git.ConfigSet(context.Background(), "agola.repouuid", repoUUID); err != nil {
 			return fmt.Errorf("failed to set agola repo uid in git config: %v", err)
 		}
@@ -174,7 +174,7 @@ func directRunStart(cmd *cobra.Command, args []string) error {
 		AddIgnored:   directRunStartOpts.ignored,
 	})
 
-	localBranch := "gitsavebranch-" + uuid.NewV4().String()
+	localBranch := "gitsavebranch-" + uuid.Must(uuid.NewV4()).String()
 	message := "agola direct run"
 
 	commitSHA, err := gs.Save(message, localBranch)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/elazarl/go-bindata-assetfs v1.0.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v1.0.0
+	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/golang-jwt/jwt/v4 v4.0.0
 	github.com/google/go-cmp v0.4.0
 	github.com/google/go-containerregistry v0.0.0-20200212224832-c629a66d7231
@@ -26,7 +27,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/sanity-io/litter v1.2.0
-	github.com/satori/go.uuid v1.2.0
 	github.com/sgotti/gexpect v0.0.0-20210315095146-1ec64e69809b
 	github.com/spf13/cobra v0.0.5
 	github.com/xanzy/go-gitlab v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
+github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=
+github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d h1:3PaI8p3seN09VjbTYC/QWlUZdZ1qS1zGjy7LH2Wt07I=
@@ -366,7 +368,6 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sanity-io/litter v1.2.0 h1:DGJO0bxH/+C2EukzOSBmAlxmkhVMGqzvcx/rvySYw9M=
 github.com/sanity-io/litter v1.2.0/go.mod h1:JF6pZUFgu2Q0sBZ+HSV35P8TVPI1TTzEwyu9FXAw2W4=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=

--- a/internal/datamanager/data.go
+++ b/internal/datamanager/data.go
@@ -30,7 +30,7 @@ import (
 	"agola.io/agola/internal/sequence"
 	"agola.io/agola/internal/util"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	errors "golang.org/x/xerrors"
 )
 
@@ -469,7 +469,7 @@ func (d *DataManager) writeDataType(ctx context.Context, wi walIndex, dataType s
 			}
 			dataFileIndexes = append(dataFileIndexes, dataFileIndex)
 			for i, sp := range splitPoints {
-				curDataFileID := d.dataFileID(dataSequence, uuid.NewV4().String())
+				curDataFileID := d.dataFileID(dataSequence, uuid.Must(uuid.NewV4()).String())
 				if err := d.writeDataFile(ctx, &buf, sp.pos-curPos, dataFileIndexes[i], curDataFileID, dataType); err != nil {
 					return nil, err
 				}
@@ -744,7 +744,7 @@ func (d *DataManager) Import(ctx context.Context, r io.Reader) error {
 
 		err := dec.Decode(&de)
 		if err == io.EOF {
-			dataFileID := d.dataFileID(dataSequence, uuid.NewV4().String())
+			dataFileID := d.dataFileID(dataSequence, uuid.Must(uuid.NewV4()).String())
 			if err := d.writeDataFile(ctx, &buf, int64(buf.Len()), dataFileIndex, dataFileID, curDataType); err != nil {
 				return err
 			}
@@ -778,7 +778,7 @@ func (d *DataManager) Import(ctx context.Context, r io.Reader) error {
 		}
 
 		if mustWrite {
-			dataFileID := d.dataFileID(dataSequence, uuid.NewV4().String())
+			dataFileID := d.dataFileID(dataSequence, uuid.Must(uuid.NewV4()).String())
 			if err := d.writeDataFile(ctx, &buf, int64(buf.Len()), dataFileIndex, dataFileID, curDataType); err != nil {
 				return err
 			}

--- a/internal/datamanager/wal.go
+++ b/internal/datamanager/wal.go
@@ -30,7 +30,7 @@ import (
 	"agola.io/agola/internal/sequence"
 	"agola.io/agola/internal/util"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	etcdclientv3 "go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/clientv3/concurrency"
 	etcdclientv3rpc "go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
@@ -439,7 +439,7 @@ func (d *DataManager) WriteWalAdditionalOps(ctx context.Context, actions []*Acti
 	}
 	walsData.Revision = resp.Kvs[0].ModRevision
 
-	walDataFileID := uuid.NewV4().String()
+	walDataFileID := uuid.Must(uuid.NewV4()).String()
 	walDataFilePath := d.storageWalDataFile(walDataFileID)
 	walKey := etcdWalKey(walSequence.String())
 
@@ -1196,7 +1196,7 @@ func (d *DataManager) InitEtcd(ctx context.Context, dataStatus *DataStatus) erro
 		return err
 	}
 
-	walDataFileID := uuid.NewV4().String()
+	walDataFileID := uuid.Must(uuid.NewV4()).String()
 	walDataFilePath := d.storageWalDataFile(walDataFileID)
 	walKey := etcdWalKey(walSequence.String())
 

--- a/internal/git-save/save.go
+++ b/internal/git-save/save.go
@@ -21,8 +21,8 @@ import (
 	"path/filepath"
 
 	"agola.io/agola/internal/util"
-	uuid "github.com/satori/go.uuid"
 
+	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 	errors "golang.org/x/xerrors"
 )
@@ -181,7 +181,7 @@ func (s *GitSave) Save(message, branchName string) (string, error) {
 		return "", err
 	}
 
-	tmpIndexPath := filepath.Join(gitdir, "gitsave-index-"+uuid.NewV4().String())
+	tmpIndexPath := filepath.Join(gitdir, "gitsave-index-"+uuid.Must(uuid.NewV4()).String())
 	defer os.Remove(tmpIndexPath)
 
 	indexPath := filepath.Join(gitdir, gitIndexFile)

--- a/internal/services/configstore/action/org.go
+++ b/internal/services/configstore/action/org.go
@@ -26,7 +26,7 @@ import (
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/configstore/types"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	errors "golang.org/x/xerrors"
 )
 
@@ -119,7 +119,7 @@ func (h *ActionHandler) CreateOrg(ctx context.Context, org *types.Organization) 
 
 	actions := []*datamanager.Action{}
 
-	org.ID = uuid.NewV4().String()
+	org.ID = uuid.Must(uuid.NewV4()).String()
 	org.CreatedAt = time.Now()
 	orgj, err := json.Marshal(org)
 	if err != nil {
@@ -135,7 +135,7 @@ func (h *ActionHandler) CreateOrg(ctx context.Context, org *types.Organization) 
 	if org.CreatorUserID != "" {
 		// add the creator as org member with role owner
 		orgmember := &types.OrganizationMember{
-			ID:             uuid.NewV4().String(),
+			ID:             uuid.Must(uuid.NewV4()).String(),
 			OrganizationID: org.ID,
 			UserID:         org.CreatorUserID,
 			MemberRole:     types.MemberRoleOwner,
@@ -154,7 +154,7 @@ func (h *ActionHandler) CreateOrg(ctx context.Context, org *types.Organization) 
 
 	// create root org project group
 	pg := &types.ProjectGroup{
-		ID: uuid.NewV4().String(),
+		ID: uuid.Must(uuid.NewV4()).String(),
 		// use same org visibility
 		Visibility: org.Visibility,
 		Parent: types.Parent{
@@ -277,7 +277,7 @@ func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string
 		orgmember.MemberRole = role
 	} else {
 		orgmember = &types.OrganizationMember{
-			ID:             uuid.NewV4().String(),
+			ID:             uuid.Must(uuid.NewV4()).String(),
 			OrganizationID: org.ID,
 			UserID:         user.ID,
 			MemberRole:     role,

--- a/internal/services/configstore/action/project.go
+++ b/internal/services/configstore/action/project.go
@@ -24,7 +24,7 @@ import (
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/configstore/types"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	errors "golang.org/x/xerrors"
 )
 
@@ -148,11 +148,11 @@ func (h *ActionHandler) CreateProject(ctx context.Context, project *types.Projec
 		return nil, err
 	}
 
-	project.ID = uuid.NewV4().String()
+	project.ID = uuid.Must(uuid.NewV4()).String()
 	project.Parent.Type = types.ConfigTypeProjectGroup
 	// generate the Secret and the WebhookSecret
-	project.Secret = util.EncodeSha1Hex(uuid.NewV4().String())
-	project.WebhookSecret = util.EncodeSha1Hex(uuid.NewV4().String())
+	project.Secret = util.EncodeSha1Hex(uuid.Must(uuid.NewV4()).String())
+	project.WebhookSecret = util.EncodeSha1Hex(uuid.Must(uuid.NewV4()).String())
 
 	pcj, err := json.Marshal(project)
 	if err != nil {

--- a/internal/services/configstore/action/projectgroup.go
+++ b/internal/services/configstore/action/projectgroup.go
@@ -25,7 +25,7 @@ import (
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/configstore/types"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	errors "golang.org/x/xerrors"
 )
 
@@ -176,7 +176,7 @@ func (h *ActionHandler) CreateProjectGroup(ctx context.Context, projectGroup *ty
 		return nil, err
 	}
 
-	projectGroup.ID = uuid.NewV4().String()
+	projectGroup.ID = uuid.Must(uuid.NewV4()).String()
 	projectGroup.Parent.Type = types.ConfigTypeProjectGroup
 
 	pgj, err := json.Marshal(projectGroup)

--- a/internal/services/configstore/action/remotesource.go
+++ b/internal/services/configstore/action/remotesource.go
@@ -23,7 +23,7 @@ import (
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/configstore/types"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	errors "golang.org/x/xerrors"
 )
 
@@ -95,7 +95,7 @@ func (h *ActionHandler) CreateRemoteSource(ctx context.Context, remoteSource *ty
 		return nil, err
 	}
 
-	remoteSource.ID = uuid.NewV4().String()
+	remoteSource.ID = uuid.Must(uuid.NewV4()).String()
 
 	rsj, err := json.Marshal(remoteSource)
 	if err != nil {

--- a/internal/services/configstore/action/secret.go
+++ b/internal/services/configstore/action/secret.go
@@ -23,7 +23,7 @@ import (
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/configstore/types"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	errors "golang.org/x/xerrors"
 )
 
@@ -133,7 +133,7 @@ func (h *ActionHandler) CreateSecret(ctx context.Context, secret *types.Secret) 
 		return nil, err
 	}
 
-	secret.ID = uuid.NewV4().String()
+	secret.ID = uuid.Must(uuid.NewV4()).String()
 
 	secretj, err := json.Marshal(secret)
 	if err != nil {

--- a/internal/services/configstore/action/user.go
+++ b/internal/services/configstore/action/user.go
@@ -25,7 +25,7 @@ import (
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/configstore/types"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	errors "golang.org/x/xerrors"
 )
 
@@ -89,9 +89,9 @@ func (h *ActionHandler) CreateUser(ctx context.Context, req *CreateUserRequest) 
 	}
 
 	user := &types.User{
-		ID:     uuid.NewV4().String(),
+		ID:     uuid.Must(uuid.NewV4()).String(),
 		Name:   req.UserName,
-		Secret: util.EncodeSha1Hex(uuid.NewV4().String()),
+		Secret: util.EncodeSha1Hex(uuid.Must(uuid.NewV4()).String()),
 	}
 	if req.CreateUserLARequest != nil {
 		if user.LinkedAccounts == nil {
@@ -99,7 +99,7 @@ func (h *ActionHandler) CreateUser(ctx context.Context, req *CreateUserRequest) 
 		}
 
 		la := &types.LinkedAccount{
-			ID:                         uuid.NewV4().String(),
+			ID:                         uuid.Must(uuid.NewV4()).String(),
 			RemoteSourceID:             rs.ID,
 			RemoteUserID:               req.CreateUserLARequest.RemoteUserID,
 			RemoteUserName:             req.CreateUserLARequest.RemoteUserName,
@@ -119,7 +119,7 @@ func (h *ActionHandler) CreateUser(ctx context.Context, req *CreateUserRequest) 
 
 	// create root user project group
 	pg := &types.ProjectGroup{
-		ID: uuid.NewV4().String(),
+		ID: uuid.Must(uuid.NewV4()).String(),
 		// use public visibility
 		Visibility: types.VisibilityPublic,
 		Parent: types.Parent{
@@ -332,7 +332,7 @@ func (h *ActionHandler) CreateUserLA(ctx context.Context, req *CreateUserLAReque
 	}
 
 	la := &types.LinkedAccount{
-		ID:                         uuid.NewV4().String(),
+		ID:                         uuid.Must(uuid.NewV4()).String(),
 		RemoteSourceID:             rs.ID,
 		RemoteUserID:               req.RemoteUserID,
 		RemoteUserName:             req.RemoteUserName,
@@ -550,7 +550,7 @@ func (h *ActionHandler) CreateUserToken(ctx context.Context, userRef, tokenName 
 		user.Tokens = make(map[string]string)
 	}
 
-	token := util.EncodeSha1Hex(uuid.NewV4().String())
+	token := util.EncodeSha1Hex(uuid.Must(uuid.NewV4()).String())
 	user.Tokens[tokenName] = token
 
 	userj, err := json.Marshal(user)

--- a/internal/services/configstore/action/variable.go
+++ b/internal/services/configstore/action/variable.go
@@ -23,7 +23,7 @@ import (
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/configstore/types"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	errors "golang.org/x/xerrors"
 )
 
@@ -109,7 +109,7 @@ func (h *ActionHandler) CreateVariable(ctx context.Context, variable *types.Vari
 		return nil, err
 	}
 
-	variable.ID = uuid.NewV4().String()
+	variable.ID = uuid.Must(uuid.NewV4()).String()
 
 	variablej, err := json.Marshal(variable)
 	if err != nil {

--- a/internal/services/configstore/common/common.go
+++ b/internal/services/configstore/common/common.go
@@ -18,7 +18,7 @@ import (
 	"net/url"
 	"strings"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 )
 
 const (

--- a/internal/services/executor/driver/docker_test.go
+++ b/internal/services/executor/driver/docker_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/google/go-cmp/cmp"
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
@@ -57,8 +57,8 @@ func TestDockerPod(t *testing.T) {
 
 	t.Run("create a pod with one container", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
-			ID:     uuid.NewV4().String(),
-			TaskID: uuid.NewV4().String(),
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			TaskID: uuid.Must(uuid.NewV4()).String(),
 			Containers: []*ContainerConfig{
 				&ContainerConfig{
 					Cmd:   []string{"cat"},
@@ -75,8 +75,8 @@ func TestDockerPod(t *testing.T) {
 
 	t.Run("execute a command inside a pod", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
-			ID:     uuid.NewV4().String(),
-			TaskID: uuid.NewV4().String(),
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			TaskID: uuid.Must(uuid.NewV4()).String(),
 			Containers: []*ContainerConfig{
 				&ContainerConfig{
 					Cmd:   []string{"cat"},
@@ -113,8 +113,8 @@ func TestDockerPod(t *testing.T) {
 		}
 
 		pod, err := d.NewPod(ctx, &PodConfig{
-			ID:     uuid.NewV4().String(),
-			TaskID: uuid.NewV4().String(),
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			TaskID: uuid.Must(uuid.NewV4()).String(),
 			Containers: []*ContainerConfig{
 				&ContainerConfig{
 					Cmd:   []string{"cat"},
@@ -165,8 +165,8 @@ func TestDockerPod(t *testing.T) {
 
 	t.Run("create a pod with two containers", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
-			ID:     uuid.NewV4().String(),
-			TaskID: uuid.NewV4().String(),
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			TaskID: uuid.Must(uuid.NewV4()).String(),
 			Containers: []*ContainerConfig{
 				&ContainerConfig{
 					Cmd:   []string{"cat"},
@@ -186,8 +186,8 @@ func TestDockerPod(t *testing.T) {
 
 	t.Run("test communication between two containers", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
-			ID:     uuid.NewV4().String(),
-			TaskID: uuid.NewV4().String(),
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			TaskID: uuid.Must(uuid.NewV4()).String(),
 			Containers: []*ContainerConfig{
 				&ContainerConfig{
 					Cmd:   []string{"cat"},
@@ -225,8 +225,8 @@ func TestDockerPod(t *testing.T) {
 
 	t.Run("test get pods single container", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
-			ID:     uuid.NewV4().String(),
-			TaskID: uuid.NewV4().String(),
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			TaskID: uuid.Must(uuid.NewV4()).String(),
 			Containers: []*ContainerConfig{
 				&ContainerConfig{
 					Cmd:   []string{"cat"},
@@ -268,8 +268,8 @@ func TestDockerPod(t *testing.T) {
 
 	t.Run("test get pods two containers", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
-			ID:     uuid.NewV4().String(),
-			TaskID: uuid.NewV4().String(),
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			TaskID: uuid.Must(uuid.NewV4()).String(),
 			Containers: []*ContainerConfig{
 				&ContainerConfig{
 					Cmd:   []string{"cat"},
@@ -314,8 +314,8 @@ func TestDockerPod(t *testing.T) {
 
 	t.Run("test get pods with two containers and the first already deleted", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
-			ID:     uuid.NewV4().String(),
-			TaskID: uuid.NewV4().String(),
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			TaskID: uuid.Must(uuid.NewV4()).String(),
 			Containers: []*ContainerConfig{
 				&ContainerConfig{
 					Cmd:   []string{"cat"},
@@ -367,8 +367,8 @@ func TestDockerPod(t *testing.T) {
 
 	t.Run("test pod with a tmpfs volume with size limit", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
-			ID:     uuid.NewV4().String(),
-			TaskID: uuid.NewV4().String(),
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			TaskID: uuid.Must(uuid.NewV4()).String(),
 			Containers: []*ContainerConfig{
 				&ContainerConfig{
 					Cmd:   []string{"cat"},
@@ -408,8 +408,8 @@ func TestDockerPod(t *testing.T) {
 
 	t.Run("test pod with a tmpfs volume without size limit", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
-			ID:     uuid.NewV4().String(),
-			TaskID: uuid.NewV4().String(),
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			TaskID: uuid.Must(uuid.NewV4()).String(),
 			Containers: []*ContainerConfig{
 				&ContainerConfig{
 					Cmd:   []string{"cat"},
@@ -447,8 +447,8 @@ func TestDockerPod(t *testing.T) {
 
 	t.Run("test pod with two tmpfs volumes with size limit", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
-			ID:     uuid.NewV4().String(),
-			TaskID: uuid.NewV4().String(),
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			TaskID: uuid.Must(uuid.NewV4()).String(),
 			Containers: []*ContainerConfig{
 				&ContainerConfig{
 					Cmd:   []string{"cat"},
@@ -494,8 +494,8 @@ func TestDockerPod(t *testing.T) {
 
 	t.Run("test pod with two tmpfs volumes one with size limit and one without", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
-			ID:     uuid.NewV4().String(),
-			TaskID: uuid.NewV4().String(),
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			TaskID: uuid.Must(uuid.NewV4()).String(),
 			Containers: []*ContainerConfig{
 				&ContainerConfig{
 					Cmd:   []string{"cat"},

--- a/internal/services/executor/driver/k8s.go
+++ b/internal/services/executor/driver/k8s.go
@@ -31,7 +31,7 @@ import (
 	"agola.io/agola/services/types"
 
 	"github.com/docker/docker/pkg/archive"
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 	errors "golang.org/x/xerrors"
 	corev1 "k8s.io/api/core/v1"
@@ -297,7 +297,7 @@ func (d *K8sDriver) getOrCreateExecutorsGroupID(ctx context.Context) (string, er
 		return cm.Data[executorsGroupIDConfigMapKey], nil
 	}
 
-	executorsGroupID := uuid.NewV4().String()
+	executorsGroupID := uuid.Must(uuid.NewV4()).String()
 
 	cm = &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/services/executor/driver/k8s_test.go
+++ b/internal/services/executor/driver/k8s_test.go
@@ -25,7 +25,7 @@ import (
 
 	"agola.io/agola/internal/testutil"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
@@ -56,8 +56,8 @@ func TestK8sPod(t *testing.T) {
 
 	t.Run("create a pod with one container", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
-			ID:     uuid.NewV4().String(),
-			TaskID: uuid.NewV4().String(),
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			TaskID: uuid.Must(uuid.NewV4()).String(),
 			Containers: []*ContainerConfig{
 				&ContainerConfig{
 					Cmd:   []string{"cat"},
@@ -74,8 +74,8 @@ func TestK8sPod(t *testing.T) {
 
 	t.Run("execute a command inside a pod", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
-			ID:     uuid.NewV4().String(),
-			TaskID: uuid.NewV4().String(),
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			TaskID: uuid.Must(uuid.NewV4()).String(),
 			Containers: []*ContainerConfig{
 				&ContainerConfig{
 					Cmd:   []string{"cat"},
@@ -114,8 +114,8 @@ func TestK8sPod(t *testing.T) {
 		}
 
 		pod, err := d.NewPod(ctx, &PodConfig{
-			ID:     uuid.NewV4().String(),
-			TaskID: uuid.NewV4().String(),
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			TaskID: uuid.Must(uuid.NewV4()).String(),
 			Containers: []*ContainerConfig{
 				&ContainerConfig{
 					Cmd:   []string{"cat"},
@@ -166,8 +166,8 @@ func TestK8sPod(t *testing.T) {
 
 	t.Run("create a pod with two containers", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
-			ID:     uuid.NewV4().String(),
-			TaskID: uuid.NewV4().String(),
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			TaskID: uuid.Must(uuid.NewV4()).String(),
 			Containers: []*ContainerConfig{
 				&ContainerConfig{
 					Cmd:   []string{"cat"},
@@ -187,8 +187,8 @@ func TestK8sPod(t *testing.T) {
 
 	t.Run("test communication between two containers", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
-			ID:     uuid.NewV4().String(),
-			TaskID: uuid.NewV4().String(),
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			TaskID: uuid.Must(uuid.NewV4()).String(),
 			Containers: []*ContainerConfig{
 				&ContainerConfig{
 					Cmd:   []string{"cat"},
@@ -228,8 +228,8 @@ func TestK8sPod(t *testing.T) {
 
 	t.Run("test get pods", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
-			ID:     uuid.NewV4().String(),
-			TaskID: uuid.NewV4().String(),
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			TaskID: uuid.Must(uuid.NewV4()).String(),
 			Containers: []*ContainerConfig{
 				&ContainerConfig{
 					Cmd:   []string{"cat"},
@@ -261,8 +261,8 @@ func TestK8sPod(t *testing.T) {
 
 	t.Run("test pod with a tmpfs volume", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
-			ID:     uuid.NewV4().String(),
-			TaskID: uuid.NewV4().String(),
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			TaskID: uuid.Must(uuid.NewV4()).String(),
 			Containers: []*ContainerConfig{
 				&ContainerConfig{
 					Cmd:   []string{"cat"},
@@ -305,8 +305,8 @@ func TestK8sPod(t *testing.T) {
 
 	t.Run("test pod with two tmpfs volumes", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
-			ID:     uuid.NewV4().String(),
-			TaskID: uuid.NewV4().String(),
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			TaskID: uuid.Must(uuid.NewV4()).String(),
 			Containers: []*ContainerConfig{
 				&ContainerConfig{
 					Cmd:   []string{"cat"},

--- a/internal/services/executor/executor.go
+++ b/internal/services/executor/executor.go
@@ -38,8 +38,8 @@ import (
 	"agola.io/agola/internal/util"
 	rsclient "agola.io/agola/services/runservice/client"
 	"agola.io/agola/services/runservice/types"
-	uuid "github.com/satori/go.uuid"
 
+	"github.com/gofrs/uuid"
 	"github.com/gorilla/mux"
 	sockaddr "github.com/hashicorp/go-sockaddr"
 	"go.uber.org/zap"
@@ -846,7 +846,7 @@ func (e *Executor) setupTask(ctx context.Context, rt *runningTask) error {
 	podConfig := &driver.PodConfig{
 		// generate a random pod id (don't use task id for future ability to restart
 		// tasks failed to start and don't clash with existing pods)
-		ID:            uuid.NewV4().String(),
+		ID:            uuid.Must(uuid.NewV4()).String(),
 		TaskID:        et.ID,
 		Arch:          et.Spec.Arch,
 		InitVolumeDir: toolboxContainerDir,
@@ -1393,7 +1393,7 @@ func NewExecutor(ctx context.Context, l *zap.Logger, c *config.Executor) (*Execu
 		return nil, err
 	}
 	if id == "" {
-		id = uuid.NewV4().String()
+		id = uuid.Must(uuid.NewV4()).String()
 		if err := e.saveExecutorID(id); err != nil {
 			return nil, err
 		}

--- a/internal/testutil/utils.go
+++ b/internal/testutil/utils.go
@@ -36,7 +36,7 @@ import (
 	"go.etcd.io/etcd/embed"
 	"go.uber.org/zap"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"github.com/sgotti/gexpect"
 )
 
@@ -149,7 +149,7 @@ type TestEmbeddedEtcd struct {
 }
 
 func NewTestEmbeddedEtcd(t *testing.T, logger *zap.Logger, dir string, a ...string) (*TestEmbeddedEtcd, error) {
-	u := uuid.NewV4()
+	u := uuid.Must(uuid.NewV4())
 	uid := fmt.Sprintf("%x", u[:4])
 
 	dataDir := filepath.Join(dir, fmt.Sprintf("etcd%s", uid))
@@ -235,7 +235,7 @@ type TestExternalEtcd struct {
 }
 
 func NewTestExternalEtcd(t *testing.T, logger *zap.Logger, dir string, a ...string) (*TestExternalEtcd, error) {
-	u := uuid.NewV4()
+	u := uuid.Must(uuid.NewV4())
 	uid := fmt.Sprintf("%x", u[:4])
 
 	dataDir := filepath.Join(dir, fmt.Sprintf("etcd%s", uid))
@@ -448,7 +448,7 @@ type TestGitea struct {
 }
 
 func NewTestGitea(t *testing.T, dir, dockerBridgeAddress string, a ...string) (*TestGitea, error) {
-	u := uuid.NewV4()
+	u := uuid.Must(uuid.NewV4())
 	uid := fmt.Sprintf("%x", u[:4])
 
 	giteaPath := os.Getenv("GITEA_PATH")

--- a/internal/util/uuid.go
+++ b/internal/util/uuid.go
@@ -15,7 +15,7 @@
 package util
 
 import (
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 )
 
 type UUIDGenerator interface {
@@ -25,7 +25,7 @@ type UUIDGenerator interface {
 type DefaultUUIDGenerator struct{}
 
 func (u DefaultUUIDGenerator) New(s string) uuid.UUID {
-	return uuid.NewV4()
+	return uuid.Must(uuid.NewV4())
 }
 
 type TestUUIDGenerator struct{}

--- a/internal/util/validation.go
+++ b/internal/util/validation.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"regexp"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 )
 
 var nameRegexp = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9]*([-]?[a-zA-Z0-9]+)+$`)


### PR DESCRIPTION
Replace https://github.com/satori/go.uuid with maintained version at
https://github.com/gofrs/uuid

Since the new version uuid.NewV4 returns an error when failing to read
from the random source reader we use uuid.Must to panic on error since
it's considered an unrecoverable error.

In future, if needed, we could handle the error instead of panicking.