### PR TITLE
gateway: use dedicated auth context keys type

### DIFF
--- a/internal/services/gateway/action/org.go
+++ b/internal/services/gateway/action/org.go
@@ -17,6 +17,7 @@ package action
 import (
 	"context"
 
+	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
 	cstypes "agola.io/agola/services/configstore/types"
 
@@ -87,7 +88,7 @@ type CreateOrgRequest struct {
 }
 
 func (h *ActionHandler) CreateOrg(ctx context.Context, req *CreateOrgRequest) (*cstypes.Organization, error) {
-	if !h.IsUserLoggedOrAdmin(ctx) {
+	if !common.IsUserLoggedOrAdmin(ctx) {
 		return nil, errors.Errorf("user not logged in")
 	}
 

--- a/internal/services/gateway/action/project.go
+++ b/internal/services/gateway/action/project.go
@@ -22,6 +22,7 @@ import (
 	"path"
 
 	gitsource "agola.io/agola/internal/gitsources"
+	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/services/types"
 	"agola.io/agola/internal/util"
 	csapitypes "agola.io/agola/services/configstore/api/types"
@@ -61,7 +62,7 @@ type CreateProjectRequest struct {
 }
 
 func (h *ActionHandler) CreateProject(ctx context.Context, req *CreateProjectRequest) (*csapitypes.Project, error) {
-	curUserID := h.CurrentUserID(ctx)
+	curUserID := common.CurrentUserID(ctx)
 
 	user, resp, err := h.configstoreClient.GetUser(ctx, curUserID)
 	if err != nil {
@@ -227,7 +228,7 @@ func (h *ActionHandler) UpdateProject(ctx context.Context, projectRef string, re
 }
 
 func (h *ActionHandler) ProjectUpdateRepoLinkedAccount(ctx context.Context, projectRef string) (*csapitypes.Project, error) {
-	curUserID := h.CurrentUserID(ctx)
+	curUserID := common.CurrentUserID(ctx)
 
 	user, resp, err := h.configstoreClient.GetUser(ctx, curUserID)
 	if err != nil {
@@ -428,7 +429,7 @@ func (h *ActionHandler) DeleteProject(ctx context.Context, projectRef string) er
 }
 
 func (h *ActionHandler) ProjectCreateRun(ctx context.Context, projectRef, branch, tag, refName, commitSHA string) error {
-	curUserID := h.CurrentUserID(ctx)
+	curUserID := common.CurrentUserID(ctx)
 
 	user, resp, err := h.configstoreClient.GetUser(ctx, curUserID)
 	if err != nil {

--- a/internal/services/gateway/action/remotesource.go
+++ b/internal/services/gateway/action/remotesource.go
@@ -17,6 +17,7 @@ package action
 import (
 	"context"
 
+	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
 	cstypes "agola.io/agola/services/configstore/types"
 
@@ -60,7 +61,7 @@ type CreateRemoteSourceRequest struct {
 }
 
 func (h *ActionHandler) CreateRemoteSource(ctx context.Context, req *CreateRemoteSourceRequest) (*cstypes.RemoteSource, error) {
-	if !h.IsUserAdmin(ctx) {
+	if !common.IsUserAdmin(ctx) {
 		return nil, errors.Errorf("user not admin")
 	}
 
@@ -134,7 +135,7 @@ type UpdateRemoteSourceRequest struct {
 }
 
 func (h *ActionHandler) UpdateRemoteSource(ctx context.Context, req *UpdateRemoteSourceRequest) (*cstypes.RemoteSource, error) {
-	if !h.IsUserAdmin(ctx) {
+	if !common.IsUserAdmin(ctx) {
 		return nil, errors.Errorf("user not admin")
 	}
 
@@ -182,7 +183,7 @@ func (h *ActionHandler) UpdateRemoteSource(ctx context.Context, req *UpdateRemot
 }
 
 func (h *ActionHandler) DeleteRemoteSource(ctx context.Context, rsRef string) error {
-	if !h.IsUserAdmin(ctx) {
+	if !common.IsUserAdmin(ctx) {
 		return errors.Errorf("user not admin")
 	}
 

--- a/internal/services/gateway/api/org.go
+++ b/internal/services/gateway/api/org.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"agola.io/agola/internal/services/gateway/action"
+	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
 	cstypes "agola.io/agola/services/configstore/types"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
@@ -41,11 +42,7 @@ func NewCreateOrgHandler(logger *zap.Logger, ah *action.ActionHandler) *CreateOr
 func (h *CreateOrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	var userID string
-	userIDVal := ctx.Value("userid")
-	if userIDVal != nil {
-		userID = userIDVal.(string)
-	}
+	userID := common.CurrentUserID(ctx)
 
 	var req gwapitypes.CreateOrgRequest
 	d := json.NewDecoder(r.Body)

--- a/internal/services/gateway/api/projectgroup.go
+++ b/internal/services/gateway/api/projectgroup.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 
 	"agola.io/agola/internal/services/gateway/action"
+	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
 	csapitypes "agola.io/agola/services/configstore/api/types"
 	cstypes "agola.io/agola/services/configstore/types"
@@ -49,12 +50,11 @@ func (h *CreateProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	userIDVal := ctx.Value("userid")
-	if userIDVal == nil {
+	userID := common.CurrentUserID(ctx)
+	if userID == "" {
 		httpError(w, util.NewErrBadRequest(errors.Errorf("user not authenticated")))
 		return
 	}
-	userID := userIDVal.(string)
 
 	creq := &action.CreateProjectGroupRequest{
 		Name:          req.Name,

--- a/internal/services/gateway/api/remoterepo.go
+++ b/internal/services/gateway/api/remoterepo.go
@@ -19,6 +19,7 @@ import (
 
 	gitsource "agola.io/agola/internal/gitsources"
 	"agola.io/agola/internal/services/gateway/action"
+	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
 	csclient "agola.io/agola/services/configstore/client"
 	cstypes "agola.io/agola/services/configstore/types"
@@ -53,12 +54,11 @@ func (h *UserRemoteReposHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	vars := mux.Vars(r)
 	remoteSourceRef := vars["remotesourceref"]
 
-	userIDVal := ctx.Value("userid")
-	if userIDVal == nil {
+	userID := common.CurrentUserID(ctx)
+	if userID == "" {
 		httpError(w, util.NewErrBadRequest(errors.Errorf("user not authenticated")))
 		return
 	}
-	userID := userIDVal.(string)
 
 	user, resp, err := h.configstoreClient.GetUser(ctx, userID)
 	if httpErrorFromRemote(w, resp, err) {

--- a/internal/services/gateway/api/user.go
+++ b/internal/services/gateway/api/user.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 
 	"agola.io/agola/internal/services/gateway/action"
+	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
 	csapitypes "agola.io/agola/services/configstore/api/types"
 	cstypes "agola.io/agola/services/configstore/types"
@@ -104,12 +105,11 @@ func NewCurrentUserHandler(logger *zap.Logger, ah *action.ActionHandler) *Curren
 func (h *CurrentUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	userIDVal := ctx.Value("userid")
-	if userIDVal == nil {
+	userID := common.CurrentUserID(ctx)
+	if userID == "" {
 		httpError(w, util.NewErrBadRequest(errors.Errorf("user not authenticated")))
 		return
 	}
-	userID := userIDVal.(string)
 
 	user, err := h.ah.GetUser(ctx, userID)
 	if httpError(w, err) {
@@ -604,14 +604,13 @@ func NewUserOrgsHandler(logger *zap.Logger, ah *action.ActionHandler) *UserOrgsH
 func (h *UserOrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	userIDVal := ctx.Value("userid")
-	if userIDVal == nil {
+	userID := common.CurrentUserID(ctx)
+	if userID == "" {
 		httpError(w, util.NewErrBadRequest(errors.Errorf("user not authenticated")))
 		return
 	}
-	userRef := userIDVal.(string)
 
-	userOrgs, err := h.ah.GetUserOrgs(ctx, userRef)
+	userOrgs, err := h.ah.GetUserOrgs(ctx, userID)
 	if httpError(w, err) {
 		h.log.Errorf("err: %+v", err)
 		return

--- a/internal/services/gateway/common/common.go
+++ b/internal/services/gateway/common/common.go
@@ -1,0 +1,36 @@
+package common
+
+import "context"
+
+type ContextKey int
+
+const (
+	ContextKeyUserID ContextKey = iota
+	ContextKeyUsername
+	ContextKeyUserAdmin
+)
+
+func CurrentUserID(ctx context.Context) string {
+	userIDVal := ctx.Value(ContextKeyUserID)
+	if userIDVal == nil {
+		return ""
+	}
+	return userIDVal.(string)
+}
+
+func IsUserLogged(ctx context.Context) bool {
+	return ctx.Value(ContextKeyUserID) != nil
+}
+
+func IsUserAdmin(ctx context.Context) bool {
+	isAdmin := false
+	isAdminVal := ctx.Value(ContextKeyUserAdmin)
+	if isAdminVal != nil {
+		isAdmin = isAdminVal.(bool)
+	}
+	return isAdmin
+}
+
+func IsUserLoggedOrAdmin(ctx context.Context) bool {
+	return IsUserLogged(ctx) || IsUserAdmin(ctx)
+}


### PR DESCRIPTION
Use auth context keys dedicated type instead of strings and avoid code
duplication by moving shared code under a common package.