### PR TITLE
*: Improve error handling

### DIFF
--- a/internal/datamanager/datamanager.go
+++ b/internal/datamanager/datamanager.go
@@ -50,6 +50,35 @@ var (
 	ErrConcurrency = errors.New("wal concurrency error: change groups already updated")
 )
 
+type ErrNotExist struct {
+	err error
+}
+
+func newErrNotExist(err error) error {
+	return &ErrNotExist{err: err}
+}
+
+func (e *ErrNotExist) Error() string {
+	return e.err.Error()
+}
+
+func (e *ErrNotExist) Unwrap() error {
+	return e.err
+}
+
+func IsNotExist(err error) bool {
+	var e *ErrNotExist
+	return errors.As(err, &e)
+}
+
+func fromOSTError(err error) error {
+	if objectstorage.IsNotExist(err) {
+		return newErrNotExist(err)
+	}
+
+	return err
+}
+
 var (
 	// Storage paths. Always use path (not filepath) to use the "/" separator
 	storageDataDir = "data"

--- a/internal/datamanager/datamanager_test.go
+++ b/internal/datamanager/datamanager_test.go
@@ -31,7 +31,6 @@ import (
 
 	"agola.io/agola/internal/objectstorage"
 	"agola.io/agola/internal/testutil"
-	"agola.io/agola/internal/util"
 
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
@@ -559,8 +558,8 @@ func TestReadObject(t *testing.T) {
 
 	// should not exists
 	_, _, err = dm.ReadObject("datatype01", "object1", nil)
-	if !util.IsNotExist(err) {
-		t.Fatalf("expected err %v, got: %v", &util.ErrNotExist{}, err)
+	if !IsNotExist(err) {
+		t.Fatalf("expected not exist error, got: %v", err)
 	}
 	// should exist
 	_, _, err = dm.ReadObject("datatype01", "object19", nil)
@@ -583,8 +582,8 @@ func TestReadObject(t *testing.T) {
 
 	// should not exists
 	_, _, err = dm.ReadObject("datatype01", "object1", nil)
-	if !util.IsNotExist(err) {
-		t.Fatalf("expected err %v, got: %v", &util.ErrNotExist{}, err)
+	if !IsNotExist(err) {
+		t.Fatalf("expected not exist error, got: %v", err)
 	}
 	// should exist
 	_, _, err = dm.ReadObject("datatype01", "object19", nil)

--- a/internal/gitsources/agolagit/agolagit.go
+++ b/internal/gitsources/agolagit/agolagit.go
@@ -28,7 +28,7 @@ import (
 
 	gitsource "agola.io/agola/internal/gitsources"
 	"agola.io/agola/internal/services/types"
-	errors "golang.org/x/xerrors"
+	"agola.io/agola/internal/util"
 )
 
 var (
@@ -96,20 +96,8 @@ func (c *Client) getResponse(method, path string, query url.Values, header http.
 		return nil, err
 	}
 
-	if resp.StatusCode/100 != 2 {
-		defer resp.Body.Close()
-		data, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, err
-		}
-
-		if len(data) <= 1 {
-			return resp, errors.New(resp.Status)
-		}
-
-		// TODO(sgotti) use a json error response
-
-		return resp, errors.New(string(data))
+	if err := util.ErrFromRemote(resp); err != nil {
+		return resp, err
 	}
 
 	return resp, nil

--- a/internal/services/configstore/action/maintenance.go
+++ b/internal/services/configstore/action/maintenance.go
@@ -32,10 +32,10 @@ func (h *ActionHandler) MaintenanceMode(ctx context.Context, enable bool) error 
 	}
 
 	if enable && len(resp.Kvs) > 0 {
-		return util.NewErrBadRequest(errors.Errorf("maintenance mode already enabled"))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("maintenance mode already enabled"))
 	}
 	if !enable && len(resp.Kvs) == 0 {
-		return util.NewErrBadRequest(errors.Errorf("maintenance mode already disabled"))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("maintenance mode already disabled"))
 	}
 
 	if enable {
@@ -67,7 +67,7 @@ func (h *ActionHandler) Export(ctx context.Context, w io.Writer) error {
 
 func (h *ActionHandler) Import(ctx context.Context, r io.Reader) error {
 	if !h.maintenanceMode {
-		return util.NewErrBadRequest(errors.Errorf("not in maintenance mode"))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("not in maintenance mode"))
 	}
 	return h.dm.Import(ctx, r)
 }

--- a/internal/services/configstore/action/org.go
+++ b/internal/services/configstore/action/org.go
@@ -51,7 +51,7 @@ func (h *ActionHandler) GetOrgMembers(ctx context.Context, orgRef string) ([]*Or
 			return err
 		}
 		if org == nil {
-			return util.NewErrNotExist(errors.Errorf("org %q doesn't exist", orgRef))
+			return util.NewAPIError(util.ErrNotExist, errors.Errorf("org %q doesn't exist", orgRef))
 		}
 
 		orgUsers, err = h.readDB.GetOrgUsers(tx, org.ID)
@@ -71,13 +71,13 @@ func (h *ActionHandler) GetOrgMembers(ctx context.Context, orgRef string) ([]*Or
 
 func (h *ActionHandler) CreateOrg(ctx context.Context, org *types.Organization) (*types.Organization, error) {
 	if org.Name == "" {
-		return nil, util.NewErrBadRequest(errors.Errorf("organization name required"))
+		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("organization name required"))
 	}
 	if !util.ValidateName(org.Name) {
-		return nil, util.NewErrBadRequest(errors.Errorf("invalid organization name %q", org.Name))
+		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid organization name %q", org.Name))
 	}
 	if !types.IsValidVisibility(org.Visibility) {
-		return nil, util.NewErrBadRequest(errors.Errorf("invalid organization visibility"))
+		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid organization visibility"))
 	}
 
 	var cgt *datamanager.ChangeGroupsUpdateToken
@@ -98,7 +98,7 @@ func (h *ActionHandler) CreateOrg(ctx context.Context, org *types.Organization) 
 			return err
 		}
 		if o != nil {
-			return util.NewErrBadRequest(errors.Errorf("org %q already exists", o.Name))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("org %q already exists", o.Name))
 		}
 
 		if org.CreatorUserID != "" {
@@ -107,7 +107,7 @@ func (h *ActionHandler) CreateOrg(ctx context.Context, org *types.Organization) 
 				return err
 			}
 			if user == nil {
-				return util.NewErrBadRequest(errors.Errorf("creator user %q doesn't exist", org.CreatorUserID))
+				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("creator user %q doesn't exist", org.CreatorUserID))
 			}
 		}
 
@@ -190,7 +190,7 @@ func (h *ActionHandler) DeleteOrg(ctx context.Context, orgRef string) error {
 			return err
 		}
 		if org == nil {
-			return util.NewErrBadRequest(errors.Errorf("org %q doesn't exist", orgRef))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("org %q doesn't exist", orgRef))
 		}
 
 		// changegroup is the org id
@@ -223,7 +223,7 @@ func (h *ActionHandler) DeleteOrg(ctx context.Context, orgRef string) error {
 // TODO(sgotti) handle invitation when implemented
 func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string, role types.MemberRole) (*types.OrganizationMember, error) {
 	if !types.IsValidMemberRole(role) {
-		return nil, util.NewErrBadRequest(errors.Errorf("invalid role %q", role))
+		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid role %q", role))
 	}
 
 	var org *types.Organization
@@ -240,7 +240,7 @@ func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string
 			return err
 		}
 		if org == nil {
-			return util.NewErrBadRequest(errors.Errorf("org %q doesn't exists", orgRef))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("org %q doesn't exists", orgRef))
 		}
 		// check existing user
 		user, err = h.readDB.GetUser(tx, userRef)
@@ -248,7 +248,7 @@ func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string
 			return err
 		}
 		if user == nil {
-			return util.NewErrBadRequest(errors.Errorf("user %q doesn't exists", userRef))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exists", userRef))
 		}
 
 		// fetch org member if it already exist
@@ -316,7 +316,7 @@ func (h *ActionHandler) RemoveOrgMember(ctx context.Context, orgRef, userRef str
 			return err
 		}
 		if org == nil {
-			return util.NewErrBadRequest(errors.Errorf("org %q doesn't exists", orgRef))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("org %q doesn't exists", orgRef))
 		}
 		// check existing user
 		user, err = h.readDB.GetUser(tx, userRef)
@@ -324,7 +324,7 @@ func (h *ActionHandler) RemoveOrgMember(ctx context.Context, orgRef, userRef str
 			return err
 		}
 		if user == nil {
-			return util.NewErrBadRequest(errors.Errorf("user %q doesn't exists", userRef))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exists", userRef))
 		}
 
 		// check that org member exists
@@ -333,7 +333,7 @@ func (h *ActionHandler) RemoveOrgMember(ctx context.Context, orgRef, userRef str
 			return err
 		}
 		if orgmember == nil {
-			return util.NewErrBadRequest(errors.Errorf("orgmember for org %q, user %q doesn't exists", orgRef, userRef))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("orgmember for org %q, user %q doesn't exists", orgRef, userRef))
 		}
 
 		cgNames := []string{util.EncodeSha256Hex(fmt.Sprintf("orgmember-%s-%s", org.ID, user.ID))}

--- a/internal/services/configstore/action/project.go
+++ b/internal/services/configstore/action/project.go
@@ -30,35 +30,35 @@ import (
 
 func (h *ActionHandler) ValidateProject(ctx context.Context, project *types.Project) error {
 	if project.Name == "" {
-		return util.NewErrBadRequest(errors.Errorf("project name required"))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project name required"))
 	}
 	if !util.ValidateName(project.Name) {
-		return util.NewErrBadRequest(errors.Errorf("invalid project name %q", project.Name))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid project name %q", project.Name))
 	}
 	if project.Parent.ID == "" {
-		return util.NewErrBadRequest(errors.Errorf("project parent id required"))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project parent id required"))
 	}
 	if project.Parent.Type != types.ConfigTypeProjectGroup {
-		return util.NewErrBadRequest(errors.Errorf("invalid project parent type %q", project.Parent.Type))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid project parent type %q", project.Parent.Type))
 	}
 	if !types.IsValidVisibility(project.Visibility) {
-		return util.NewErrBadRequest(errors.Errorf("invalid project visibility"))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid project visibility"))
 	}
 	if !types.IsValidRemoteRepositoryConfigType(project.RemoteRepositoryConfigType) {
-		return util.NewErrBadRequest(errors.Errorf("invalid project remote repository config type %q", project.RemoteRepositoryConfigType))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid project remote repository config type %q", project.RemoteRepositoryConfigType))
 	}
 	if project.RemoteRepositoryConfigType == types.RemoteRepositoryConfigTypeRemoteSource {
 		if project.RemoteSourceID == "" {
-			return util.NewErrBadRequest(errors.Errorf("empty remote source id"))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("empty remote source id"))
 		}
 		if project.LinkedAccountID == "" {
-			return util.NewErrBadRequest(errors.Errorf("empty linked account id"))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("empty linked account id"))
 		}
 		if project.RepositoryID == "" {
-			return util.NewErrBadRequest(errors.Errorf("empty remote repository id"))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("empty remote repository id"))
 		}
 		if project.RepositoryPath == "" {
-			return util.NewErrBadRequest(errors.Errorf("empty remote repository path"))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("empty remote repository path"))
 		}
 	}
 	return nil
@@ -76,7 +76,7 @@ func (h *ActionHandler) GetProject(ctx context.Context, projectRef string) (*typ
 	}
 
 	if project == nil {
-		return nil, util.NewErrNotExist(errors.Errorf("project %q doesn't exist", projectRef))
+		return nil, util.NewAPIError(util.ErrNotExist, errors.Errorf("project %q doesn't exist", projectRef))
 	}
 
 	return project, nil
@@ -97,7 +97,7 @@ func (h *ActionHandler) CreateProject(ctx context.Context, project *types.Projec
 			return err
 		}
 		if group == nil {
-			return util.NewErrBadRequest(errors.Errorf("project group with id %q doesn't exist", project.Parent.ID))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project group with id %q doesn't exist", project.Parent.ID))
 		}
 		project.Parent.ID = group.ID
 
@@ -121,7 +121,7 @@ func (h *ActionHandler) CreateProject(ctx context.Context, project *types.Projec
 			return err
 		}
 		if p != nil {
-			return util.NewErrBadRequest(errors.Errorf("project with name %q, path %q already exists", p.Name, pp))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with name %q, path %q already exists", p.Name, pp))
 		}
 
 		if project.RemoteRepositoryConfigType == types.RemoteRepositoryConfigTypeRemoteSource {
@@ -131,14 +131,14 @@ func (h *ActionHandler) CreateProject(ctx context.Context, project *types.Projec
 				return errors.Errorf("failed to get user with linked account id %q: %w", project.LinkedAccountID, err)
 			}
 			if user == nil {
-				return util.NewErrBadRequest(errors.Errorf("user for linked account %q doesn't exist", project.LinkedAccountID))
+				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user for linked account %q doesn't exist", project.LinkedAccountID))
 			}
 			la, ok := user.LinkedAccounts[project.LinkedAccountID]
 			if !ok {
-				return util.NewErrBadRequest(errors.Errorf("linked account id %q for user %q doesn't exist", project.LinkedAccountID, user.Name))
+				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("linked account id %q for user %q doesn't exist", project.LinkedAccountID, user.Name))
 			}
 			if la.RemoteSourceID != project.RemoteSourceID {
-				return util.NewErrBadRequest(errors.Errorf("linked account id %q remote source %q different than project remote source %q", project.LinkedAccountID, la.RemoteSourceID, project.RemoteSourceID))
+				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("linked account id %q remote source %q different than project remote source %q", project.LinkedAccountID, la.RemoteSourceID, project.RemoteSourceID))
 			}
 		}
 
@@ -193,11 +193,11 @@ func (h *ActionHandler) UpdateProject(ctx context.Context, req *UpdateProjectReq
 			return err
 		}
 		if p == nil {
-			return util.NewErrBadRequest(errors.Errorf("project with ref %q doesn't exist", req.ProjectRef))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with ref %q doesn't exist", req.ProjectRef))
 		}
 		// check that the project.ID matches
 		if p.ID != req.Project.ID {
-			return util.NewErrBadRequest(errors.Errorf("project with ref %q has a different id", req.ProjectRef))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with ref %q has a different id", req.ProjectRef))
 		}
 
 		// check parent project group exists
@@ -206,7 +206,7 @@ func (h *ActionHandler) UpdateProject(ctx context.Context, req *UpdateProjectReq
 			return err
 		}
 		if group == nil {
-			return util.NewErrBadRequest(errors.Errorf("project group with id %q doesn't exist", req.Project.Parent.ID))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project group with id %q doesn't exist", req.Project.Parent.ID))
 		}
 		req.Project.Parent.ID = group.ID
 
@@ -223,7 +223,7 @@ func (h *ActionHandler) UpdateProject(ctx context.Context, req *UpdateProjectReq
 				return err
 			}
 			if ap != nil {
-				return util.NewErrBadRequest(errors.Errorf("project with name %q, path %q already exists", req.Project.Name, pp))
+				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with name %q, path %q already exists", req.Project.Name, pp))
 			}
 		}
 
@@ -239,7 +239,7 @@ func (h *ActionHandler) UpdateProject(ctx context.Context, req *UpdateProjectReq
 				return err
 			}
 			if curGroup == nil {
-				return util.NewErrBadRequest(errors.Errorf("project group with id %q doesn't exist", p.Parent.ID))
+				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project group with id %q doesn't exist", p.Parent.ID))
 			}
 			curGroupPath, err := h.readDB.GetProjectGroupPath(tx, curGroup)
 			if err != nil {
@@ -262,14 +262,14 @@ func (h *ActionHandler) UpdateProject(ctx context.Context, req *UpdateProjectReq
 				return errors.Errorf("failed to get user with linked account id %q: %w", req.Project.LinkedAccountID, err)
 			}
 			if user == nil {
-				return util.NewErrBadRequest(errors.Errorf("user for linked account %q doesn't exist", req.Project.LinkedAccountID))
+				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user for linked account %q doesn't exist", req.Project.LinkedAccountID))
 			}
 			la, ok := user.LinkedAccounts[req.Project.LinkedAccountID]
 			if !ok {
-				return util.NewErrBadRequest(errors.Errorf("linked account id %q for user %q doesn't exist", req.Project.LinkedAccountID, user.Name))
+				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("linked account id %q for user %q doesn't exist", req.Project.LinkedAccountID, user.Name))
 			}
 			if la.RemoteSourceID != req.Project.RemoteSourceID {
-				return util.NewErrBadRequest(errors.Errorf("linked account id %q remote source %q different than project remote source %q", req.Project.LinkedAccountID, la.RemoteSourceID, req.Project.RemoteSourceID))
+				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("linked account id %q remote source %q different than project remote source %q", req.Project.LinkedAccountID, la.RemoteSourceID, req.Project.RemoteSourceID))
 			}
 		}
 
@@ -311,7 +311,7 @@ func (h *ActionHandler) DeleteProject(ctx context.Context, projectRef string) er
 			return err
 		}
 		if project == nil {
-			return util.NewErrBadRequest(errors.Errorf("project %q doesn't exist", projectRef))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project %q doesn't exist", projectRef))
 		}
 
 		// changegroup is the project id.

--- a/internal/services/configstore/action/remotesource.go
+++ b/internal/services/configstore/action/remotesource.go
@@ -29,35 +29,35 @@ import (
 
 func (h *ActionHandler) ValidateRemoteSource(ctx context.Context, remoteSource *types.RemoteSource) error {
 	if remoteSource.Name == "" {
-		return util.NewErrBadRequest(errors.Errorf("remotesource name required"))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource name required"))
 	}
 	if !util.ValidateName(remoteSource.Name) {
-		return util.NewErrBadRequest(errors.Errorf("invalid remotesource name %q", remoteSource.Name))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid remotesource name %q", remoteSource.Name))
 	}
 
 	if remoteSource.Name == "" {
-		return util.NewErrBadRequest(errors.Errorf("remotesource name required"))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource name required"))
 	}
 	if remoteSource.APIURL == "" {
-		return util.NewErrBadRequest(errors.Errorf("remotesource api url required"))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource api url required"))
 	}
 	if remoteSource.Type == "" {
-		return util.NewErrBadRequest(errors.Errorf("remotesource type required"))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource type required"))
 	}
 	if remoteSource.AuthType == "" {
-		return util.NewErrBadRequest(errors.Errorf("remotesource auth type required"))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource auth type required"))
 	}
 
 	// validate if the remotesource type supports the required auth type
 	if !types.SourceSupportsAuthType(types.RemoteSourceType(remoteSource.Type), types.RemoteSourceAuthType(remoteSource.AuthType)) {
-		return util.NewErrBadRequest(errors.Errorf("remotesource type %q doesn't support auth type %q", remoteSource.Type, remoteSource.AuthType))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource type %q doesn't support auth type %q", remoteSource.Type, remoteSource.AuthType))
 	}
 	if remoteSource.AuthType == types.RemoteSourceAuthTypeOauth2 {
 		if remoteSource.Oauth2ClientID == "" {
-			return util.NewErrBadRequest(errors.Errorf("remotesource oauth2clientid required for auth type %q", types.RemoteSourceAuthTypeOauth2))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource oauth2clientid required for auth type %q", types.RemoteSourceAuthTypeOauth2))
 		}
 		if remoteSource.Oauth2ClientSecret == "" {
-			return util.NewErrBadRequest(errors.Errorf("remotesource oauth2clientsecret required for auth type %q", types.RemoteSourceAuthTypeOauth2))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource oauth2clientsecret required for auth type %q", types.RemoteSourceAuthTypeOauth2))
 		}
 	}
 
@@ -87,7 +87,7 @@ func (h *ActionHandler) CreateRemoteSource(ctx context.Context, remoteSource *ty
 			return err
 		}
 		if u != nil {
-			return util.NewErrBadRequest(errors.Errorf("remotesource %q already exists", u.Name))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource %q already exists", u.Name))
 		}
 		return nil
 	})
@@ -138,7 +138,7 @@ func (h *ActionHandler) UpdateRemoteSource(ctx context.Context, req *UpdateRemot
 			return err
 		}
 		if curRemoteSource == nil {
-			return util.NewErrBadRequest(errors.Errorf("remotesource with ref %q doesn't exist", req.RemoteSourceRef))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource with ref %q doesn't exist", req.RemoteSourceRef))
 		}
 
 		if curRemoteSource.Name != req.RemoteSource.Name {
@@ -148,7 +148,7 @@ func (h *ActionHandler) UpdateRemoteSource(ctx context.Context, req *UpdateRemot
 				return err
 			}
 			if u != nil {
-				return util.NewErrBadRequest(errors.Errorf("remotesource %q already exists", u.Name))
+				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource %q already exists", u.Name))
 			}
 		}
 
@@ -199,7 +199,7 @@ func (h *ActionHandler) DeleteRemoteSource(ctx context.Context, remoteSourceName
 			return err
 		}
 		if remoteSource == nil {
-			return util.NewErrBadRequest(errors.Errorf("remotesource %q doesn't exist", remoteSourceName))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource %q doesn't exist", remoteSourceName))
 		}
 
 		// changegroup is the remotesource id

--- a/internal/services/configstore/action/user.go
+++ b/internal/services/configstore/action/user.go
@@ -37,10 +37,10 @@ type CreateUserRequest struct {
 
 func (h *ActionHandler) CreateUser(ctx context.Context, req *CreateUserRequest) (*types.User, error) {
 	if req.UserName == "" {
-		return nil, util.NewErrBadRequest(errors.Errorf("user name required"))
+		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user name required"))
 	}
 	if !util.ValidateName(req.UserName) {
-		return nil, util.NewErrBadRequest(errors.Errorf("invalid user name %q", req.UserName))
+		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid user name %q", req.UserName))
 	}
 
 	var cgt *datamanager.ChangeGroupsUpdateToken
@@ -63,7 +63,7 @@ func (h *ActionHandler) CreateUser(ctx context.Context, req *CreateUserRequest) 
 			return err
 		}
 		if u != nil {
-			return util.NewErrBadRequest(errors.Errorf("user with name %q already exists", u.Name))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user with name %q already exists", u.Name))
 		}
 
 		if req.CreateUserLARequest != nil {
@@ -72,14 +72,14 @@ func (h *ActionHandler) CreateUser(ctx context.Context, req *CreateUserRequest) 
 				return err
 			}
 			if rs == nil {
-				return util.NewErrBadRequest(errors.Errorf("remote source %q doesn't exist", req.CreateUserLARequest.RemoteSourceName))
+				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remote source %q doesn't exist", req.CreateUserLARequest.RemoteSourceName))
 			}
 			user, err := h.readDB.GetUserByLinkedAccountRemoteUserIDandSource(tx, req.CreateUserLARequest.RemoteUserID, rs.ID)
 			if err != nil {
 				return errors.Errorf("failed to get user for remote user id %q and remote source %q: %w", req.CreateUserLARequest.RemoteUserID, rs.ID, err)
 			}
 			if user != nil {
-				return util.NewErrBadRequest(errors.Errorf("user for remote user id %q for remote source %q already exists", req.CreateUserLARequest.RemoteUserID, req.CreateUserLARequest.RemoteSourceName))
+				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user for remote user id %q for remote source %q already exists", req.CreateUserLARequest.RemoteUserID, req.CreateUserLARequest.RemoteSourceName))
 			}
 		}
 		return nil
@@ -165,7 +165,7 @@ func (h *ActionHandler) DeleteUser(ctx context.Context, userRef string) error {
 			return err
 		}
 		if user == nil {
-			return util.NewErrBadRequest(errors.Errorf("user %q doesn't exist", userRef))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exist", userRef))
 		}
 
 		// changegroup is the userid
@@ -213,7 +213,7 @@ func (h *ActionHandler) UpdateUser(ctx context.Context, req *UpdateUserRequest) 
 			return err
 		}
 		if user == nil {
-			return util.NewErrBadRequest(errors.Errorf("user %q doesn't exist", req.UserRef))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exist", req.UserRef))
 		}
 
 		cgt, err = h.readDB.GetChangeGroupsUpdateTokens(tx, cgNames)
@@ -228,7 +228,7 @@ func (h *ActionHandler) UpdateUser(ctx context.Context, req *UpdateUserRequest) 
 				return err
 			}
 			if u != nil {
-				return util.NewErrBadRequest(errors.Errorf("user with name %q already exists", u.Name))
+				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user with name %q already exists", u.Name))
 			}
 			// changegroup is the username (and in future the email) to ensure no
 			// concurrent user creation/modification using the same name
@@ -277,10 +277,10 @@ type CreateUserLARequest struct {
 
 func (h *ActionHandler) CreateUserLA(ctx context.Context, req *CreateUserLARequest) (*types.LinkedAccount, error) {
 	if req.UserRef == "" {
-		return nil, util.NewErrBadRequest(errors.Errorf("user ref required"))
+		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user ref required"))
 	}
 	if req.RemoteSourceName == "" {
-		return nil, util.NewErrBadRequest(errors.Errorf("remote source name required"))
+		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("remote source name required"))
 	}
 
 	var user *types.User
@@ -296,7 +296,7 @@ func (h *ActionHandler) CreateUserLA(ctx context.Context, req *CreateUserLAReque
 			return err
 		}
 		if user == nil {
-			return util.NewErrBadRequest(errors.Errorf("user %q doesn't exist", req.UserRef))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exist", req.UserRef))
 		}
 
 		// changegroup is the userid
@@ -311,7 +311,7 @@ func (h *ActionHandler) CreateUserLA(ctx context.Context, req *CreateUserLAReque
 			return err
 		}
 		if rs == nil {
-			return util.NewErrBadRequest(errors.Errorf("remote source %q doesn't exist", req.RemoteSourceName))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remote source %q doesn't exist", req.RemoteSourceName))
 		}
 
 		user, err := h.readDB.GetUserByLinkedAccountRemoteUserIDandSource(tx, req.RemoteUserID, rs.ID)
@@ -319,7 +319,7 @@ func (h *ActionHandler) CreateUserLA(ctx context.Context, req *CreateUserLAReque
 			return errors.Errorf("failed to get user for remote user id %q and remote source %q: %w", req.RemoteUserID, rs.ID, err)
 		}
 		if user != nil {
-			return util.NewErrBadRequest(errors.Errorf("user for remote user id %q for remote source %q already exists", req.RemoteUserID, req.RemoteSourceName))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user for remote user id %q for remote source %q already exists", req.RemoteUserID, req.RemoteSourceName))
 		}
 		return nil
 	})
@@ -363,10 +363,10 @@ func (h *ActionHandler) CreateUserLA(ctx context.Context, req *CreateUserLAReque
 
 func (h *ActionHandler) DeleteUserLA(ctx context.Context, userRef, laID string) error {
 	if userRef == "" {
-		return util.NewErrBadRequest(errors.Errorf("user ref  required"))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user ref  required"))
 	}
 	if laID == "" {
-		return util.NewErrBadRequest(errors.Errorf("user linked account id required"))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user linked account id required"))
 	}
 
 	var user *types.User
@@ -381,7 +381,7 @@ func (h *ActionHandler) DeleteUserLA(ctx context.Context, userRef, laID string) 
 			return err
 		}
 		if user == nil {
-			return util.NewErrBadRequest(errors.Errorf("user %q doesn't exist", userRef))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exist", userRef))
 		}
 
 		// changegroup is the userid
@@ -399,7 +399,7 @@ func (h *ActionHandler) DeleteUserLA(ctx context.Context, userRef, laID string) 
 
 	_, ok := user.LinkedAccounts[laID]
 	if !ok {
-		return util.NewErrBadRequest(errors.Errorf("linked account id %q for user %q doesn't exist", laID, userRef))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("linked account id %q for user %q doesn't exist", laID, userRef))
 	}
 
 	delete(user.LinkedAccounts, laID)
@@ -435,7 +435,7 @@ type UpdateUserLARequest struct {
 
 func (h *ActionHandler) UpdateUserLA(ctx context.Context, req *UpdateUserLARequest) (*types.LinkedAccount, error) {
 	if req.UserRef == "" {
-		return nil, util.NewErrBadRequest(errors.Errorf("user ref required"))
+		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user ref required"))
 	}
 
 	var user *types.User
@@ -451,7 +451,7 @@ func (h *ActionHandler) UpdateUserLA(ctx context.Context, req *UpdateUserLAReque
 			return err
 		}
 		if user == nil {
-			return util.NewErrBadRequest(errors.Errorf("user %q doesn't exist", req.UserRef))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exist", req.UserRef))
 		}
 
 		// changegroup is the userid
@@ -463,7 +463,7 @@ func (h *ActionHandler) UpdateUserLA(ctx context.Context, req *UpdateUserLAReque
 
 		la, ok := user.LinkedAccounts[req.LinkedAccountID]
 		if !ok {
-			return util.NewErrBadRequest(errors.Errorf("linked account id %q for user %q doesn't exist", req.LinkedAccountID, user.Name))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("linked account id %q for user %q doesn't exist", req.LinkedAccountID, user.Name))
 		}
 
 		rs, err = h.readDB.GetRemoteSource(tx, la.RemoteSourceID)
@@ -471,7 +471,7 @@ func (h *ActionHandler) UpdateUserLA(ctx context.Context, req *UpdateUserLAReque
 			return err
 		}
 		if rs == nil {
-			return util.NewErrBadRequest(errors.Errorf("remote source with id %q doesn't exist", la.RemoteSourceID))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remote source with id %q doesn't exist", la.RemoteSourceID))
 		}
 		return nil
 	})
@@ -507,10 +507,10 @@ func (h *ActionHandler) UpdateUserLA(ctx context.Context, req *UpdateUserLAReque
 
 func (h *ActionHandler) CreateUserToken(ctx context.Context, userRef, tokenName string) (string, error) {
 	if userRef == "" {
-		return "", util.NewErrBadRequest(errors.Errorf("user ref required"))
+		return "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("user ref required"))
 	}
 	if tokenName == "" {
-		return "", util.NewErrBadRequest(errors.Errorf("token name required"))
+		return "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("token name required"))
 	}
 
 	var user *types.User
@@ -525,7 +525,7 @@ func (h *ActionHandler) CreateUserToken(ctx context.Context, userRef, tokenName 
 			return err
 		}
 		if user == nil {
-			return util.NewErrBadRequest(errors.Errorf("user %q doesn't exist", userRef))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exist", userRef))
 		}
 
 		// changegroup is the userid
@@ -542,7 +542,7 @@ func (h *ActionHandler) CreateUserToken(ctx context.Context, userRef, tokenName 
 	}
 	if user.Tokens != nil {
 		if _, ok := user.Tokens[tokenName]; ok {
-			return "", util.NewErrBadRequest(errors.Errorf("token %q for user %q already exists", tokenName, userRef))
+			return "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("token %q for user %q already exists", tokenName, userRef))
 		}
 	}
 
@@ -572,10 +572,10 @@ func (h *ActionHandler) CreateUserToken(ctx context.Context, userRef, tokenName 
 
 func (h *ActionHandler) DeleteUserToken(ctx context.Context, userRef, tokenName string) error {
 	if userRef == "" {
-		return util.NewErrBadRequest(errors.Errorf("user ref required"))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user ref required"))
 	}
 	if tokenName == "" {
-		return util.NewErrBadRequest(errors.Errorf("token name required"))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("token name required"))
 	}
 
 	var user *types.User
@@ -590,7 +590,7 @@ func (h *ActionHandler) DeleteUserToken(ctx context.Context, userRef, tokenName 
 			return err
 		}
 		if user == nil {
-			return util.NewErrBadRequest(errors.Errorf("user %q doesn't exist", userRef))
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exist", userRef))
 		}
 
 		// changegroup is the userid
@@ -608,7 +608,7 @@ func (h *ActionHandler) DeleteUserToken(ctx context.Context, userRef, tokenName 
 
 	_, ok := user.Tokens[tokenName]
 	if !ok {
-		return util.NewErrBadRequest(errors.Errorf("token %q for user %q doesn't exist", tokenName, userRef))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("token %q for user %q doesn't exist", tokenName, userRef))
 	}
 
 	delete(user.Tokens, tokenName)
@@ -651,7 +651,7 @@ func (h *ActionHandler) GetUserOrgs(ctx context.Context, userRef string) ([]*Use
 			return err
 		}
 		if user == nil {
-			return util.NewErrNotExist(errors.Errorf("user %q doesn't exist", userRef))
+			return util.NewAPIError(util.ErrNotExist, errors.Errorf("user %q doesn't exist", userRef))
 		}
 
 		userOrgs, err = h.readDB.GetUserOrgs(tx, user.ID)

--- a/internal/services/configstore/api/api.go
+++ b/internal/services/configstore/api/api.go
@@ -15,7 +15,6 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/url"
 
@@ -30,97 +29,11 @@ type ErrorResponse struct {
 	Message string `json:"message"`
 }
 
-func ErrorResponseFromError(err error) *ErrorResponse {
-	var aerr error
-	// use inner errors if of these types
-	switch {
-	case util.IsBadRequest(err):
-		var cerr *util.ErrBadRequest
-		errors.As(err, &cerr)
-		aerr = cerr
-	case util.IsNotExist(err):
-		var cerr *util.ErrNotExist
-		errors.As(err, &cerr)
-		aerr = cerr
-	case util.IsForbidden(err):
-		var cerr *util.ErrForbidden
-		errors.As(err, &cerr)
-		aerr = cerr
-	case util.IsUnauthorized(err):
-		var cerr *util.ErrUnauthorized
-		errors.As(err, &cerr)
-		aerr = cerr
-	case util.IsInternal(err):
-		var cerr *util.ErrInternal
-		errors.As(err, &cerr)
-		aerr = cerr
-	}
-
-	if aerr != nil {
-		return &ErrorResponse{Message: aerr.Error()}
-	}
-
-	// on generic error return an generic message to not leak the real error
-	return &ErrorResponse{Message: "internal server error"}
-}
-
-func httpError(w http.ResponseWriter, err error) bool {
-	if err == nil {
-		return false
-	}
-
-	response := ErrorResponseFromError(err)
-	resj, merr := json.Marshal(response)
-	if merr != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		return true
-	}
-	switch {
-	case util.IsBadRequest(err):
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write(resj)
-	case util.IsNotExist(err):
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write(resj)
-	case util.IsForbidden(err):
-		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write(resj)
-	case util.IsUnauthorized(err):
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write(resj)
-	case util.IsInternal(err):
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write(resj)
-	default:
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write(resj)
-	}
-	return true
-}
-
-func httpResponse(w http.ResponseWriter, code int, res interface{}) error {
-	w.Header().Set("Content-Type", "application/json")
-
-	if res != nil {
-		resj, err := json.Marshal(res)
-		if err != nil {
-			httpError(w, err)
-			return err
-		}
-		w.WriteHeader(code)
-		_, err = w.Write(resj)
-		return err
-	}
-
-	w.WriteHeader(code)
-	return nil
-}
-
 func GetConfigTypeRef(r *http.Request) (types.ConfigType, string, error) {
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		return "", "", util.NewErrBadRequest(errors.Errorf("wrong projectref %q: %w", vars["projectref"], err))
+		return "", "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("wrong projectref %q: %w", vars["projectref"], err))
 	}
 	if projectRef != "" {
 		return types.ConfigTypeProject, projectRef, nil
@@ -128,11 +41,11 @@ func GetConfigTypeRef(r *http.Request) (types.ConfigType, string, error) {
 
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		return "", "", util.NewErrBadRequest(errors.Errorf("wrong projectgroupref %q: %w", vars["projectgroupref"], err))
+		return "", "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("wrong projectgroupref %q: %w", vars["projectgroupref"], err))
 	}
 	if projectGroupRef != "" {
 		return types.ConfigTypeProjectGroup, projectGroupRef, nil
 	}
 
-	return "", "", util.NewErrBadRequest(errors.Errorf("cannot get project or projectgroup ref"))
+	return "", "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot get project or projectgroup ref"))
 }

--- a/internal/services/configstore/api/maintenance.go
+++ b/internal/services/configstore/api/maintenance.go
@@ -19,6 +19,7 @@ import (
 
 	"agola.io/agola/internal/etcd"
 	"agola.io/agola/internal/services/configstore/action"
+	"agola.io/agola/internal/util"
 
 	"go.uber.org/zap"
 )
@@ -47,11 +48,11 @@ func (h *MaintenanceModeHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	err := h.ah.MaintenanceMode(ctx, enable)
 	if err != nil {
 		h.log.Errorf("err: %+v", err)
-		httpError(w, err)
+		util.HTTPError(w, err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 
@@ -96,11 +97,11 @@ func (h *ImportHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err := h.ah.Import(ctx, r.Body)
 	if err != nil {
 		h.log.Errorf("err: %+v", err)
-		httpError(w, err)
+		util.HTTPError(w, err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 

--- a/internal/services/configstore/api/org.go
+++ b/internal/services/configstore/api/org.go
@@ -53,16 +53,16 @@ func (h *OrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		h.log.Errorf("err: %+v", err)
-		httpError(w, err)
+		util.HTTPError(w, err)
 		return
 	}
 
 	if org == nil {
-		httpError(w, util.NewErrNotExist(errors.Errorf("org %q doesn't exist", orgRef)))
+		util.HTTPError(w, util.NewAPIError(util.ErrNotExist, errors.Errorf("org %q doesn't exist", orgRef)))
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, org); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, org); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -82,17 +82,17 @@ func (h *CreateOrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req types.Organization
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	org, err := h.ah.CreateOrg(ctx, &req)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusCreated, org); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, org); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -113,11 +113,11 @@ func (h *DeleteOrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	orgRef := vars["orgref"]
 
 	err := h.ah.DeleteOrg(ctx, orgRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -146,12 +146,12 @@ func (h *OrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			httpError(w, util.NewErrBadRequest(errors.Errorf("cannot parse limit: %w", err)))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot parse limit: %w", err)))
 			return
 		}
 	}
 	if limit < 0 {
-		httpError(w, util.NewErrBadRequest(errors.Errorf("limit must be greater or equal than 0")))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("limit must be greater or equal than 0")))
 		return
 	}
 	if limit > MaxOrgsLimit {
@@ -172,11 +172,11 @@ func (h *OrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		h.log.Errorf("err: %+v", err)
-		httpError(w, err)
+		util.HTTPError(w, err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, orgs); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, orgs); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -200,17 +200,17 @@ func (h *AddOrgMemberHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	var req csapitypes.AddOrgMemberRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	org, err := h.ah.AddOrgMember(ctx, orgRef, userRef, req.Role)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusCreated, org); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, org); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -232,12 +232,12 @@ func (h *RemoveOrgMemberHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	userRef := vars["userref"]
 
 	err := h.ah.RemoveOrgMember(ctx, orgRef, userRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -264,7 +264,7 @@ func (h *OrgMembersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	orgRef := vars["orgref"]
 
 	orgUsers, err := h.ah.GetOrgMembers(ctx, orgRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -274,7 +274,7 @@ func (h *OrgMembersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		res[i] = orgMemberResponse(orgUser)
 	}
 
-	if err := httpResponse(w, http.StatusOK, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }

--- a/internal/services/configstore/api/project.go
+++ b/internal/services/configstore/api/project.go
@@ -126,23 +126,23 @@ func (h *ProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	project, err := h.ah.GetProject(ctx, projectRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	resProject, err := projectResponse(ctx, h.readDB, project)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, resProject); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, resProject); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -163,23 +163,23 @@ func (h *CreateProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	var req types.Project
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	project, err := h.ah.CreateProject(ctx, &req)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	resProject, err := projectResponse(ctx, h.readDB, project)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusCreated, resProject); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, resProject); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -200,14 +200,14 @@ func (h *UpdateProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	var project *types.Project
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&project); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -216,18 +216,18 @@ func (h *UpdateProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		Project:    project,
 	}
 	project, err = h.ah.UpdateProject(ctx, areq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	resProject, err := projectResponse(ctx, h.readDB, project)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusCreated, resProject); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, resProject); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -247,15 +247,15 @@ func (h *DeleteProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	err = h.ah.DeleteProject(ctx, projectRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 	}
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }

--- a/internal/services/configstore/api/projectgroup.go
+++ b/internal/services/configstore/api/projectgroup.go
@@ -95,23 +95,23 @@ func (h *ProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	projectGroup, err := h.ah.GetProjectGroup(ctx, projectGroupRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	resProjectGroup, err := projectGroupResponse(ctx, h.readDB, projectGroup)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, resProjectGroup); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, resProjectGroup); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -132,23 +132,23 @@ func (h *ProjectGroupProjectsHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	projects, err := h.ah.GetProjectGroupProjects(ctx, projectGroupRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	resProjects, err := projectsResponse(ctx, h.readDB, projects)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, resProjects); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, resProjects); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -168,23 +168,23 @@ func (h *ProjectGroupSubgroupsHandler) ServeHTTP(w http.ResponseWriter, r *http.
 	vars := mux.Vars(r)
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	projectGroups, err := h.ah.GetProjectGroupSubgroups(ctx, projectGroupRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	resProjectGroups, err := projectGroupsResponse(ctx, h.readDB, projectGroups)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, resProjectGroups); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, resProjectGroups); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -205,23 +205,23 @@ func (h *CreateProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	var req types.ProjectGroup
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	projectGroup, err := h.ah.CreateProjectGroup(ctx, &req)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	resProjectGroup, err := projectGroupResponse(ctx, h.readDB, projectGroup)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusCreated, resProjectGroup); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, resProjectGroup); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -242,14 +242,14 @@ func (h *UpdateProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	vars := mux.Vars(r)
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	var projectGroup *types.ProjectGroup
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&projectGroup); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -258,18 +258,18 @@ func (h *UpdateProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 		ProjectGroup:    projectGroup,
 	}
 	projectGroup, err = h.ah.UpdateProjectGroup(ctx, areq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	resProjectGroup, err := projectGroupResponse(ctx, h.readDB, projectGroup)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusCreated, resProjectGroup); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, resProjectGroup); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -289,15 +289,15 @@ func (h *DeleteProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	vars := mux.Vars(r)
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	err = h.ah.DeleteProjectGroup(ctx, projectGroupRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 	}
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }

--- a/internal/services/configstore/api/remotesource.go
+++ b/internal/services/configstore/api/remotesource.go
@@ -52,16 +52,16 @@ func (h *RemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	})
 	if err != nil {
 		h.log.Errorf("err: %+v", err)
-		httpError(w, err)
+		util.HTTPError(w, err)
 		return
 	}
 
 	if remoteSource == nil {
-		httpError(w, util.NewErrNotExist(errors.Errorf("remote source %q doesn't exist", rsRef)))
+		util.HTTPError(w, util.NewAPIError(util.ErrNotExist, errors.Errorf("remote source %q doesn't exist", rsRef)))
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, remoteSource); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, remoteSource); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -81,17 +81,17 @@ func (h *CreateRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	var req types.RemoteSource
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	remoteSource, err := h.ah.CreateRemoteSource(ctx, &req)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusCreated, remoteSource); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, remoteSource); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -114,7 +114,7 @@ func (h *UpdateRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	var remoteSource *types.RemoteSource
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&remoteSource); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -123,12 +123,12 @@ func (h *UpdateRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 		RemoteSource:    remoteSource,
 	}
 	remoteSource, err := h.ah.UpdateRemoteSource(ctx, areq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusCreated, remoteSource); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, remoteSource); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -149,10 +149,10 @@ func (h *DeleteRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	rsRef := vars["remotesourceref"]
 
 	err := h.ah.DeleteRemoteSource(ctx, rsRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 	}
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -181,12 +181,12 @@ func (h *RemoteSourcesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			httpError(w, util.NewErrBadRequest(errors.Errorf("cannot parse limit: %w", err)))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot parse limit: %w", err)))
 			return
 		}
 	}
 	if limit < 0 {
-		httpError(w, util.NewErrBadRequest(errors.Errorf("limit must be greater or equal than 0")))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("limit must be greater or equal than 0")))
 		return
 	}
 	if limit > MaxRemoteSourcesLimit {
@@ -202,11 +202,11 @@ func (h *RemoteSourcesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	remoteSources, err := h.readDB.GetRemoteSources(ctx, start, limit, asc)
 	if err != nil {
 		h.log.Errorf("err: %+v", err)
-		httpError(w, err)
+		util.HTTPError(w, err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, remoteSources); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, remoteSources); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }

--- a/internal/services/configstore/api/secret.go
+++ b/internal/services/configstore/api/secret.go
@@ -45,12 +45,12 @@ func (h *SecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	secretID := vars["secretid"]
 
 	secret, err := h.ah.GetSecret(ctx, secretID)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, secret); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, secret); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -71,13 +71,13 @@ func (h *SecretsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, tree := query["tree"]
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	secrets, err := h.ah.GetSecrets(ctx, parentType, parentRef, tree)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -100,11 +100,11 @@ func (h *SecretsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		h.log.Errorf("err: %+v", err)
-		httpError(w, err)
+		util.HTTPError(w, err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, resSecrets); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, resSecrets); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -121,7 +121,7 @@ func NewCreateSecretHandler(logger *zap.Logger, ah *action.ActionHandler) *Creat
 func (h *CreateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	parentType, parentRef, err := GetConfigTypeRef(r)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -129,7 +129,7 @@ func (h *CreateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	var secret *types.Secret
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&secret); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -137,12 +137,12 @@ func (h *CreateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	secret.Parent.ID = parentRef
 
 	secret, err = h.ah.CreateSecret(ctx, secret)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusCreated, secret); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, secret); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -162,7 +162,7 @@ func (h *UpdateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	secretName := vars["secretname"]
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -170,7 +170,7 @@ func (h *UpdateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	var secret *types.Secret
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&secret); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -182,12 +182,12 @@ func (h *UpdateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		Secret:     secret,
 	}
 	secret, err = h.ah.UpdateSecret(ctx, areq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, secret); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, secret); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -207,16 +207,16 @@ func (h *DeleteSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	secretName := vars["secretname"]
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	err = h.ah.DeleteSecret(ctx, parentType, parentRef, secretName)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 	}
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }

--- a/internal/services/configstore/api/user.go
+++ b/internal/services/configstore/api/user.go
@@ -53,16 +53,16 @@ func (h *UserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		h.log.Errorf("err: %+v", err)
-		httpError(w, err)
+		util.HTTPError(w, err)
 		return
 	}
 
 	if user == nil {
-		httpError(w, util.NewErrNotExist(errors.Errorf("user %q doesn't exist", userRef)))
+		util.HTTPError(w, util.NewAPIError(util.ErrNotExist, errors.Errorf("user %q doesn't exist", userRef)))
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, user); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, user); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -82,7 +82,7 @@ func (h *CreateUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req *csapitypes.CreateUserRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -102,12 +102,12 @@ func (h *CreateUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	user, err := h.ah.CreateUser(ctx, creq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusCreated, user); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, user); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -130,7 +130,7 @@ func (h *UpdateUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req *csapitypes.UpdateUserRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -140,12 +140,12 @@ func (h *UpdateUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	user, err := h.ah.UpdateUser(ctx, creq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusCreated, user); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, user); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -166,10 +166,10 @@ func (h *DeleteUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	userRef := vars["userref"]
 
 	err := h.ah.DeleteUser(ctx, userRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 	}
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -198,12 +198,12 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			httpError(w, util.NewErrBadRequest(errors.Errorf("cannot parse limit: %w", err)))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot parse limit: %w", err)))
 			return
 		}
 	}
 	if limit < 0 {
-		httpError(w, util.NewErrBadRequest(errors.Errorf("limit must be greater or equal than 0")))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("limit must be greater or equal than 0")))
 		return
 	}
 	if limit > MaxUsersLimit {
@@ -231,11 +231,11 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		})
 		if err != nil {
 			h.log.Errorf("err: %+v", err)
-			httpError(w, err)
+			util.HTTPError(w, err)
 			return
 		}
 		if user == nil {
-			httpError(w, util.NewErrNotExist(errors.Errorf("user with required token doesn't exist")))
+			util.HTTPError(w, util.NewAPIError(util.ErrNotExist, errors.Errorf("user with required token doesn't exist")))
 			return
 		}
 		users = []*types.User{user}
@@ -249,11 +249,11 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		})
 		if err != nil {
 			h.log.Errorf("err: %+v", err)
-			httpError(w, err)
+			util.HTTPError(w, err)
 			return
 		}
 		if user == nil {
-			httpError(w, util.NewErrNotExist(errors.Errorf("user with linked account %q token doesn't exist", linkedAccountID)))
+			util.HTTPError(w, util.NewAPIError(util.ErrNotExist, errors.Errorf("user with linked account %q token doesn't exist", linkedAccountID)))
 			return
 		}
 		users = []*types.User{user}
@@ -268,11 +268,11 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		})
 		if err != nil {
 			h.log.Errorf("err: %+v", err)
-			httpError(w, err)
+			util.HTTPError(w, err)
 			return
 		}
 		if user == nil {
-			httpError(w, util.NewErrNotExist(errors.Errorf("user with remote user %q for remote source %q token doesn't exist", remoteUserID, remoteSourceID)))
+			util.HTTPError(w, util.NewAPIError(util.ErrNotExist, errors.Errorf("user with remote user %q for remote source %q token doesn't exist", remoteUserID, remoteSourceID)))
 			return
 		}
 		users = []*types.User{user}
@@ -285,12 +285,12 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		})
 		if err != nil {
 			h.log.Errorf("err: %+v", err)
-			httpError(w, err)
+			util.HTTPError(w, err)
 			return
 		}
 	}
 
-	if err := httpResponse(w, http.StatusOK, users); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, users); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -312,7 +312,7 @@ func (h *CreateUserLAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	var req csapitypes.CreateUserLARequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -327,12 +327,12 @@ func (h *CreateUserLAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		Oauth2AccessTokenExpiresAt: req.Oauth2AccessTokenExpiresAt,
 	}
 	user, err := h.ah.CreateUserLA(ctx, creq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusCreated, user); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, user); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -353,10 +353,10 @@ func (h *DeleteUserLAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	laID := vars["laid"]
 
 	err := h.ah.DeleteUserLA(ctx, userRef, laID)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 	}
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -379,7 +379,7 @@ func (h *UpdateUserLAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	var req csapitypes.UpdateUserLARequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -394,12 +394,12 @@ func (h *UpdateUserLAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		Oauth2AccessTokenExpiresAt: req.Oauth2AccessTokenExpiresAt,
 	}
 	user, err := h.ah.UpdateUserLA(ctx, creq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, user); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, user); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -421,12 +421,12 @@ func (h *CreateUserTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	var req csapitypes.CreateUserTokenRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	token, err := h.ah.CreateUserToken(ctx, userRef, req.TokenName)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -434,7 +434,7 @@ func (h *CreateUserTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	resp := &csapitypes.CreateUserTokenResponse{
 		Token: token,
 	}
-	if err := httpResponse(w, http.StatusCreated, resp); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, resp); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -455,11 +455,11 @@ func (h *DeleteUserTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	tokenName := vars["tokenname"]
 
 	err := h.ah.DeleteUserToken(ctx, userRef, tokenName)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -486,7 +486,7 @@ func (h *UserOrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	userRef := vars["userref"]
 
 	userOrgs, err := h.ah.GetUserOrgs(ctx, userRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -496,7 +496,7 @@ func (h *UserOrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		res[i] = userOrgsResponse(userOrg)
 	}
 
-	if err := httpResponse(w, http.StatusOK, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }

--- a/internal/services/configstore/api/variable.go
+++ b/internal/services/configstore/api/variable.go
@@ -45,13 +45,13 @@ func (h *VariablesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, tree := query["tree"]
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	variables, err := h.ah.GetVariables(ctx, parentType, parentRef, tree)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -73,11 +73,11 @@ func (h *VariablesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		h.log.Errorf("err: %+v", err)
-		httpError(w, err)
+		util.HTTPError(w, err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, resVariables); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, resVariables); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -94,7 +94,7 @@ func NewCreateVariableHandler(logger *zap.Logger, ah *action.ActionHandler) *Cre
 func (h *CreateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	parentType, parentRef, err := GetConfigTypeRef(r)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -102,7 +102,7 @@ func (h *CreateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	var variable *types.Variable
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&variable); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -110,12 +110,12 @@ func (h *CreateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	variable.Parent.ID = parentRef
 
 	variable, err = h.ah.CreateVariable(ctx, variable)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusCreated, variable); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, variable); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -135,7 +135,7 @@ func (h *UpdateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	variableName := vars["variablename"]
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -143,7 +143,7 @@ func (h *UpdateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	var variable *types.Variable
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&variable); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -155,12 +155,12 @@ func (h *UpdateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		Variable:     variable,
 	}
 	variable, err = h.ah.UpdateVariable(ctx, areq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, variable); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, variable); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -180,16 +180,16 @@ func (h *DeleteVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	variableName := vars["variablename"]
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	err = h.ah.DeleteVariable(ctx, parentType, parentRef, variableName)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 	}
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }

--- a/internal/services/configstore/configstore_test.go
+++ b/internal/services/configstore/configstore_test.go
@@ -1321,7 +1321,7 @@ func TestRemoteSource(t *testing.T) {
 					t.Fatalf("unexpected err: %v", err)
 				}
 
-				expectedError := util.NewErrBadRequest(fmt.Errorf(`remotesource "rs01" already exists`))
+				expectedError := util.NewAPIError(util.ErrBadRequest, fmt.Errorf(`remotesource "rs01" already exists`))
 				_, err = cs.ah.CreateRemoteSource(ctx, rs)
 				if err.Error() != expectedError.Error() {
 					t.Fatalf("expected err: %v, got err: %v", expectedError.Error(), err.Error())
@@ -1410,7 +1410,7 @@ func TestRemoteSource(t *testing.T) {
 					t.Fatalf("unexpected err: %v", err)
 				}
 
-				expectedError := util.NewErrBadRequest(fmt.Errorf(`remotesource "rs02" already exists`))
+				expectedError := util.NewAPIError(util.ErrBadRequest, fmt.Errorf(`remotesource "rs02" already exists`))
 				rs01.Name = "rs02"
 				req := &action.UpdateRemoteSourceRequest{
 					RemoteSourceRef: "rs01",

--- a/internal/services/configstore/readdb/resolve.go
+++ b/internal/services/configstore/readdb/resolve.go
@@ -18,37 +18,10 @@ import (
 	"path"
 
 	"agola.io/agola/internal/db"
-	"agola.io/agola/internal/util"
 	"agola.io/agola/services/configstore/types"
+
 	errors "golang.org/x/xerrors"
 )
-
-func (r *ReadDB) ResolveConfigID(tx *db.Tx, configType types.ConfigType, ref string) (string, error) {
-	switch configType {
-	case types.ConfigTypeProjectGroup:
-		group, err := r.GetProjectGroup(tx, ref)
-		if err != nil {
-			return "", err
-		}
-		if group == nil {
-			return "", util.NewErrBadRequest(errors.Errorf("group with ref %q doesn't exists", ref))
-		}
-		return group.ID, nil
-
-	case types.ConfigTypeProject:
-		project, err := r.GetProject(tx, ref)
-		if err != nil {
-			return "", err
-		}
-		if project == nil {
-			return "", util.NewErrBadRequest(errors.Errorf("project with ref %q doesn't exists", ref))
-		}
-		return project.ID, nil
-
-	default:
-		return "", util.NewErrBadRequest(errors.Errorf("unknown config type %q", configType))
-	}
-}
 
 func (r *ReadDB) GetPath(tx *db.Tx, configType types.ConfigType, id string) (string, error) {
 	var p string

--- a/internal/services/executor/driver/docker_test.go
+++ b/internal/services/executor/driver/docker_test.go
@@ -25,8 +25,8 @@ import (
 	"agola.io/agola/internal/testutil"
 
 	"github.com/docker/docker/api/types"
-	"github.com/google/go-cmp/cmp"
 	"github.com/gofrs/uuid"
+	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )

--- a/internal/services/gateway/action/action.go
+++ b/internal/services/gateway/action/action.go
@@ -15,10 +15,7 @@
 package action
 
 import (
-	"net/http"
-
 	"agola.io/agola/internal/services/common"
-	"agola.io/agola/internal/util"
 	csclient "agola.io/agola/services/configstore/client"
 	rsclient "agola.io/agola/services/runservice/client"
 
@@ -45,21 +42,4 @@ func NewActionHandler(logger *zap.Logger, sd *common.TokenSigningData, configsto
 		apiExposedURL:     apiExposedURL,
 		webExposedURL:     webExposedURL,
 	}
-}
-
-func ErrFromRemote(resp *http.Response, err error) error {
-	if err == nil {
-		return nil
-	}
-
-	if resp != nil {
-		switch resp.StatusCode {
-		case http.StatusBadRequest:
-			return util.NewErrBadRequest(err)
-		case http.StatusNotFound:
-			return util.NewErrNotExist(err)
-		}
-	}
-
-	return err
 }

--- a/internal/services/gateway/action/auth.go
+++ b/internal/services/gateway/action/auth.go
@@ -19,6 +19,7 @@ import (
 
 	scommon "agola.io/agola/internal/services/common"
 	"agola.io/agola/internal/services/gateway/common"
+	"agola.io/agola/internal/util"
 	cstypes "agola.io/agola/services/configstore/types"
 
 	errors "golang.org/x/xerrors"
@@ -35,9 +36,9 @@ func (h *ActionHandler) IsOrgOwner(ctx context.Context, orgID string) (bool, err
 		return false, nil
 	}
 
-	userOrgs, resp, err := h.configstoreClient.GetUserOrgs(ctx, userID)
+	userOrgs, _, err := h.configstoreClient.GetUserOrgs(ctx, userID)
 	if err != nil {
-		return false, errors.Errorf("failed to get user orgs: %w", ErrFromRemote(resp, err))
+		return false, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to get user orgs: %w", err))
 	}
 
 	for _, userOrg := range userOrgs {
@@ -70,9 +71,9 @@ func (h *ActionHandler) IsProjectOwner(ctx context.Context, ownerType cstypes.Co
 	}
 
 	if ownerType == cstypes.ConfigTypeOrg {
-		userOrgs, resp, err := h.configstoreClient.GetUserOrgs(ctx, userID)
+		userOrgs, _, err := h.configstoreClient.GetUserOrgs(ctx, userID)
 		if err != nil {
-			return false, errors.Errorf("failed to get user orgs: %w", ErrFromRemote(resp, err))
+			return false, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to get user orgs: %w", err))
 		}
 
 		for _, userOrg := range userOrgs {
@@ -106,9 +107,9 @@ func (h *ActionHandler) IsProjectMember(ctx context.Context, ownerType cstypes.C
 	}
 
 	if ownerType == cstypes.ConfigTypeOrg {
-		userOrgs, resp, err := h.configstoreClient.GetUserOrgs(ctx, userID)
+		userOrgs, _, err := h.configstoreClient.GetUserOrgs(ctx, userID)
 		if err != nil {
-			return false, errors.Errorf("failed to get user orgs: %w", ErrFromRemote(resp, err))
+			return false, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to get user orgs: %w", err))
 		}
 
 		for _, userOrg := range userOrgs {
@@ -127,16 +128,16 @@ func (h *ActionHandler) IsVariableOwner(ctx context.Context, parentType cstypes.
 	var ownerID string
 	switch parentType {
 	case cstypes.ConfigTypeProjectGroup:
-		pg, resp, err := h.configstoreClient.GetProjectGroup(ctx, parentRef)
+		pg, _, err := h.configstoreClient.GetProjectGroup(ctx, parentRef)
 		if err != nil {
-			return false, errors.Errorf("failed to get project group %q: %w", parentRef, ErrFromRemote(resp, err))
+			return false, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to get project group %q: %w", parentRef, err))
 		}
 		ownerType = pg.OwnerType
 		ownerID = pg.OwnerID
 	case cstypes.ConfigTypeProject:
-		p, resp, err := h.configstoreClient.GetProject(ctx, parentRef)
+		p, _, err := h.configstoreClient.GetProject(ctx, parentRef)
 		if err != nil {
-			return false, errors.Errorf("failed to get project  %q: %w", parentRef, ErrFromRemote(resp, err))
+			return false, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to get project  %q: %w", parentRef, err))
 		}
 		ownerType = p.OwnerType
 		ownerID = p.OwnerID
@@ -156,9 +157,9 @@ func (h *ActionHandler) CanGetRun(ctx context.Context, runGroup string) (bool, e
 	var ownerID string
 	switch groupType {
 	case scommon.GroupTypeProject:
-		p, resp, err := h.configstoreClient.GetProject(ctx, groupID)
+		p, _, err := h.configstoreClient.GetProject(ctx, groupID)
 		if err != nil {
-			return false, ErrFromRemote(resp, err)
+			return false, util.NewAPIError(util.KindFromRemoteError(err), err)
 		}
 		ownerType = p.OwnerType
 		ownerID = p.OwnerID
@@ -193,9 +194,9 @@ func (h *ActionHandler) CanDoRunActions(ctx context.Context, runGroup string) (b
 	var ownerID string
 	switch groupType {
 	case scommon.GroupTypeProject:
-		p, resp, err := h.configstoreClient.GetProject(ctx, groupID)
+		p, _, err := h.configstoreClient.GetProject(ctx, groupID)
 		if err != nil {
-			return false, ErrFromRemote(resp, err)
+			return false, util.NewAPIError(util.KindFromRemoteError(err), err)
 		}
 		ownerType = p.OwnerType
 		ownerID = p.OwnerID

--- a/internal/services/gateway/action/badge.go
+++ b/internal/services/gateway/action/badge.go
@@ -20,22 +20,23 @@ import (
 	"path"
 
 	"agola.io/agola/internal/services/common"
+	"agola.io/agola/internal/util"
 	rstypes "agola.io/agola/services/runservice/types"
 )
 
 // GetBadge return a badge for a project branch
 // TODO(sgotti) also handle tags and PRs
 func (h *ActionHandler) GetBadge(ctx context.Context, projectRef, branch string) (string, error) {
-	project, resp, err := h.configstoreClient.GetProject(ctx, projectRef)
+	project, _, err := h.configstoreClient.GetProject(ctx, projectRef)
 	if err != nil {
-		return "", ErrFromRemote(resp, err)
+		return "", util.NewAPIError(util.KindFromRemoteError(err), err)
 	}
 
 	// if branch is empty we get the latest run for every branch.
 	group := path.Join("/", string(common.GroupTypeProject), project.ID, string(common.GroupTypeBranch), url.PathEscape(branch))
-	runResp, resp, err := h.runserviceClient.GetGroupLastRun(ctx, group, nil)
+	runResp, _, err := h.runserviceClient.GetGroupLastRun(ctx, group, nil)
 	if err != nil {
-		return "", ErrFromRemote(resp, err)
+		return "", util.NewAPIError(util.KindFromRemoteError(err), err)
 	}
 	if len(runResp.Runs) == 0 {
 		return badgeUnknown, nil

--- a/internal/services/gateway/api/api.go
+++ b/internal/services/gateway/api/api.go
@@ -15,7 +15,6 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/url"
 
@@ -26,124 +25,11 @@ import (
 	errors "golang.org/x/xerrors"
 )
 
-type ErrorResponse struct {
-	Message string `json:"message"`
-}
-
-func ErrorResponseFromError(err error) *ErrorResponse {
-	var aerr error
-	// use inner errors if of these types
-	switch {
-	case util.IsBadRequest(err):
-		var cerr *util.ErrBadRequest
-		errors.As(err, &cerr)
-		aerr = cerr
-	case util.IsNotExist(err):
-		var cerr *util.ErrNotExist
-		errors.As(err, &cerr)
-		aerr = cerr
-	case util.IsForbidden(err):
-		var cerr *util.ErrForbidden
-		errors.As(err, &cerr)
-		aerr = cerr
-	case util.IsUnauthorized(err):
-		var cerr *util.ErrUnauthorized
-		errors.As(err, &cerr)
-		aerr = cerr
-	case util.IsInternal(err):
-		var cerr *util.ErrInternal
-		errors.As(err, &cerr)
-		aerr = cerr
-	}
-
-	if aerr != nil {
-		return &ErrorResponse{Message: aerr.Error()}
-	}
-
-	// on generic error return an generic message to not leak the real error
-	return &ErrorResponse{Message: "internal server error"}
-}
-
-func httpError(w http.ResponseWriter, err error) bool {
-	if err == nil {
-		return false
-	}
-
-	response := ErrorResponseFromError(err)
-	resj, merr := json.Marshal(response)
-	if merr != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		return true
-	}
-	switch {
-	case util.IsBadRequest(err):
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write(resj)
-	case util.IsNotExist(err):
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write(resj)
-	case util.IsForbidden(err):
-		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write(resj)
-	case util.IsUnauthorized(err):
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write(resj)
-	case util.IsInternal(err):
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write(resj)
-	default:
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write(resj)
-	}
-	return true
-}
-
-func httpResponse(w http.ResponseWriter, code int, res interface{}) error {
-	w.Header().Set("Content-Type", "application/json")
-
-	if res != nil {
-		resj, err := json.Marshal(res)
-		if err != nil {
-			httpError(w, err)
-			return err
-		}
-		w.WriteHeader(code)
-		_, err = w.Write(resj)
-		return err
-	}
-
-	w.WriteHeader(code)
-	return nil
-}
-
-func httpErrorFromRemote(w http.ResponseWriter, resp *http.Response, err error) bool {
-	if err != nil {
-		// on generic error return an generic message to not leak the real error
-		response := &ErrorResponse{Message: "internal server error"}
-		if resp != nil {
-			response = &ErrorResponse{Message: err.Error()}
-		}
-		resj, merr := json.Marshal(response)
-		if merr != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return true
-		}
-		if resp != nil {
-			w.WriteHeader(resp.StatusCode)
-		} else {
-			w.WriteHeader(http.StatusInternalServerError)
-		}
-		_, _ = w.Write(resj)
-		return true
-	}
-	return false
-}
-
 func GetConfigTypeRef(r *http.Request) (cstypes.ConfigType, string, error) {
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		return "", "", util.NewErrBadRequest(errors.Errorf("wrong projectref %q: %w", vars["projectref"], err))
+		return "", "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("wrong projectref %q: %w", vars["projectref"], err))
 	}
 	if projectRef != "" {
 		return cstypes.ConfigTypeProject, projectRef, nil
@@ -151,11 +37,11 @@ func GetConfigTypeRef(r *http.Request) (cstypes.ConfigType, string, error) {
 
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		return "", "", util.NewErrBadRequest(errors.Errorf("wrong projectgroupref %q: %w", vars["projectgroupref"], err))
+		return "", "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("wrong projectgroupref %q: %w", vars["projectgroupref"], err))
 	}
 	if projectGroupRef != "" {
 		return cstypes.ConfigTypeProjectGroup, projectGroupRef, nil
 	}
 
-	return "", "", util.NewErrBadRequest(errors.Errorf("cannot get project or projectgroup ref"))
+	return "", "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot get project or projectgroup ref"))
 }

--- a/internal/services/gateway/api/badge.go
+++ b/internal/services/gateway/api/badge.go
@@ -20,6 +20,7 @@ import (
 
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/util"
+
 	"github.com/gorilla/mux"
 	"go.uber.org/zap"
 )
@@ -40,13 +41,13 @@ func (h *BadgeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 	branch := query.Get("branch")
 
 	badge, err := h.ah.GetBadge(ctx, projectRef, branch)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}

--- a/internal/services/gateway/api/oauth2.go
+++ b/internal/services/gateway/api/oauth2.go
@@ -42,7 +42,7 @@ func (h *OAuth2CallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	cresp, err := h.ah.HandleOauth2Callback(ctx, code, state)
 	if err != nil {
 		h.log.Errorf("err: %+v", err)
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -86,7 +86,7 @@ func (h *OAuth2CallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		RequestType: string(cresp.RequestType),
 		Response:    response,
 	}
-	if err := httpResponse(w, http.StatusOK, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }

--- a/internal/services/gateway/api/org.go
+++ b/internal/services/gateway/api/org.go
@@ -47,7 +47,7 @@ func (h *CreateOrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req gwapitypes.CreateOrgRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -58,13 +58,13 @@ func (h *CreateOrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	org, err := h.ah.CreateOrg(ctx, creq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	res := createOrgResponse(org)
-	if err := httpResponse(w, http.StatusCreated, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -84,12 +84,12 @@ func (h *DeleteOrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	orgRef := vars["orgref"]
 
 	err := h.ah.DeleteOrg(ctx, orgRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -109,13 +109,13 @@ func (h *OrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	orgRef := vars["orgref"]
 
 	org, err := h.ah.GetOrg(ctx, orgRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	res := createOrgResponse(org)
-	if err := httpResponse(w, http.StatusOK, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -148,12 +148,12 @@ func (h *OrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			httpError(w, util.NewErrBadRequest(errors.Errorf("cannot parse limit: %w", err)))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot parse limit: %w", err)))
 			return
 		}
 	}
 	if limit < 0 {
-		httpError(w, util.NewErrBadRequest(errors.Errorf("limit must be greater or equal than 0")))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("limit must be greater or equal than 0")))
 		return
 	}
 	if limit > MaxRunsLimit {
@@ -172,7 +172,7 @@ func (h *OrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Asc:   asc,
 	}
 	csorgs, err := h.ah.GetOrgs(ctx, areq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -181,7 +181,7 @@ func (h *OrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for i, p := range csorgs {
 		orgs[i] = createOrgResponse(p)
 	}
-	if err := httpResponse(w, http.StatusOK, orgs); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, orgs); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -209,7 +209,7 @@ func (h *OrgMembersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	orgRef := vars["orgref"]
 
 	ares, err := h.ah.GetOrgMembers(ctx, orgRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -221,7 +221,7 @@ func (h *OrgMembersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for i, m := range ares.Members {
 		res.Members[i] = createOrgMemberResponse(m.User, m.Role)
 	}
-	if err := httpResponse(w, http.StatusOK, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -255,18 +255,18 @@ func (h *AddOrgMemberHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	var req gwapitypes.AddOrgMemberRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	ares, err := h.ah.AddOrgMember(ctx, orgRef, userRef, cstypes.MemberRole(req.Role))
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	res := createAddOrgMemberResponse(ares.Org, ares.User, ares.OrganizationMember.MemberRole)
-	if err := httpResponse(w, http.StatusOK, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -288,12 +288,12 @@ func (h *RemoveOrgMemberHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	userRef := vars["userref"]
 
 	err := h.ah.RemoveOrgMember(ctx, orgRef, userRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }

--- a/internal/services/gateway/api/project.go
+++ b/internal/services/gateway/api/project.go
@@ -44,7 +44,7 @@ func (h *CreateProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	var req gwapitypes.CreateProjectRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -59,13 +59,13 @@ func (h *CreateProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	project, err := h.ah.CreateProject(ctx, areq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	res := createProjectResponse(project)
-	if err := httpResponse(w, http.StatusCreated, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -84,14 +84,14 @@ func (h *UpdateProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	var req gwapitypes.UpdateProjectRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -108,13 +108,13 @@ func (h *UpdateProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		PassVarsToForkedPR: req.PassVarsToForkedPR,
 	}
 	project, err := h.ah.UpdateProject(ctx, projectRef, areq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	res := createProjectResponse(project)
-	if err := httpResponse(w, http.StatusCreated, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -133,15 +133,15 @@ func (h *ProjectReconfigHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	if err := h.ah.ReconfigProject(ctx, projectRef); err != nil {
-		httpError(w, err)
+		util.HTTPError(w, err)
 		return
 	}
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -160,18 +160,18 @@ func (h *ProjectUpdateRepoLinkedAccountHandler) ServeHTTP(w http.ResponseWriter,
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	project, err := h.ah.ProjectUpdateRepoLinkedAccount(ctx, projectRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	res := createProjectResponse(project)
-	if err := httpResponse(w, http.StatusOK, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -190,17 +190,17 @@ func (h *DeleteProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	err = h.ah.DeleteProject(ctx, projectRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -219,18 +219,18 @@ func (h *ProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	project, err := h.ah.GetProject(ctx, projectRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	res := createProjectResponse(project)
-	if err := httpResponse(w, http.StatusOK, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -263,24 +263,24 @@ func (h *ProjectCreateRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	var req gwapitypes.ProjectCreateRunRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	err = h.ah.ProjectCreateRun(ctx, projectRef, req.Branch, req.Tag, req.Ref, req.CommitSHA)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusCreated, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }

--- a/internal/services/gateway/api/projectgroup.go
+++ b/internal/services/gateway/api/projectgroup.go
@@ -46,13 +46,13 @@ func (h *CreateProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	var req gwapitypes.CreateProjectGroupRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	userID := common.CurrentUserID(ctx)
 	if userID == "" {
-		httpError(w, util.NewErrBadRequest(errors.Errorf("user not authenticated")))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user not authenticated")))
 		return
 	}
 
@@ -64,13 +64,13 @@ func (h *CreateProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	}
 
 	projectGroup, err := h.ah.CreateProjectGroup(ctx, creq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	res := createProjectGroupResponse(projectGroup)
-	if err := httpResponse(w, http.StatusCreated, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -89,14 +89,14 @@ func (h *UpdateProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	vars := mux.Vars(r)
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	var req gwapitypes.UpdateProjectGroupRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -112,13 +112,13 @@ func (h *UpdateProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 		Visibility: visibility,
 	}
 	projectGroup, err := h.ah.UpdateProjectGroup(ctx, projectGroupRef, areq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	res := createProjectGroupResponse(projectGroup)
-	if err := httpResponse(w, http.StatusCreated, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -137,17 +137,17 @@ func (h *DeleteProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	vars := mux.Vars(r)
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	err = h.ah.DeleteProjectGroup(ctx, projectGroupRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -166,18 +166,18 @@ func (h *ProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	vars := mux.Vars(r)
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	projectGroup, err := h.ah.GetProjectGroup(ctx, projectGroupRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	res := createProjectGroupResponse(projectGroup)
-	if err := httpResponse(w, http.StatusOK, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -196,12 +196,12 @@ func (h *ProjectGroupProjectsHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 	vars := mux.Vars(r)
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	csprojects, err := h.ah.GetProjectGroupProjects(ctx, projectGroupRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -211,7 +211,7 @@ func (h *ProjectGroupProjectsHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 		projects[i] = createProjectResponse(p)
 	}
 
-	if err := httpResponse(w, http.StatusOK, projects); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, projects); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -230,12 +230,12 @@ func (h *ProjectGroupSubgroupsHandler) ServeHTTP(w http.ResponseWriter, r *http.
 	vars := mux.Vars(r)
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	cssubgroups, err := h.ah.GetProjectGroupSubgroups(ctx, projectGroupRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -245,7 +245,7 @@ func (h *ProjectGroupSubgroupsHandler) ServeHTTP(w http.ResponseWriter, r *http.
 		subgroups[i] = createProjectGroupResponse(g)
 	}
 
-	if err := httpResponse(w, http.StatusOK, subgroups); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, subgroups); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }

--- a/internal/services/gateway/api/remotesource.go
+++ b/internal/services/gateway/api/remotesource.go
@@ -44,7 +44,7 @@ func (h *CreateRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	var req gwapitypes.CreateRemoteSourceRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -62,13 +62,13 @@ func (h *CreateRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 		LoginEnabled:        req.LoginEnabled,
 	}
 	rs, err := h.ah.CreateRemoteSource(ctx, creq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	res := createRemoteSourceResponse(rs)
-	if err := httpResponse(w, http.StatusCreated, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -90,7 +90,7 @@ func (h *UpdateRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	var req gwapitypes.UpdateRemoteSourceRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -108,13 +108,13 @@ func (h *UpdateRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 		LoginEnabled:        req.LoginEnabled,
 	}
 	rs, err := h.ah.UpdateRemoteSource(ctx, creq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	res := createRemoteSourceResponse(rs)
-	if err := httpResponse(w, http.StatusCreated, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -145,13 +145,13 @@ func (h *RemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	rsRef := vars["remotesourceref"]
 
 	rs, err := h.ah.GetRemoteSource(ctx, rsRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	res := createRemoteSourceResponse(rs)
-	if err := httpResponse(w, http.StatusOK, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -175,12 +175,12 @@ func (h *RemoteSourcesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			httpError(w, util.NewErrBadRequest(errors.Errorf("cannot parse limit: %w", err)))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot parse limit: %w", err)))
 			return
 		}
 	}
 	if limit < 0 {
-		httpError(w, util.NewErrBadRequest(errors.Errorf("limit must be greater or equal than 0")))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("limit must be greater or equal than 0")))
 		return
 	}
 	if limit > MaxRunsLimit {
@@ -199,7 +199,7 @@ func (h *RemoteSourcesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		Asc:   asc,
 	}
 	csRemoteSources, err := h.ah.GetRemoteSources(ctx, areq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -209,7 +209,7 @@ func (h *RemoteSourcesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		remoteSources[i] = createRemoteSourceResponse(rs)
 	}
 
-	if err := httpResponse(w, http.StatusOK, remoteSources); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, remoteSources); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -229,12 +229,12 @@ func (h *DeleteRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	rsRef := vars["remotesourceref"]
 
 	err := h.ah.DeleteRemoteSource(ctx, rsRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }

--- a/internal/services/gateway/api/repos.go
+++ b/internal/services/gateway/api/repos.go
@@ -19,9 +19,10 @@ import (
 	"net/http"
 	"net/url"
 
-	"go.uber.org/zap"
+	util "agola.io/agola/internal/util"
 
 	"github.com/gorilla/mux"
+	"go.uber.org/zap"
 )
 
 type ReposHandler struct {
@@ -41,7 +42,7 @@ func (h *ReposHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	u, err := url.Parse(h.gitServerURL)
 	if err != nil {
 		h.log.Errorf("err: %+v", err)
-		httpError(w, err)
+		util.HTTPError(w, err)
 		return
 	}
 	u.Path = path
@@ -53,7 +54,7 @@ func (h *ReposHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	req = req.WithContext(ctx)
 	if err != nil {
 		h.log.Errorf("err: %+v", err)
-		httpError(w, err)
+		util.HTTPError(w, err)
 		return
 	}
 
@@ -67,7 +68,7 @@ func (h *ReposHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		h.log.Errorf("err: %+v", err)
-		httpError(w, err)
+		util.HTTPError(w, err)
 		return
 	}
 
@@ -84,7 +85,7 @@ func (h *ReposHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// copy response body
 	if _, err := io.Copy(w, resp.Body); err != nil {
 		h.log.Errorf("err: %+v", err)
-		httpError(w, err)
+		util.HTTPError(w, err)
 		return
 	}
 }

--- a/internal/services/gateway/api/secret.go
+++ b/internal/services/gateway/api/secret.go
@@ -52,7 +52,7 @@ func (h *SecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, removeoverridden := query["removeoverridden"]
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -64,7 +64,7 @@ func (h *SecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		RemoveOverridden: removeoverridden,
 	}
 	cssecrets, err := h.ah.GetSecrets(ctx, areq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -74,7 +74,7 @@ func (h *SecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		secrets[i] = createSecretResponse(s)
 	}
 
-	if err := httpResponse(w, http.StatusOK, secrets); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, secrets); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -91,14 +91,14 @@ func NewCreateSecretHandler(logger *zap.Logger, ah *action.ActionHandler) *Creat
 func (h *CreateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	parentType, parentRef, err := GetConfigTypeRef(r)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		return
 	}
 
 	var req gwapitypes.CreateSecretRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -112,13 +112,13 @@ func (h *CreateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		Path:             req.Path,
 	}
 	cssecret, err := h.ah.CreateSecret(ctx, areq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	res := createSecretResponse(cssecret)
-	if err := httpResponse(w, http.StatusCreated, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -138,7 +138,7 @@ func (h *UpdateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	secretName := vars["secretname"]
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -146,7 +146,7 @@ func (h *UpdateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	var req gwapitypes.UpdateSecretRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 	areq := &action.UpdateSecretRequest{
@@ -161,13 +161,13 @@ func (h *UpdateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		Path:             req.Path,
 	}
 	cssecret, err := h.ah.UpdateSecret(ctx, areq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	res := createSecretResponse(cssecret)
-	if err := httpResponse(w, http.StatusOK, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -187,17 +187,17 @@ func (h *DeleteSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	secretName := vars["secretname"]
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		return
 	}
 
 	err = h.ah.DeleteSecret(ctx, parentType, parentRef, secretName)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }

--- a/internal/services/gateway/api/user.go
+++ b/internal/services/gateway/api/user.go
@@ -48,7 +48,7 @@ func (h *CreateUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req gwapitypes.CreateUserRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -57,13 +57,13 @@ func (h *CreateUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	u, err := h.ah.CreateUser(ctx, creq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	res := createUserResponse(u)
-	if err := httpResponse(w, http.StatusCreated, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -83,12 +83,12 @@ func (h *DeleteUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	userRef := vars["userref"]
 
 	err := h.ah.DeleteUser(ctx, userRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -107,18 +107,18 @@ func (h *CurrentUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	userID := common.CurrentUserID(ctx)
 	if userID == "" {
-		httpError(w, util.NewErrBadRequest(errors.Errorf("user not authenticated")))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user not authenticated")))
 		return
 	}
 
 	user, err := h.ah.GetUser(ctx, userID)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	res := createUserResponse(user)
-	if err := httpResponse(w, http.StatusOK, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -138,13 +138,13 @@ func (h *UserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	userRef := vars["userref"]
 
 	user, err := h.ah.GetUser(ctx, userRef)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	res := createUserResponse(user)
-	if err := httpResponse(w, http.StatusOK, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -193,12 +193,12 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			httpError(w, util.NewErrBadRequest(errors.Errorf("cannot parse limit: %w", err)))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot parse limit: %w", err)))
 			return
 		}
 	}
 	if limit < 0 {
-		httpError(w, util.NewErrBadRequest(errors.Errorf("limit must be greater or equal than 0")))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("limit must be greater or equal than 0")))
 		return
 	}
 	if limit > MaxRunsLimit {
@@ -217,7 +217,7 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Asc:   asc,
 	}
 	csusers, err := h.ah.GetUsers(ctx, areq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -227,7 +227,7 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		users[i] = createUserResponse(p)
 	}
 
-	if err := httpResponse(w, http.StatusOK, users); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, users); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -249,17 +249,17 @@ func (h *CreateUserLAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	var req *gwapitypes.CreateUserLARequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	res, err := h.createUserLA(ctx, userRef, req)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusCreated, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -311,12 +311,12 @@ func (h *DeleteUserLAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	laID := vars["laid"]
 
 	err := h.ah.DeleteUserLA(ctx, userRef, laID)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -338,7 +338,7 @@ func (h *CreateUserTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	var req gwapitypes.CreateUserTokenRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -348,7 +348,7 @@ func (h *CreateUserTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	}
 	h.log.Infof("creating user %q token", userRef)
 	token, err := h.ah.CreateUserToken(ctx, creq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -357,7 +357,7 @@ func (h *CreateUserTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		Token: token,
 	}
 
-	if err := httpResponse(w, http.StatusCreated, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -379,12 +379,12 @@ func (h *DeleteUserTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	h.log.Infof("deleting user %q token %q", userRef, tokenName)
 	err := h.ah.DeleteUserToken(ctx, userRef, tokenName)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -404,17 +404,17 @@ func (h *RegisterUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	var req *gwapitypes.RegisterUserRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	res, err := h.registerUser(ctx, req)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusCreated, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -455,17 +455,17 @@ func (h *AuthorizeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req *gwapitypes.LoginUserRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	res, err := h.authorize(ctx, req)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusCreated, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -512,17 +512,17 @@ func (h *LoginUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req *gwapitypes.LoginUserRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
 	res, err := h.loginUser(ctx, req)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusCreated, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -566,7 +566,7 @@ func (h *UserCreateRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	var req gwapitypes.UserCreateRunRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -582,12 +582,12 @@ func (h *UserCreateRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		Variables:             req.Variables,
 	}
 	err := h.ah.UserCreateRun(ctx, creq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusCreated, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -606,12 +606,12 @@ func (h *UserOrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	userID := common.CurrentUserID(ctx)
 	if userID == "" {
-		httpError(w, util.NewErrBadRequest(errors.Errorf("user not authenticated")))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user not authenticated")))
 		return
 	}
 
 	userOrgs, err := h.ah.GetUserOrgs(ctx, userID)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -621,7 +621,7 @@ func (h *UserOrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		res[i] = createUserOrgsResponse(userOrg)
 	}
 
-	if err := httpResponse(w, http.StatusOK, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }

--- a/internal/services/gateway/api/variable.go
+++ b/internal/services/gateway/api/variable.go
@@ -69,7 +69,7 @@ func (h *VariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, removeoverridden := query["removeoverridden"]
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -81,7 +81,7 @@ func (h *VariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		RemoveOverridden: removeoverridden,
 	}
 	csvars, cssecrets, err := h.ah.GetVariables(ctx, areq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -91,7 +91,7 @@ func (h *VariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		variables[i] = createVariableResponse(v, cssecrets)
 	}
 
-	if err := httpResponse(w, http.StatusOK, variables); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, variables); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -108,7 +108,7 @@ func NewCreateVariableHandler(logger *zap.Logger, ah *action.ActionHandler) *Cre
 func (h *CreateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	parentType, parentRef, err := GetConfigTypeRef(r)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -116,7 +116,7 @@ func (h *CreateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	var req gwapitypes.CreateVariableRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 	areq := &action.CreateVariableRequest{
@@ -126,13 +126,13 @@ func (h *CreateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		Values:     fromApiVariableValues(req.Values),
 	}
 	csvar, cssecrets, err := h.ah.CreateVariable(ctx, areq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	res := createVariableResponse(csvar, cssecrets)
-	if err := httpResponse(w, http.StatusCreated, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusCreated, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -152,7 +152,7 @@ func (h *UpdateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	variableName := vars["variablename"]
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
@@ -160,7 +160,7 @@ func (h *UpdateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	var req gwapitypes.UpdateVariableRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		httpError(w, util.NewErrBadRequest(err))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
@@ -173,13 +173,13 @@ func (h *UpdateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		Values:     fromApiVariableValues(req.Values),
 	}
 	csvar, cssecrets, err := h.ah.UpdateVariable(ctx, areq)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	res := createVariableResponse(csvar, cssecrets)
-	if err := httpResponse(w, http.StatusOK, res); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, res); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -199,18 +199,18 @@ func (h *DeleteVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	variableName := vars["variablename"]
 
 	parentType, parentRef, err := GetConfigTypeRef(r)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
 	err = h.ah.DeleteVariable(ctx, parentType, parentRef, variableName)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusNoContent, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }

--- a/internal/services/gateway/api/version.go
+++ b/internal/services/gateway/api/version.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 
 	"agola.io/agola/internal/services/gateway/action"
+	util "agola.io/agola/internal/util"
 
 	"go.uber.org/zap"
 )
@@ -35,12 +36,12 @@ func (h *VersionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	version, err := h.ah.GetVersion(ctx)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, version); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, version); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }

--- a/internal/services/gateway/api/webhook.go
+++ b/internal/services/gateway/api/webhook.go
@@ -48,12 +48,12 @@ func NewWebhooksHandler(logger *zap.Logger, ah *action.ActionHandler, configstor
 
 func (h *webhooksHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err := h.handleWebhook(r)
-	if httpError(w, err) {
+	if util.HTTPError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 }
@@ -63,33 +63,33 @@ func (h *webhooksHandler) handleWebhook(r *http.Request) error {
 
 	projectID := r.URL.Query().Get("projectid")
 	if projectID == "" {
-		return util.NewErrBadRequest(errors.Errorf("bad webhook url %q. Missing projectid", r.URL))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("bad webhook url %q. Missing projectid", r.URL))
 	}
 
 	defer r.Body.Close()
 
 	csProject, _, err := h.configstoreClient.GetProject(ctx, projectID)
 	if err != nil {
-		return util.NewErrBadRequest(errors.Errorf("failed to get project %s: %w", projectID, err))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("failed to get project %s: %w", projectID, err))
 	}
 	project := csProject.Project
 
 	user, _, err := h.configstoreClient.GetUserByLinkedAccount(ctx, project.LinkedAccountID)
 	if err != nil {
-		return util.NewErrInternal(errors.Errorf("failed to get user by linked account %q: %w", project.LinkedAccountID, err))
+		return util.NewAPIError(util.ErrInternal, errors.Errorf("failed to get user by linked account %q: %w", project.LinkedAccountID, err))
 	}
 	la := user.LinkedAccounts[project.LinkedAccountID]
 	if la == nil {
-		return util.NewErrInternal(errors.Errorf("linked account %q in user %q doesn't exist", project.LinkedAccountID, user.Name))
+		return util.NewAPIError(util.ErrInternal, errors.Errorf("linked account %q in user %q doesn't exist", project.LinkedAccountID, user.Name))
 	}
 	rs, _, err := h.configstoreClient.GetRemoteSource(ctx, la.RemoteSourceID)
 	if err != nil {
-		return util.NewErrInternal(errors.Errorf("failed to get remote source %q: %w", la.RemoteSourceID, err))
+		return util.NewAPIError(util.ErrInternal, errors.Errorf("failed to get remote source %q: %w", la.RemoteSourceID, err))
 	}
 
 	gitSource, err := h.ah.GetGitSource(ctx, rs, user.Name, la)
 	if err != nil {
-		return util.NewErrInternal(errors.Errorf("failed to create gitea client: %w", err))
+		return util.NewAPIError(util.ErrInternal, errors.Errorf("failed to create gitea client: %w", err))
 	}
 
 	sshPrivKey := project.SSHPrivateKey
@@ -102,7 +102,7 @@ func (h *webhooksHandler) handleWebhook(r *http.Request) error {
 
 	webhookData, err := gitSource.ParseWebhook(r, project.WebhookSecret)
 	if err != nil {
-		return util.NewErrBadRequest(errors.Errorf("failed to parse webhook: %w", err))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("failed to parse webhook: %w", err))
 	}
 	// skip nil webhook data
 	// TODO(sgotti) report the reason of the skip
@@ -141,7 +141,7 @@ func (h *webhooksHandler) handleWebhook(r *http.Request) error {
 		CompareLink:     webhookData.CompareLink,
 	}
 	if err := h.ah.CreateRuns(ctx, req); err != nil {
-		return util.NewErrInternal(errors.Errorf("failed to create run: %w", err))
+		return util.NewAPIError(util.ErrInternal, errors.Errorf("failed to create run: %w", err))
 	}
 
 	return nil

--- a/internal/services/runservice/action/maintenance.go
+++ b/internal/services/runservice/action/maintenance.go
@@ -32,10 +32,10 @@ func (h *ActionHandler) MaintenanceMode(ctx context.Context, enable bool) error 
 	}
 
 	if enable && len(resp.Kvs) > 0 {
-		return util.NewErrBadRequest(errors.Errorf("maintenance mode already enabled"))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("maintenance mode already enabled"))
 	}
 	if !enable && len(resp.Kvs) == 0 {
-		return util.NewErrBadRequest(errors.Errorf("maintenance mode already disabled"))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("maintenance mode already disabled"))
 	}
 
 	if enable {
@@ -67,7 +67,7 @@ func (h *ActionHandler) Export(ctx context.Context, w io.Writer) error {
 
 func (h *ActionHandler) Import(ctx context.Context, r io.Reader) error {
 	if !h.maintenanceMode {
-		return util.NewErrBadRequest(errors.Errorf("not in maintenance mode"))
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("not in maintenance mode"))
 	}
 	return h.dm.Import(ctx, r)
 }

--- a/internal/services/runservice/api/maintenance.go
+++ b/internal/services/runservice/api/maintenance.go
@@ -19,6 +19,7 @@ import (
 
 	"agola.io/agola/internal/etcd"
 	"agola.io/agola/internal/services/runservice/action"
+	"agola.io/agola/internal/util"
 
 	"go.uber.org/zap"
 )
@@ -47,11 +48,11 @@ func (h *MaintenanceModeHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	err := h.ah.MaintenanceMode(ctx, enable)
 	if err != nil {
 		h.log.Errorf("err: %+v", err)
-		httpError(w, err)
+		util.HTTPError(w, err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 
@@ -96,11 +97,11 @@ func (h *ImportHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err := h.ah.Import(ctx, r.Body)
 	if err != nil {
 		h.log.Errorf("err: %+v", err)
-		httpError(w, err)
+		util.HTTPError(w, err)
 		return
 	}
 
-	if err := httpResponse(w, http.StatusOK, nil); err != nil {
+	if err := util.HTTPResponse(w, http.StatusOK, nil); err != nil {
 		h.log.Errorf("err: %+v", err)
 	}
 

--- a/internal/services/runservice/store/store.go
+++ b/internal/services/runservice/store/store.go
@@ -24,7 +24,6 @@ import (
 
 	"agola.io/agola/internal/datamanager"
 	"agola.io/agola/internal/etcd"
-	"agola.io/agola/internal/objectstorage"
 	"agola.io/agola/internal/services/runservice/common"
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/runservice/types"
@@ -527,7 +526,7 @@ func GetRunEtcdOrOST(ctx context.Context, e *etcd.Store, dm *datamanager.DataMan
 	}
 	if r == nil {
 		r, err = OSTGetRun(dm, runID)
-		if err != nil && !objectstorage.IsNotExist(err) {
+		if err != nil && !datamanager.IsNotExist(err) {
 			return nil, err
 		}
 	}

--- a/internal/services/scheduler/scheduler.go
+++ b/internal/services/scheduler/scheduler.go
@@ -163,7 +163,7 @@ func (s *Scheduler) approveRunTasks(ctx context.Context, runID string) error {
 	for _, rtID := range tasksWaitingApproval {
 		rt, ok := run.Tasks[rtID]
 		if !ok {
-			return util.NewErrBadRequest(errors.Errorf("run %q doesn't have task %q", run.ID, rtID))
+			return errors.Errorf("run %q doesn't have task %q", run.ID, rtID)
 		}
 		annotations := rt.Annotations
 		if annotations == nil {

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -15,9 +15,9 @@
 package util
 
 import (
+	"errors"
+	"fmt"
 	"strings"
-
-	errors "golang.org/x/xerrors"
 )
 
 // Errors is an error that contains multiple errors
@@ -59,116 +59,130 @@ func (e *Errors) Equal(e2 error) bool {
 	return CompareStringSliceNoOrder(errs1, errs2)
 }
 
-// ErrBadRequest represent an error caused by a bad command request
-// it's used to differentiate an internal error from an user error
-type ErrBadRequest struct {
-	Err error
+type ErrorKind int
+type ErrorCode string
+
+const (
+	ErrBadRequest ErrorKind = iota
+	ErrNotExist
+	ErrForbidden
+	ErrUnauthorized
+	ErrInternal
+)
+
+func (k ErrorKind) String() string {
+	switch k {
+	case ErrBadRequest:
+		return "badrequest"
+	case ErrNotExist:
+		return "notexist"
+	case ErrForbidden:
+		return "forbidden"
+	case ErrUnauthorized:
+		return "unauthorized"
+	case ErrInternal:
+		return "internal"
+	}
+
+	return "unknown"
 }
 
-func (e *ErrBadRequest) Error() string {
-	return e.Err.Error()
+type APIError struct {
+	err     error
+	Kind    ErrorKind
+	Code    ErrorCode
+	Message string
 }
 
-func NewErrBadRequest(err error) *ErrBadRequest {
-	return &ErrBadRequest{Err: err}
+func NewAPIError(kind ErrorKind, err error, options ...APIErrorOption) error {
+	derr := &APIError{err: err, Kind: kind}
+
+	for _, opt := range options {
+		opt(derr)
+	}
+
+	return derr
 }
 
-func (e *ErrBadRequest) Unwrap() error {
-	return e.Err
+func (e *APIError) Error() string {
+	return e.err.Error()
 }
 
-func IsBadRequest(err error) bool {
-	var e *ErrBadRequest
-	return errors.As(err, &e)
+func (e *APIError) Unwrap() error {
+	return e.err
 }
 
-// ErrNotExist represent a not exist error
-// it's used to differentiate an internal error from an user error
-type ErrNotExist struct {
-	Err error
+type APIErrorOption func(e *APIError)
+
+func WithCode(code ErrorCode) APIErrorOption {
+	return func(e *APIError) {
+		e.Code = code
+	}
 }
 
-func (e *ErrNotExist) Error() string {
-	return e.Err.Error()
+func WithMessage(message string) APIErrorOption {
+	return func(e *APIError) {
+		e.Message = message
+	}
 }
 
-func NewErrNotExist(err error) *ErrNotExist {
-	return &ErrNotExist{Err: err}
+func AsAPIError(err error) (*APIError, bool) {
+	var derr *APIError
+	return derr, errors.As(err, &derr)
 }
 
-func (e *ErrNotExist) Unwrap() error {
-	return e.Err
+func APIErrorIs(err error, kind ErrorKind) bool {
+	if derr, ok := AsAPIError(err); ok && derr.Kind == kind {
+		return true
+	}
+
+	return false
 }
 
-func IsNotExist(err error) bool {
-	var e *ErrNotExist
-	return errors.As(err, &e)
+// RemoteError is an error received from a remote call. It's similar to
+// APIError but with another type so it can be distinguished and won't be
+// propagated to the api response.
+type RemoteError struct {
+	Kind    ErrorKind
+	Code    string
+	Message string
 }
 
-// ErrForbidden represent an error caused by an forbidden operation
-// it's used to differentiate an internal error from an user error
-type ErrForbidden struct {
-	Err error
+func NewRemoteError(kind ErrorKind, code string, message string) error {
+	return &RemoteError{Kind: kind, Code: code, Message: message}
 }
 
-func (e *ErrForbidden) Error() string {
-	return e.Err.Error()
+func (e *RemoteError) Error() string {
+	code := e.Code
+	message := e.Message
+	errStr := fmt.Sprintf("remote error %s", e.Kind)
+	if code != "" {
+		errStr += fmt.Sprintf(" (code: %s)", code)
+	}
+	if message != "" {
+		errStr += fmt.Sprintf(" (message: %s)", message)
+	}
+
+	return errStr
 }
 
-func NewErrForbidden(err error) *ErrForbidden {
-	return &ErrForbidden{Err: err}
+func AsRemoteError(err error) (*RemoteError, bool) {
+	var rerr *RemoteError
+	return rerr, errors.As(err, &rerr)
 }
 
-func (e *ErrForbidden) Unwrap() error {
-	return e.Err
+func RemoteErrorIs(err error, kind ErrorKind) bool {
+	if rerr, ok := AsRemoteError(err); ok && rerr.Kind == kind {
+		return true
+	}
+
+	return false
 }
 
-func IsForbidden(err error) bool {
-	var e *ErrForbidden
-	return errors.As(err, &e)
-}
+func KindFromRemoteError(err error) ErrorKind {
+	if rerr, ok := AsRemoteError(err); ok {
+		return rerr.Kind
+	}
 
-// ErrUnauthorized represent an error caused by an unauthorized request
-// it's used to differentiate an internal error from an user error
-type ErrUnauthorized struct {
-	Err error
-}
-
-func (e *ErrUnauthorized) Error() string {
-	return e.Err.Error()
-}
-
-func NewErrUnauthorized(err error) *ErrUnauthorized {
-	return &ErrUnauthorized{Err: err}
-}
-
-func (e *ErrUnauthorized) Unwrap() error {
-	return e.Err
-}
-
-func IsUnauthorized(err error) bool {
-	var e *ErrUnauthorized
-	return errors.As(err, &e)
-}
-
-type ErrInternal struct {
-	Err error
-}
-
-// ErrInternal represent an internal error that should be returned to the user
-func (e *ErrInternal) Error() string {
-	return e.Err.Error()
-}
-
-func NewErrInternal(err error) *ErrInternal {
-	return &ErrInternal{Err: err}
-}
-
-func (e *ErrInternal) Unwrap() error {
-	return e.Err
-}
-
-func IsInternal(err error) bool {
-	var e *ErrInternal
-	return errors.As(err, &e)
+	return ErrInternal
 }

--- a/internal/util/http.go
+++ b/internal/util/http.go
@@ -1,0 +1,124 @@
+package util
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	errors "golang.org/x/xerrors"
+)
+
+func HTTPResponse(w http.ResponseWriter, code int, res interface{}) error {
+	w.Header().Set("Content-Type", "application/json")
+
+	if res != nil {
+		resj, err := json.Marshal(res)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return err
+		}
+		w.WriteHeader(code)
+		_, err = w.Write(resj)
+		return err
+	}
+
+	w.WriteHeader(code)
+	return nil
+}
+
+type ErrorResponse struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func ErrorResponseFromError(err error) *ErrorResponse {
+	if err == nil {
+		return nil
+	}
+
+	var derr *APIError
+	if errors.As(err, &derr) {
+		return &ErrorResponse{Code: string(derr.Code), Message: derr.Message}
+	}
+
+	// on generic error return an error response without any code
+	return &ErrorResponse{}
+}
+
+func HTTPError(w http.ResponseWriter, err error) bool {
+	if err == nil {
+		return false
+	}
+
+	response := ErrorResponseFromError(err)
+	resj, merr := json.Marshal(response)
+	if merr != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return true
+	}
+
+	code := http.StatusInternalServerError
+
+	var derr *APIError
+	if errors.As(err, &derr) {
+		switch derr.Kind {
+		case ErrBadRequest:
+			code = http.StatusBadRequest
+		case ErrNotExist:
+			code = http.StatusNotFound
+		case ErrForbidden:
+			code = http.StatusForbidden
+		case ErrUnauthorized:
+			code = http.StatusUnauthorized
+		case ErrInternal:
+			code = http.StatusInternalServerError
+		}
+	}
+
+	w.WriteHeader(code)
+	_, _ = w.Write(resj)
+
+	return true
+}
+
+func ErrFromRemote(resp *http.Response) error {
+	if resp == nil {
+		return nil
+	}
+	if resp.StatusCode/100 == 2 {
+		return nil
+	}
+
+	response := &ErrorResponse{}
+
+	defer resp.Body.Close()
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	// Re-populate error response body so it can be parsed by the caller if needed
+	resp.Body = ioutil.NopCloser(bytes.NewBuffer(data))
+
+	if err := json.Unmarshal(data, &response); err != nil {
+		return errors.Errorf("unknown api error (status: %d)", resp.StatusCode)
+	}
+
+	kind := ErrInternal
+	switch resp.StatusCode {
+	case http.StatusBadRequest:
+		kind = ErrBadRequest
+	case http.StatusNotFound:
+		kind = ErrNotExist
+	case http.StatusForbidden:
+		kind = ErrForbidden
+	case http.StatusUnauthorized:
+		kind = ErrUnauthorized
+	case http.StatusInternalServerError:
+		kind = ErrInternal
+	}
+
+	return NewRemoteError(kind, response.Code, response.Message)
+}

--- a/services/runservice/client/client.go
+++ b/services/runservice/client/client.go
@@ -20,15 +20,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 
+	"agola.io/agola/internal/util"
 	rsapitypes "agola.io/agola/services/runservice/api/types"
 	rstypes "agola.io/agola/services/runservice/types"
-	errors "golang.org/x/xerrors"
 )
 
 var jsonContent = http.Header{"Content-Type": []string{"application/json"}}
@@ -80,18 +79,8 @@ func (c *Client) getResponse(ctx context.Context, method, path string, query url
 		return nil, err
 	}
 
-	if resp.StatusCode/100 != 2 {
-		defer resp.Body.Close()
-		data, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return resp, err
-		}
-
-		errMap := make(map[string]interface{})
-		if err = json.Unmarshal(data, &errMap); err != nil {
-			return resp, fmt.Errorf("unknown api error (code: %d): %s", resp.StatusCode, string(data))
-		}
-		return resp, errors.New(errMap["message"].(string))
+	if err := util.ErrFromRemote(resp); err != nil {
+		return resp, err
 	}
 
 	return resp, nil

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -1288,7 +1288,7 @@ func TestDirectRunLogs(t *testing.T) {
 		{
 			name: "test get log with unexisting step",
 			step: 99,
-			err:  errors.Errorf("log doesn't exist"),
+			err:  util.NewRemoteError(util.ErrNotExist, "", ""),
 		},
 		{
 			name:   "test delete log step 1",
@@ -1304,7 +1304,7 @@ func TestDirectRunLogs(t *testing.T) {
 			name:   "test delete log with unexisting step",
 			step:   99,
 			delete: true,
-			err:    errors.Errorf("log doesn't exist"),
+			err:    util.NewRemoteError(util.ErrNotExist, "", ""),
 		},
 	}
 


### PR DESCRIPTION
* Create an APIError that should only be used for api returned errors.
  It'll wrap an error and can have different Kinds and optional code and
  message.
* The http handlers will use the first APIError available in the
  error chain and generate a json response body containing the code and
  the user message. The wrapped error is internal and is not sent in the
  response.
  If no api error is available in the chain a generic internal
  server error will be returned.
* Add a RemoteError type that will be created from remote services calls
  (runservice, configstore). It's similar to the APIError but a
  different type to not propagate to the caller response and it'll not
  contain any wrapped error.
* Gateway: when we call a remote service, by default, we'll create a
  APIError using the RemoteError Kind (omitting the code and the
  message that usually must not be propagated).
  This is done for all the remote service calls as a starting point, in
  future, if this default behavior is not the right one for a specific
  remote service call, a new api error with a different kind and/or
  augmented with the calling service error codes and user messages could
  be created.
* datamanager: Use a dedicated ErrNotExist (and converting objectstorage
  ErrNotExist).