### PR TITLE
*: use new errors handling library

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,2 +1,25 @@
 linters:
-  enable: errorlint
+  enable:
+    - errorlint
+    - wrapcheck
+
+linters-settings:
+  wrapcheck:
+    # An array of strings that specify substrings of signatures to ignore.
+    # If this set, it will override the default set of ignored signatures.
+    # See https://github.com/tomarrell/wrapcheck#configuration for more information.
+    ignoreSigs:
+      - .Errorf(
+      - errors.New(
+      - errors.Unwrap(
+      - .Wrap(
+      - .Wrapf(
+      - .WithMessage(
+      - .WithMessagef(
+      - .WithStack(
+      - .NewDetailedError(
+    ignoreSigRegexps:
+      - \.New.*Error\(
+    ignorePackageGlobs:
+      - encoding/*
+      - github.com/pkg/*

--- a/cmd/agola/cmd/agola.go
+++ b/cmd/agola/cmd/agola.go
@@ -20,19 +20,20 @@ import (
 	"time"
 
 	"agola.io/agola/cmd"
+	"agola.io/agola/internal/errors"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var token string
 
 func init() {
 	cw := zerolog.ConsoleWriter{
-		Out:        os.Stderr,
-		TimeFormat: time.RFC3339Nano,
+		Out:                 os.Stderr,
+		TimeFormat:          time.RFC3339Nano,
+		FormatErrFieldValue: errors.FormatErrFieldValue,
 	}
 
 	zerolog.TimeFieldFormat = time.RFC3339Nano
@@ -53,6 +54,9 @@ var cmdAgola = &cobra.Command{
 		if agolaOpts.debug {
 			log.Logger = log.Level(zerolog.DebugLevel)
 		}
+		if agolaOpts.detailedErrors {
+			zerolog.ErrorMarshalFunc = errors.ErrorMarshalFunc
+		}
 	},
 	Run: func(c *cobra.Command, args []string) {
 		if err := c.Help(); err != nil {
@@ -62,8 +66,9 @@ var cmdAgola = &cobra.Command{
 }
 
 type agolaOptions struct {
-	gatewayURL string
-	debug      bool
+	gatewayURL     string
+	debug          bool
+	detailedErrors bool
 }
 
 var agolaOpts agolaOptions
@@ -84,6 +89,7 @@ func init() {
 	flags.StringVarP(&agolaOpts.gatewayURL, "gateway-url", "u", gatewayURL, "agola gateway exposed url")
 	flags.StringVar(&token, "token", token, "api token")
 	flags.BoolVarP(&agolaOpts.debug, "debug", "d", false, "debug")
+	flags.BoolVar(&agolaOpts.detailedErrors, "detailed-errors", false, "enabled detailed errors logging")
 }
 
 func Execute() {

--- a/cmd/agola/cmd/completion.go
+++ b/cmd/agola/cmd/completion.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"os"
 
+	"agola.io/agola/internal/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -33,11 +34,11 @@ func completionShell(cmd *cobra.Command, args []string, shell string) error {
 	switch shell {
 	case "bash":
 		if err := cmdAgola.GenBashCompletion(os.Stdout); err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	case "zsh":
 		if err := cmdAgola.GenZshCompletion(os.Stdout); err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	}
 	return nil

--- a/cmd/agola/cmd/logdelete.go
+++ b/cmd/agola/cmd/logdelete.go
@@ -17,12 +17,12 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdLogDelete = &cobra.Command{
@@ -93,7 +93,7 @@ func logDelete(cmd *cobra.Command, args []string) error {
 
 		run, _, err := gwclient.GetRun(context.TODO(), logDeleteOpts.runid)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 		for _, t := range run.Tasks {
 			if t.Name == logDeleteOpts.taskname {

--- a/cmd/agola/cmd/logget.go
+++ b/cmd/agola/cmd/logget.go
@@ -19,12 +19,12 @@ import (
 	"io"
 	"os"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdLogGet = &cobra.Command{
@@ -102,7 +102,7 @@ func logGet(cmd *cobra.Command, args []string) error {
 
 		run, _, err := gwclient.GetRun(context.TODO(), logGetOpts.runid)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 		for _, t := range run.Tasks {
 			if t.Name == logGetOpts.taskname {
@@ -127,7 +127,7 @@ func logGet(cmd *cobra.Command, args []string) error {
 	if flags.Changed("output") {
 		f, err := os.Create(logGetOpts.output)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 		defer f.Close()
 		if _, err := io.Copy(f, resp.Body); err != nil {

--- a/cmd/agola/cmd/orgcreate.go
+++ b/cmd/agola/cmd/orgcreate.go
@@ -17,12 +17,12 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdOrgCreate = &cobra.Command{
@@ -71,7 +71,7 @@ func orgCreate(cmd *cobra.Command, args []string) error {
 	log.Info().Msgf("creating org")
 	org, _, err := gwclient.CreateOrg(context.TODO(), req)
 	if err != nil {
-		return errors.Errorf("failed to create org: %w", err)
+		return errors.Wrapf(err, "failed to create org")
 	}
 	log.Info().Msgf("org %q created, ID: %q", org.Name, org.ID)
 

--- a/cmd/agola/cmd/orgdelete.go
+++ b/cmd/agola/cmd/orgdelete.go
@@ -17,11 +17,11 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdOrgDelete = &cobra.Command{
@@ -57,7 +57,7 @@ func orgDelete(cmd *cobra.Command, args []string) error {
 
 	log.Info().Msgf("deleting organization %q", orgDeleteOpts.name)
 	if _, err := gwclient.DeleteOrg(context.TODO(), orgDeleteOpts.name); err != nil {
-		return errors.Errorf("failed to delete organization: %w", err)
+		return errors.Wrapf(err, "failed to delete organization")
 	}
 
 	return nil

--- a/cmd/agola/cmd/orgmemberadd.go
+++ b/cmd/agola/cmd/orgmemberadd.go
@@ -17,12 +17,12 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdOrgMemberAdd = &cobra.Command{
@@ -66,7 +66,7 @@ func orgMemberAdd(cmd *cobra.Command, args []string) error {
 	log.Info().Msgf("adding/updating member %q to organization %q with role %q", orgMemberAddOpts.username, orgMemberAddOpts.orgname, orgMemberAddOpts.role)
 	_, _, err := gwclient.AddOrgMember(context.TODO(), orgMemberAddOpts.orgname, orgMemberAddOpts.username, gwapitypes.MemberRole(orgMemberAddOpts.role))
 	if err != nil {
-		return errors.Errorf("failed to add/update organization member: %w", err)
+		return errors.Wrapf(err, "failed to add/update organization member")
 	}
 
 	return nil

--- a/cmd/agola/cmd/orgmemberlist.go
+++ b/cmd/agola/cmd/orgmemberlist.go
@@ -19,11 +19,11 @@ import (
 	"encoding/json"
 	"os"
 
+	"agola.io/agola/internal/errors"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdOrgMemberList = &cobra.Command{
@@ -59,12 +59,12 @@ func orgMemberList(cmd *cobra.Command, args []string) error {
 
 	orgMembers, _, err := gwclient.GetOrgMembers(context.TODO(), orgMemberListOpts.orgname)
 	if err != nil {
-		return errors.Errorf("failed to get organization member: %w", err)
+		return errors.Wrapf(err, "failed to get organization member")
 	}
 
 	out, err := json.MarshalIndent(orgMembers, "", "\t")
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	os.Stdout.Write(out)
 

--- a/cmd/agola/cmd/orgmemberremove.go
+++ b/cmd/agola/cmd/orgmemberremove.go
@@ -17,11 +17,11 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdOrgMemberRemove = &cobra.Command{
@@ -63,7 +63,7 @@ func orgMemberRemove(cmd *cobra.Command, args []string) error {
 	log.Info().Msgf("removing member %q from organization %q", orgMemberRemoveOpts.username, orgMemberRemoveOpts.orgname)
 	_, err := gwclient.RemoveOrgMember(context.TODO(), orgMemberRemoveOpts.orgname, orgMemberRemoveOpts.username)
 	if err != nil {
-		return errors.Errorf("failed to remove organization member: %w", err)
+		return errors.Wrapf(err, "failed to remove organization member")
 	}
 
 	return nil

--- a/cmd/agola/cmd/projectcreate.go
+++ b/cmd/agola/cmd/projectcreate.go
@@ -17,12 +17,12 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdProjectCreate = &cobra.Command{
@@ -106,7 +106,7 @@ func projectCreate(cmd *cobra.Command, args []string) error {
 
 	project, _, err := gwclient.CreateProject(context.TODO(), req)
 	if err != nil {
-		return errors.Errorf("failed to create project: %w", err)
+		return errors.Wrapf(err, "failed to create project")
 	}
 	log.Info().Msgf("project %s created, ID: %s", project.Name, project.ID)
 

--- a/cmd/agola/cmd/projectdelete.go
+++ b/cmd/agola/cmd/projectdelete.go
@@ -17,11 +17,11 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdProjectDelete = &cobra.Command{
@@ -58,7 +58,7 @@ func projectDelete(cmd *cobra.Command, args []string) error {
 	log.Info().Msgf("deleting project")
 
 	if _, err := gwclient.DeleteProject(context.TODO(), projectDeleteOpts.ref); err != nil {
-		return errors.Errorf("failed to delete project: %w", err)
+		return errors.Wrapf(err, "failed to delete project")
 	}
 
 	return nil

--- a/cmd/agola/cmd/projectgroupcreate.go
+++ b/cmd/agola/cmd/projectgroupcreate.go
@@ -17,12 +17,12 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdProjectGroupCreate = &cobra.Command{
@@ -78,7 +78,7 @@ func projectGroupCreate(cmd *cobra.Command, args []string) error {
 
 	projectGroup, _, err := gwclient.CreateProjectGroup(context.TODO(), req)
 	if err != nil {
-		return errors.Errorf("failed to create project group: %w", err)
+		return errors.Wrapf(err, "failed to create project group")
 	}
 	log.Info().Msgf("project group %s created, ID: %s", projectGroup.Name, projectGroup.ID)
 

--- a/cmd/agola/cmd/projectgroupdelete.go
+++ b/cmd/agola/cmd/projectgroupdelete.go
@@ -17,11 +17,11 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdProjectGroupDelete = &cobra.Command{
@@ -58,7 +58,7 @@ func projectGroupDelete(cmd *cobra.Command, args []string) error {
 	log.Info().Msgf("deleting project group")
 
 	if _, err := gwclient.DeleteProjectGroup(context.TODO(), projectGroupDeleteOpts.ref); err != nil {
-		return errors.Errorf("failed to delete project group: %w", err)
+		return errors.Wrapf(err, "failed to delete project group")
 	}
 
 	return nil

--- a/cmd/agola/cmd/projectgroupupdate.go
+++ b/cmd/agola/cmd/projectgroupupdate.go
@@ -17,12 +17,12 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdProjectGroupUpdate = &cobra.Command{
@@ -82,7 +82,7 @@ func projectGroupUpdate(cmd *cobra.Command, args []string) error {
 	log.Info().Msgf("updating project group")
 	projectGroup, _, err := gwclient.UpdateProjectGroup(context.TODO(), projectGroupUpdateOpts.ref, req)
 	if err != nil {
-		return errors.Errorf("failed to update project group: %w", err)
+		return errors.Wrapf(err, "failed to update project group")
 	}
 	log.Info().Msgf("project group %s update, ID: %s", projectGroup.Name, projectGroup.ID)
 

--- a/cmd/agola/cmd/projectlist.go
+++ b/cmd/agola/cmd/projectlist.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
@@ -64,7 +65,7 @@ func projectList(cmd *cobra.Command, args []string) error {
 
 	projects, _, err := gwclient.GetProjectGroupProjects(context.TODO(), projectListOpts.parentPath)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	printProjects(projects)

--- a/cmd/agola/cmd/projectreconfig.go
+++ b/cmd/agola/cmd/projectreconfig.go
@@ -17,11 +17,11 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdProjectReconfig = &cobra.Command{
@@ -57,7 +57,7 @@ func projectReconfig(cmd *cobra.Command, args []string) error {
 
 	log.Info().Msgf("reconfiguring remote project")
 	if _, err := gwclient.ReconfigProject(context.TODO(), projectReconfigOpts.name); err != nil {
-		return errors.Errorf("failed to reconfigure remote project: %w", err)
+		return errors.Wrapf(err, "failed to reconfigure remote project")
 	}
 	log.Info().Msgf("project reconfigured")
 

--- a/cmd/agola/cmd/projectsecretcreate.go
+++ b/cmd/agola/cmd/projectsecretcreate.go
@@ -19,13 +19,13 @@ import (
 	"io/ioutil"
 	"os"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/ghodss/yaml"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdProjectSecretCreate = &cobra.Command{
@@ -82,12 +82,12 @@ func secretCreate(cmd *cobra.Command, ownertype string, args []string) error {
 	if secretCreateOpts.file == "-" {
 		data, err = ioutil.ReadAll(os.Stdin)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	} else {
 		data, err = ioutil.ReadFile(secretCreateOpts.file)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	}
 
@@ -106,14 +106,14 @@ func secretCreate(cmd *cobra.Command, ownertype string, args []string) error {
 		log.Info().Msgf("creating project secret")
 		secret, _, err := gwclient.CreateProjectSecret(context.TODO(), secretCreateOpts.parentRef, req)
 		if err != nil {
-			return errors.Errorf("failed to create project secret: %w", err)
+			return errors.Wrapf(err, "failed to create project secret")
 		}
 		log.Info().Msgf("project secret %q created, ID: %q", secret.Name, secret.ID)
 	case "projectgroup":
 		log.Info().Msgf("creating project group secret")
 		secret, _, err := gwclient.CreateProjectGroupSecret(context.TODO(), secretCreateOpts.parentRef, req)
 		if err != nil {
-			return errors.Errorf("failed to create project group secret: %w", err)
+			return errors.Wrapf(err, "failed to create project group secret")
 		}
 		log.Info().Msgf("project group secret %q created, ID: %q", secret.Name, secret.ID)
 	}

--- a/cmd/agola/cmd/projectsecretdelete.go
+++ b/cmd/agola/cmd/projectsecretdelete.go
@@ -17,11 +17,11 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdProjectSecretDelete = &cobra.Command{
@@ -65,14 +65,14 @@ func secretDelete(cmd *cobra.Command, ownertype string, args []string) error {
 		log.Info().Msgf("deleting project secret")
 		_, err := gwclient.DeleteProjectSecret(context.TODO(), secretDeleteOpts.parentRef, secretDeleteOpts.name)
 		if err != nil {
-			return errors.Errorf("failed to delete project secret: %w", err)
+			return errors.Wrapf(err, "failed to delete project secret")
 		}
 		log.Info().Msgf("project secret deleted")
 	case "projectgroup":
 		log.Info().Msgf("deleting project group secret")
 		_, err := gwclient.DeleteProjectGroupSecret(context.TODO(), secretDeleteOpts.parentRef, secretDeleteOpts.name)
 		if err != nil {
-			return errors.Errorf("failed to delete project group secret: %w", err)
+			return errors.Wrapf(err, "failed to delete project group secret")
 		}
 		log.Info().Msgf("project group secret deleted")
 	}

--- a/cmd/agola/cmd/projectsecretlist.go
+++ b/cmd/agola/cmd/projectsecretlist.go
@@ -19,12 +19,12 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdProjectSecretList = &cobra.Command{
@@ -57,10 +57,10 @@ func init() {
 
 func secretList(cmd *cobra.Command, ownertype string, args []string) error {
 	if err := printSecrets(ownertype, fmt.Sprintf("%s secrets", ownertype), false, false); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	if err := printSecrets(ownertype, "All secrets (local and inherited)", true, true); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	return nil
 }
@@ -79,11 +79,11 @@ func printSecrets(ownertype, description string, tree, removeoverridden bool) er
 		secrets, _, err = gwclient.GetProjectGroupSecrets(context.TODO(), secretListOpts.parentRef, tree, removeoverridden)
 	}
 	if err != nil {
-		return errors.Errorf("failed to list %s secrets: %w", ownertype, err)
+		return errors.Wrapf(err, "failed to list %s secrets", ownertype)
 	}
 	prettyJSON, err := json.MarshalIndent(secrets, "", "\t")
 	if err != nil {
-		return errors.Errorf("failed to convert %s secrets to json: %w", ownertype, err)
+		return errors.Wrapf(err, "failed to convert %s secrets to json", ownertype)
 	}
 	fmt.Printf("%s:\n%s\n", description, string(prettyJSON))
 	return nil

--- a/cmd/agola/cmd/projectsecretupdate.go
+++ b/cmd/agola/cmd/projectsecretupdate.go
@@ -19,13 +19,13 @@ import (
 	"io/ioutil"
 	"os"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/ghodss/yaml"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdProjectSecretUpdate = &cobra.Command{
@@ -84,12 +84,12 @@ func secretUpdate(cmd *cobra.Command, ownertype string, args []string) error {
 	if secretUpdateOpts.file == "-" {
 		data, err = ioutil.ReadAll(os.Stdin)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	} else {
 		data, err = ioutil.ReadFile(secretUpdateOpts.file)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	}
 
@@ -113,14 +113,14 @@ func secretUpdate(cmd *cobra.Command, ownertype string, args []string) error {
 		log.Info().Msgf("creating project secret")
 		secret, _, err := gwclient.UpdateProjectSecret(context.TODO(), secretUpdateOpts.parentRef, secretUpdateOpts.name, req)
 		if err != nil {
-			return errors.Errorf("failed to update project secret: %w", err)
+			return errors.Wrapf(err, "failed to update project secret")
 		}
 		log.Info().Msgf("project secret %q updated, ID: %q", secret.Name, secret.ID)
 	case "projectgroup":
 		log.Info().Msgf("creating project group secret")
 		secret, _, err := gwclient.UpdateProjectGroupSecret(context.TODO(), secretUpdateOpts.parentRef, secretUpdateOpts.name, req)
 		if err != nil {
-			return errors.Errorf("failed to update project group secret: %w", err)
+			return errors.Wrapf(err, "failed to update project group secret")
 		}
 		log.Info().Msgf("project group secret %q updated, ID: %q", secret.Name, secret.ID)
 	}

--- a/cmd/agola/cmd/projectupdate.go
+++ b/cmd/agola/cmd/projectupdate.go
@@ -17,12 +17,12 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdProjectUpdate = &cobra.Command{
@@ -88,7 +88,7 @@ func projectUpdate(cmd *cobra.Command, args []string) error {
 	log.Info().Msgf("updating project")
 	project, _, err := gwclient.UpdateProject(context.TODO(), projectUpdateOpts.ref, req)
 	if err != nil {
-		return errors.Errorf("failed to update project: %w", err)
+		return errors.Wrapf(err, "failed to update project")
 	}
 	log.Info().Msgf("project %s update, ID: %s", project.Name, project.ID)
 

--- a/cmd/agola/cmd/projectvariablecreate.go
+++ b/cmd/agola/cmd/projectvariablecreate.go
@@ -20,13 +20,13 @@ import (
 	"os"
 
 	config "agola.io/agola/internal/config"
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/ghodss/yaml"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdProjectVariableCreate = &cobra.Command{
@@ -105,12 +105,12 @@ func variableCreate(cmd *cobra.Command, ownertype string, args []string) error {
 	if variableCreateOpts.file == "-" {
 		data, err = ioutil.ReadAll(os.Stdin)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	} else {
 		data, err = ioutil.ReadFile(variableCreateOpts.file)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	}
 
@@ -136,14 +136,14 @@ func variableCreate(cmd *cobra.Command, ownertype string, args []string) error {
 		log.Info().Msgf("creating project variable")
 		variable, _, err := gwclient.CreateProjectVariable(context.TODO(), variableCreateOpts.parentRef, req)
 		if err != nil {
-			return errors.Errorf("failed to create project variable: %w", err)
+			return errors.Wrapf(err, "failed to create project variable")
 		}
 		log.Info().Msgf("project variable %q created, ID: %q", variable.Name, variable.ID)
 	case "projectgroup":
 		log.Info().Msgf("creating project group variable")
 		variable, _, err := gwclient.CreateProjectGroupVariable(context.TODO(), variableCreateOpts.parentRef, req)
 		if err != nil {
-			return errors.Errorf("failed to create project group variable: %w", err)
+			return errors.Wrapf(err, "failed to create project group variable")
 		}
 		log.Info().Msgf("project group variable %q created, ID: %q", variable.Name, variable.ID)
 	}

--- a/cmd/agola/cmd/projectvariabledelete.go
+++ b/cmd/agola/cmd/projectvariabledelete.go
@@ -17,11 +17,11 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdProjectVariableDelete = &cobra.Command{
@@ -65,14 +65,14 @@ func variableDelete(cmd *cobra.Command, ownertype string, args []string) error {
 		log.Info().Msgf("deleting project variable")
 		_, err := gwclient.DeleteProjectVariable(context.TODO(), variableDeleteOpts.parentRef, variableDeleteOpts.name)
 		if err != nil {
-			return errors.Errorf("failed to delete project variable: %w", err)
+			return errors.Wrapf(err, "failed to delete project variable")
 		}
 		log.Info().Msgf("project variable deleted")
 	case "projectgroup":
 		log.Info().Msgf("deleting project group variable")
 		_, err := gwclient.DeleteProjectGroupVariable(context.TODO(), variableDeleteOpts.parentRef, variableDeleteOpts.name)
 		if err != nil {
-			return errors.Errorf("failed to delete project group variable: %w", err)
+			return errors.Wrapf(err, "failed to delete project group variable")
 		}
 		log.Info().Msgf("project group variable deleted")
 	}

--- a/cmd/agola/cmd/projectvariablelist.go
+++ b/cmd/agola/cmd/projectvariablelist.go
@@ -19,12 +19,12 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdProjectVariableList = &cobra.Command{
@@ -57,10 +57,10 @@ func init() {
 
 func variableList(cmd *cobra.Command, ownertype string, args []string) error {
 	if err := printVariables(ownertype, fmt.Sprintf("%s variables", ownertype), false, false); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	if err := printVariables(ownertype, "All variables (local and inherited)", true, true); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	return nil
 }
@@ -79,11 +79,11 @@ func printVariables(ownertype, description string, tree, removeoverridden bool) 
 		variables, _, err = gwclient.GetProjectGroupVariables(context.TODO(), variableListOpts.parentRef, tree, removeoverridden)
 	}
 	if err != nil {
-		return errors.Errorf("failed to list %s variables: %w", ownertype, err)
+		return errors.Wrapf(err, "failed to list %s variables", ownertype)
 	}
 	prettyJSON, err := json.MarshalIndent(variables, "", "\t")
 	if err != nil {
-		return errors.Errorf("failed to convert %s variables to json: %w", ownertype, err)
+		return errors.Wrapf(err, "failed to convert %s variables to json", ownertype)
 	}
 	fmt.Printf("%s:\n%s\n", description, string(prettyJSON))
 	return nil

--- a/cmd/agola/cmd/projectvariableupdate.go
+++ b/cmd/agola/cmd/projectvariableupdate.go
@@ -19,13 +19,13 @@ import (
 	"io/ioutil"
 	"os"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/ghodss/yaml"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdProjectVariableUpdate = &cobra.Command{
@@ -77,12 +77,12 @@ func variableUpdate(cmd *cobra.Command, ownertype string, args []string) error {
 	if variableUpdateOpts.file == "-" {
 		data, err = ioutil.ReadAll(os.Stdin)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	} else {
 		data, err = ioutil.ReadFile(variableUpdateOpts.file)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	}
 
@@ -113,14 +113,14 @@ func variableUpdate(cmd *cobra.Command, ownertype string, args []string) error {
 		log.Info().Msgf("updating project variable")
 		variable, _, err := gwclient.UpdateProjectVariable(context.TODO(), variableUpdateOpts.parentRef, variableUpdateOpts.name, req)
 		if err != nil {
-			return errors.Errorf("failed to update project variable: %w", err)
+			return errors.Wrapf(err, "failed to update project variable")
 		}
 		log.Info().Msgf("project variable %q updated, ID: %q", variable.Name, variable.ID)
 	case "projectgroup":
 		log.Info().Msgf("updating project group variable")
 		variable, _, err := gwclient.UpdateProjectGroupVariable(context.TODO(), variableUpdateOpts.parentRef, variableUpdateOpts.name, req)
 		if err != nil {
-			return errors.Errorf("failed to update project group variable: %w", err)
+			return errors.Wrapf(err, "failed to update project group variable")
 		}
 		log.Info().Msgf("project group variable %q updated, ID: %q", variable.Name, variable.ID)
 	}

--- a/cmd/agola/cmd/remotesourcecreate.go
+++ b/cmd/agola/cmd/remotesourcecreate.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/gitsources/github"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
@@ -24,7 +25,6 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdRemoteSourceCreate = &cobra.Command{
@@ -117,7 +117,7 @@ func remoteSourceCreate(cmd *cobra.Command, args []string) error {
 	log.Info().Msgf("creating remotesource")
 	remoteSource, _, err := gwclient.CreateRemoteSource(context.TODO(), req)
 	if err != nil {
-		return errors.Errorf("failed to create remotesource: %w", err)
+		return errors.Wrapf(err, "failed to create remotesource")
 	}
 	log.Info().Msgf("remotesource %s created, ID: %s", remoteSource.Name, remoteSource.ID)
 

--- a/cmd/agola/cmd/remotesourcelist.go
+++ b/cmd/agola/cmd/remotesourcelist.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
@@ -62,7 +63,7 @@ func remoteSourceList(cmd *cobra.Command, args []string) error {
 
 	remouteSources, _, err := gwclient.GetRemoteSources(context.TODO(), remoteSourceListOpts.start, remoteSourceListOpts.limit, false)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	printRemoteSources(remouteSources)

--- a/cmd/agola/cmd/remotesourceupdate.go
+++ b/cmd/agola/cmd/remotesourceupdate.go
@@ -17,12 +17,12 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdRemoteSourceUpdate = &cobra.Command{
@@ -109,7 +109,7 @@ func remoteSourceUpdate(cmd *cobra.Command, args []string) error {
 	log.Info().Msgf("updating remotesource")
 	remoteSource, _, err := gwclient.UpdateRemoteSource(context.TODO(), remoteSourceUpdateOpts.ref, req)
 	if err != nil {
-		return errors.Errorf("failed to update remotesource: %w", err)
+		return errors.Wrapf(err, "failed to update remotesource")
 	}
 	log.Info().Msgf("remotesource %s updated, ID: %s", remoteSource.Name, remoteSource.ID)
 

--- a/cmd/agola/cmd/runcreate.go
+++ b/cmd/agola/cmd/runcreate.go
@@ -16,8 +16,8 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
@@ -76,7 +76,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		set++
 	}
 	if set != 1 {
-		return fmt.Errorf(`one of "--branch", "--tag" or "--ref" must be provided`)
+		return errors.Errorf(`one of "--branch", "--tag" or "--ref" must be provided`)
 	}
 
 	req := &gwapitypes.ProjectCreateRunRequest{
@@ -88,5 +88,5 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	_, err := gwclient.ProjectCreateRun(context.TODO(), runCreateOpts.projectRef, req)
 
-	return err
+	return errors.WithStack(err)
 }

--- a/cmd/agola/cmd/runlist.go
+++ b/cmd/agola/cmd/runlist.go
@@ -20,9 +20,9 @@ import (
 	"path"
 	"sort"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
-	errors "golang.org/x/xerrors"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -104,14 +104,14 @@ func runList(cmd *cobra.Command, args []string) error {
 	groups := []string{path.Join("/project", project.ID)}
 	runsResp, _, err := gwclient.GetRuns(context.TODO(), runListOpts.phaseFilter, nil, groups, nil, runListOpts.start, runListOpts.limit, false)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	runs := make([]*runDetails, len(runsResp))
 	for i, runResponse := range runsResp {
 		run, _, err := gwclient.GetRun(context.TODO(), runResponse.ID)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 
 		tasks := []*taskDetails{}

--- a/cmd/agola/cmd/usercreate.go
+++ b/cmd/agola/cmd/usercreate.go
@@ -17,12 +17,12 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdUserCreate = &cobra.Command{
@@ -63,7 +63,7 @@ func userCreate(cmd *cobra.Command, args []string) error {
 	log.Info().Msgf("creating user")
 	user, _, err := gwclient.CreateUser(context.TODO(), req)
 	if err != nil {
-		return errors.Errorf("failed to create user: %w", err)
+		return errors.Wrapf(err, "failed to create user")
 	}
 	log.Info().Msgf("user %q created, ID: %q", user.UserName, user.ID)
 

--- a/cmd/agola/cmd/userdelete.go
+++ b/cmd/agola/cmd/userdelete.go
@@ -17,11 +17,11 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdUserDelete = &cobra.Command{
@@ -57,7 +57,7 @@ func userDelete(cmd *cobra.Command, args []string) error {
 
 	log.Info().Msgf("deleting user %q", userDeleteOpts.username)
 	if _, err := gwclient.DeleteUser(context.TODO(), userDeleteOpts.username); err != nil {
-		return errors.Errorf("failed to delete user: %w", err)
+		return errors.Wrapf(err, "failed to delete user")
 	}
 
 	return nil

--- a/cmd/agola/cmd/userlacreate.go
+++ b/cmd/agola/cmd/userlacreate.go
@@ -17,12 +17,12 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdUserLACreate = &cobra.Command{
@@ -74,7 +74,7 @@ func userLACreate(cmd *cobra.Command, args []string) error {
 	log.Info().Msgf("creating linked account for user %q", userLACreateOpts.username)
 	resp, _, err := gwclient.CreateUserLA(context.TODO(), userLACreateOpts.username, req)
 	if err != nil {
-		return errors.Errorf("failed to create linked account: %w", err)
+		return errors.Wrapf(err, "failed to create linked account")
 	}
 	if resp.Oauth2Redirect != "" {
 		log.Info().Msgf("visit %s to continue", resp.Oauth2Redirect)

--- a/cmd/agola/cmd/userladelete.go
+++ b/cmd/agola/cmd/userladelete.go
@@ -17,11 +17,11 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdUserLADelete = &cobra.Command{
@@ -66,7 +66,7 @@ func userLADelete(cmd *cobra.Command, args []string) error {
 	log.Info().Msgf("deleting linked account %q for user %q", laID, userName)
 	_, err := gwclient.DeleteUserLA(context.TODO(), userName, laID)
 	if err != nil {
-		return errors.Errorf("failed to delete linked account: %w", err)
+		return errors.Wrapf(err, "failed to delete linked account")
 	}
 
 	log.Info().Msgf("linked account %q for user %q deleted", laID, userName)

--- a/cmd/agola/cmd/userlist.go
+++ b/cmd/agola/cmd/userlist.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
@@ -62,7 +63,7 @@ func userList(cmd *cobra.Command, args []string) error {
 
 	users, _, err := gwclient.GetUsers(context.TODO(), userListOpts.start, userListOpts.limit, false)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	printUsers(users)

--- a/cmd/agola/cmd/usertokencreate.go
+++ b/cmd/agola/cmd/usertokencreate.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"fmt"
 
+	"agola.io/agola/internal/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdUserTokenCreate = &cobra.Command{
@@ -69,7 +69,7 @@ func userTokenCreate(cmd *cobra.Command, args []string) error {
 	log.Info().Msgf("creating token for user %q", userTokenCreateOpts.username)
 	resp, _, err := gwclient.CreateUserToken(context.TODO(), userTokenCreateOpts.username, req)
 	if err != nil {
-		return errors.Errorf("failed to create token: %w", err)
+		return errors.Wrapf(err, "failed to create token")
 	}
 	log.Info().Msgf("token for user %q created: %s", userTokenCreateOpts.username, resp.Token)
 	fmt.Println(resp.Token)

--- a/cmd/agola/cmd/usertokendelete.go
+++ b/cmd/agola/cmd/usertokendelete.go
@@ -17,11 +17,11 @@ package cmd
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	errors "golang.org/x/xerrors"
 )
 
 var cmdUserTokenDelete = &cobra.Command{
@@ -66,7 +66,7 @@ func userTokenDelete(cmd *cobra.Command, args []string) error {
 	log.Info().Msgf("deleting token %q for user %q", tokenName, userName)
 	_, err := gwclient.DeleteUserToken(context.TODO(), userName, tokenName)
 	if err != nil {
-		return errors.Errorf("failed to delete user token: %w", err)
+		return errors.Wrapf(err, "failed to delete user token")
 	}
 
 	log.Info().Msgf("token %q for user %q deleted", tokenName, userName)

--- a/cmd/agola/cmd/version.go
+++ b/cmd/agola/cmd/version.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"agola.io/agola/internal/errors"
 	gwclient "agola.io/agola/services/gateway/client"
 
 	"github.com/rs/zerolog/log"
@@ -43,7 +44,7 @@ func printVersions(cmd *cobra.Command, args []string) error {
 
 	gwversion, _, err := gwclient.GetVersion(context.TODO())
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	fmt.Printf("Gateway version:\t%s\n", gwversion.Version)

--- a/cmd/toolbox/cmd/createfile.go
+++ b/cmd/toolbox/cmd/createfile.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"os"
 
+	"agola.io/agola/internal/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -48,18 +49,18 @@ func createFile(r io.Reader) (string, error) {
 	// create a temp dir if the image doesn't have one
 	tmpDir := os.TempDir()
 	if err := os.MkdirAll(tmpDir, 0777); err != nil {
-		return "", fmt.Errorf("failed to create tmp dir %q", tmpDir)
+		return "", errors.Errorf("failed to create tmp dir %q", tmpDir)
 	}
 
 	file, err := ioutil.TempFile("", "")
 	if err != nil {
-		return "", err
+		return "", errors.WithStack(err)
 	}
 
 	filename := file.Name()
 	if _, err := io.Copy(file, r); err != nil {
 		file.Close()
-		return "", err
+		return "", errors.WithStack(err)
 	}
 	file.Close()
 

--- a/cmd/toolbox/cmd/template.go
+++ b/cmd/toolbox/cmd/template.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"crypto/md5"
 	"crypto/sha256"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -27,6 +26,8 @@ import (
 	"strconv"
 	"text/template"
 	"time"
+
+	"agola.io/agola/internal/errors"
 
 	"github.com/spf13/cobra"
 )
@@ -48,20 +49,20 @@ func md5sum(filename string) (string, error) {
 
 	if info, err := os.Stat(filename); err == nil {
 		if info.Size() > 1024*1024 {
-			return "", fmt.Errorf("file %q is too big", filename)
+			return "", errors.Errorf("file %q is too big", filename)
 		}
 	} else {
-		return "", err
+		return "", errors.WithStack(err)
 	}
 
 	f, err := os.Open(filename)
 	if err != nil {
-		return "", err
+		return "", errors.WithStack(err)
 	}
 
 	h := md5.New()
 	if _, err := io.Copy(h, f); err != nil {
-		return "", err
+		return "", errors.WithStack(err)
 	}
 
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
@@ -74,20 +75,20 @@ func sha256sum(filename string) (string, error) {
 
 	if info, err := os.Stat(filename); err == nil {
 		if info.Size() > 1024*1024 {
-			return "", fmt.Errorf("file %q is too big", filename)
+			return "", errors.Errorf("file %q is too big", filename)
 		}
 	} else {
-		return "", err
+		return "", errors.WithStack(err)
 	}
 
 	f, err := os.Open(filename)
 	if err != nil {
-		return "", err
+		return "", errors.WithStack(err)
 	}
 
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
-		return "", err
+		return "", errors.WithStack(err)
 	}
 
 	return fmt.Sprintf("%x", h.Sum(nil)), nil

--- a/doc/devel.md
+++ b/doc/devel.md
@@ -2,7 +2,7 @@
 
 #### Start the web interface
 
-* Clone the [agola-web repository](https://github.com/agola-io/agola-web)
+- Clone the [agola-web repository](https://github.com/agola-io/agola-web)
 
 For the first time you'll need the `vue cli` and its services installed as global modules:
 
@@ -27,7 +27,7 @@ make
 
 ### Start the agola server
 
-* Copy the `example/config.yml` where you prefer
+- Copy the `example/config.yml` where you prefer
 
 ```
 ./bin/agola serve --embedded-etcd --config /path/to/your/config.yml --components all-base,executor
@@ -38,3 +38,9 @@ or use an external etcd (set it in the config.yml):
 ```
 ./bin/agola serve --config /path/to/your/config.yml --components all-base,executor
 ```
+
+### Error handling
+
+Use the `--detailed-errors` option to easily follow the errors chain.
+
+When developing you should wrap every error using `errors.Wrap[f]` or `errors.WithStack`. The ci uses `golangci-lint` with the `wrapcheck` linter enabled to check if some errors aren't wrapped.

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	go.starlark.net v0.0.0-20200203144150-6677ee5c7211
 	golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/src-d/go-billy.v4 v4.3.2
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gopkg.in/yaml.v2 v2.2.8

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -21,12 +21,12 @@ import (
 	"os"
 	"path"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/etcd"
 	"agola.io/agola/internal/objectstorage"
 	"agola.io/agola/internal/services/config"
 
 	"github.com/rs/zerolog"
-	errors "golang.org/x/xerrors"
 )
 
 const (
@@ -43,7 +43,7 @@ func WriteFileAtomicFunc(filename string, perm os.FileMode, writeFunc func(f io.
 	dir, name := path.Split(filename)
 	f, err := ioutil.TempFile(dir, name)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	err = writeFunc(f)
 	if err == nil {
@@ -62,7 +62,7 @@ func WriteFileAtomicFunc(filename string, perm os.FileMode, writeFunc func(f io.
 	if err != nil {
 		os.Remove(f.Name())
 	}
-	return err
+	return errors.WithStack(err)
 }
 
 // WriteFileAtomic atomically writes a file
@@ -70,7 +70,7 @@ func WriteFileAtomic(filename string, data []byte, perm os.FileMode) error {
 	return WriteFileAtomicFunc(filename, perm,
 		func(f io.Writer) error {
 			_, err := f.Write(data)
-			return err
+			return errors.WithStack(err)
 		})
 }
 
@@ -84,7 +84,7 @@ func NewObjectStorage(c *config.ObjectStorage) (*objectstorage.ObjStorage, error
 	case config.ObjectStorageTypePosix:
 		ost, err = objectstorage.NewPosix(c.Path)
 		if err != nil {
-			return nil, errors.Errorf("failed to create posix object storage: %w", err)
+			return nil, errors.Wrapf(err, "failed to create posix object storage")
 		}
 	case config.ObjectStorageTypeS3:
 		// minio golang client doesn't accept an url as an endpoint
@@ -103,7 +103,7 @@ func NewObjectStorage(c *config.ObjectStorage) (*objectstorage.ObjStorage, error
 		}
 		ost, err = objectstorage.NewS3(c.Bucket, c.Location, endpoint, c.AccessKey, c.SecretAccessKey, secure)
 		if err != nil {
-			return nil, errors.Errorf("failed to create s3 object storage: %w", err)
+			return nil, errors.Wrapf(err, "failed to create s3 object storage")
 		}
 	}
 
@@ -121,7 +121,7 @@ func NewEtcd(c *config.Etcd, log zerolog.Logger, prefix string) (*etcd.Store, er
 		SkipTLSVerify: c.TLSSkipVerify,
 	})
 	if err != nil {
-		return nil, errors.Errorf("failed to create etcd store: %w", err)
+		return nil, errors.Wrapf(err, "failed to create etcd store")
 	}
 
 	return e, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,12 +20,12 @@ import (
 	"regexp"
 	"strings"
 
+	"agola.io/agola/internal/errors"
 	itypes "agola.io/agola/internal/services/types"
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/types"
 
 	"github.com/ghodss/yaml"
-	errors "golang.org/x/xerrors"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -201,7 +201,7 @@ type SaveContent struct {
 func (s *Steps) UnmarshalJSON(b []byte) error {
 	var stepsRaw []json.RawMessage
 	if err := json.Unmarshal(b, &stepsRaw); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	steps := make(Steps, len(stepsRaw))
@@ -210,13 +210,13 @@ func (s *Steps) UnmarshalJSON(b []byte) error {
 
 		var stepMap map[string]json.RawMessage
 		if err := json.Unmarshal(stepRaw, &stepMap); err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 		// handle default step definition using format { type: "steptype", other steps fields }
 		if _, ok := stepMap["type"]; ok {
 			var stepTypeI interface{}
 			if err := json.Unmarshal(stepMap["type"], &stepTypeI); err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 			stepType, ok := stepTypeI.(string)
 			if !ok {
@@ -227,7 +227,7 @@ func (s *Steps) UnmarshalJSON(b []byte) error {
 			case "clone":
 				var s CloneStep
 				if err := json.Unmarshal(stepRaw, &s); err != nil {
-					return err
+					return errors.WithStack(err)
 				}
 				s.Type = stepType
 				step = &s
@@ -235,7 +235,7 @@ func (s *Steps) UnmarshalJSON(b []byte) error {
 			case "run":
 				var s RunStep
 				if err := json.Unmarshal(stepRaw, &s); err != nil {
-					return err
+					return errors.WithStack(err)
 				}
 				if s.Tty == nil {
 					s.Tty = util.BoolP(true)
@@ -246,7 +246,7 @@ func (s *Steps) UnmarshalJSON(b []byte) error {
 			case "save_to_workspace":
 				var s SaveToWorkspaceStep
 				if err := json.Unmarshal(stepRaw, &s); err != nil {
-					return err
+					return errors.WithStack(err)
 				}
 				s.Type = stepType
 				step = &s
@@ -254,7 +254,7 @@ func (s *Steps) UnmarshalJSON(b []byte) error {
 			case "restore_workspace":
 				var s RestoreWorkspaceStep
 				if err := json.Unmarshal(stepRaw, &s); err != nil {
-					return err
+					return errors.WithStack(err)
 				}
 				s.Type = stepType
 				step = &s
@@ -262,7 +262,7 @@ func (s *Steps) UnmarshalJSON(b []byte) error {
 			case "save_cache":
 				var s SaveCacheStep
 				if err := json.Unmarshal(stepRaw, &s); err != nil {
-					return err
+					return errors.WithStack(err)
 				}
 				s.Type = stepType
 				step = &s
@@ -270,7 +270,7 @@ func (s *Steps) UnmarshalJSON(b []byte) error {
 			case "restore_cache":
 				var s RestoreCacheStep
 				if err := json.Unmarshal(stepRaw, &s); err != nil {
-					return err
+					return errors.WithStack(err)
 				}
 				s.Type = stepType
 				step = &s
@@ -285,14 +285,14 @@ func (s *Steps) UnmarshalJSON(b []byte) error {
 			for stepType, stepSpecRaw := range stepMap {
 				var stepSpec interface{}
 				if err := json.Unmarshal(stepSpecRaw, &stepSpec); err != nil {
-					return err
+					return errors.WithStack(err)
 				}
 
 				switch stepType {
 				case "clone":
 					var s CloneStep
 					if err := json.Unmarshal(stepSpecRaw, &s); err != nil {
-						return err
+						return errors.WithStack(err)
 					}
 					s.Type = stepType
 					step = &s
@@ -304,7 +304,7 @@ func (s *Steps) UnmarshalJSON(b []byte) error {
 						s.Command = stepSpec
 					default:
 						if err := json.Unmarshal(stepSpecRaw, &s); err != nil {
-							return err
+							return errors.WithStack(err)
 						}
 					}
 					s.Type = stepType
@@ -313,7 +313,7 @@ func (s *Steps) UnmarshalJSON(b []byte) error {
 				case "save_to_workspace":
 					var s SaveToWorkspaceStep
 					if err := json.Unmarshal(stepSpecRaw, &s); err != nil {
-						return err
+						return errors.WithStack(err)
 					}
 					s.Type = stepType
 					step = &s
@@ -321,7 +321,7 @@ func (s *Steps) UnmarshalJSON(b []byte) error {
 				case "restore_workspace":
 					var s RestoreWorkspaceStep
 					if err := json.Unmarshal(stepSpecRaw, &s); err != nil {
-						return err
+						return errors.WithStack(err)
 					}
 					s.Type = stepType
 					step = &s
@@ -329,7 +329,7 @@ func (s *Steps) UnmarshalJSON(b []byte) error {
 				case "save_cache":
 					var s SaveCacheStep
 					if err := json.Unmarshal(stepSpecRaw, &s); err != nil {
-						return err
+						return errors.WithStack(err)
 					}
 					s.Type = stepType
 					step = &s
@@ -337,7 +337,7 @@ func (s *Steps) UnmarshalJSON(b []byte) error {
 				case "restore_cache":
 					var s RestoreCacheStep
 					if err := json.Unmarshal(stepSpecRaw, &s); err != nil {
-						return err
+						return errors.WithStack(err)
 					}
 					s.Type = stepType
 					step = &s
@@ -359,14 +359,14 @@ func (d *Depends) UnmarshalJSON(b []byte) error {
 	var dependsRaw []json.RawMessage
 
 	if err := json.Unmarshal(b, &dependsRaw); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	depends := make([]*Depend, len(dependsRaw))
 	for i, dependRaw := range dependsRaw {
 		var dependi interface{}
 		if err := json.Unmarshal(dependRaw, &dependi); err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 		var depend *Depend
 		isSimpler := false
@@ -391,7 +391,7 @@ func (d *Depends) UnmarshalJSON(b []byte) error {
 			if !isSimpler {
 				// handle default depends definition using format "task": "taskname", conditions: [ list of conditions ]
 				if err := json.Unmarshal(dependRaw, &depend); err != nil {
-					return err
+					return errors.WithStack(err)
 				}
 			} else {
 				// handle simpler (for yaml) depends definition using format "taskname": [ list of conditions ]
@@ -401,7 +401,7 @@ func (d *Depends) UnmarshalJSON(b []byte) error {
 				type deplist map[string][]DependCondition
 				var dl deplist
 				if err := json.Unmarshal(dependRaw, &dl); err != nil {
-					return err
+					return errors.WithStack(err)
 				}
 				if len(dl) != 1 {
 					return errors.Errorf("unsupported depend entry format")
@@ -440,7 +440,7 @@ type Value struct {
 func (val *Value) UnmarshalJSON(b []byte) error {
 	var ival interface{}
 	if err := json.Unmarshal(b, &ival); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	switch valValue := ival.(type) {
 	case string:
@@ -479,7 +479,7 @@ func (w *When) ToWhen() *types.When {
 func (w *When) UnmarshalJSON(b []byte) error {
 	var wi *when
 	if err := json.Unmarshal(b, &wi); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	var err error
@@ -487,21 +487,21 @@ func (w *When) UnmarshalJSON(b []byte) error {
 	if wi.Branch != nil {
 		w.Branch, err = parseWhenConditions(wi.Branch)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	}
 
 	if wi.Tag != nil {
 		w.Tag, err = parseWhenConditions(wi.Tag)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	}
 
 	if wi.Ref != nil {
 		w.Ref, err = parseWhenConditions(wi.Ref)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	}
 
@@ -521,7 +521,7 @@ func parseWhenConditions(wi interface{}) (*types.WhenConditions, error) {
 	case []interface{}:
 		ss, err := parseSliceString(c)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		include = ss
 	case map[string]interface{}:
@@ -530,12 +530,12 @@ func parseWhenConditions(wi interface{}) (*types.WhenConditions, error) {
 			case "include":
 				include, err = parseStringOrSlice(v)
 				if err != nil {
-					return nil, err
+					return nil, errors.WithStack(err)
 				}
 			case "exclude":
 				exclude, err = parseStringOrSlice(v)
 				if err != nil {
-					return nil, err
+					return nil, errors.WithStack(err)
 				}
 			default:
 				return nil, errors.Errorf(`expected one of "include" or "exclude", got %s`, k)
@@ -547,11 +547,11 @@ func parseWhenConditions(wi interface{}) (*types.WhenConditions, error) {
 
 	w.Include, err = parseWhenConditionSlice(include)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	w.Exclude, err = parseWhenConditionSlice(exclude)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	return w, nil
@@ -566,7 +566,7 @@ func parseWhenConditionSlice(conds []string) ([]types.WhenCondition, error) {
 	for _, cond := range conds {
 		wc, err := parseWhenCondition(cond)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		wcs = append(wcs, *wc)
 	}
@@ -590,7 +590,7 @@ func parseWhenCondition(s string) (*types.WhenCondition, error) {
 
 	if isRegExp {
 		if _, err := regexp.Compile(s); err != nil {
-			return nil, errors.Errorf("wrong regular expression: %w", err)
+			return nil, errors.Wrapf(err, "wrong regular expression")
 		}
 		wc.Type = types.WhenConditionTypeRegExp
 	} else {
@@ -608,7 +608,7 @@ func parseStringOrSlice(si interface{}) ([]string, error) {
 		var err error
 		ss, err = parseSliceString(c)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 	}
 	return ss, nil
@@ -669,14 +669,14 @@ func ParseConfig(configData []byte, format ConfigFormat, configContext *ConfigCo
 		var err error
 		configData, err = execJsonnet(configData, configContext)
 		if err != nil {
-			return nil, errors.Errorf("failed to execute jsonnet: %w", err)
+			return nil, errors.Wrapf(err, "failed to execute jsonnet")
 		}
 	case ConfigFormatStarlark:
 		// Generate json from starlark
 		var err error
 		configData, err = execStarlark(configData, configContext)
 		if err != nil {
-			return nil, errors.Errorf("failed to execute starlark: %w", err)
+			return nil, errors.Wrapf(err, "failed to execute starlark")
 		}
 	}
 
@@ -686,7 +686,7 @@ func ParseConfig(configData []byte, format ConfigFormat, configContext *ConfigCo
 
 	config := DefaultConfig
 	if err := yaml.Unmarshal(configData, &config); err != nil {
-		return nil, errors.Errorf("failed to unmarshal config: %w", err)
+		return nil, errors.Wrapf(err, "failed to unmarshal config")
 	}
 
 	return &config, checkConfig(&config)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,14 +15,13 @@
 package config
 
 import (
-	"fmt"
 	"testing"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/types"
 
 	"github.com/google/go-cmp/cmp"
-	errors "golang.org/x/xerrors"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -35,14 +34,14 @@ func TestParseConfig(t *testing.T) {
 		{
 			name: "test no runs 1",
 			in:   ``,
-			err:  fmt.Errorf(`no runs defined`),
+			err:  errors.Errorf(`no runs defined`),
 		},
 		{
 			name: "test no runs 2",
 			in: `
                 runs:
                 `,
-			err: fmt.Errorf(`no runs defined`),
+			err: errors.Errorf(`no runs defined`),
 		},
 		{
 			name: "test empty run",
@@ -50,7 +49,7 @@ func TestParseConfig(t *testing.T) {
                 runs:
                   -
                 `,
-			err: fmt.Errorf(`run at index 0 is empty`),
+			err: errors.Errorf(`run at index 0 is empty`),
 		},
 		{
 			name: "test empty task",
@@ -60,7 +59,7 @@ func TestParseConfig(t *testing.T) {
                     tasks:
                       -
                 `,
-			err: fmt.Errorf(`run "run01": task at index 0 is empty`),
+			err: errors.Errorf(`run "run01": task at index 0 is empty`),
 		},
 		{
 			name: "test empty runtime arch",
@@ -88,7 +87,7 @@ func TestParseConfig(t *testing.T) {
                           containers:
                             - image: busybox
                 `,
-			err: fmt.Errorf(`task "task01" runtime: invalid arch "invalidarch"`),
+			err: errors.Errorf(`task "task01" runtime: invalid arch "invalidarch"`),
 		},
 		{
 			name: "test missing task dependency",
@@ -104,7 +103,7 @@ func TestParseConfig(t *testing.T) {
                         depends:
                           - task02
                 `,
-			err: fmt.Errorf(`run task "task02" needed by task "task01" doesn't exist`),
+			err: errors.Errorf(`run task "task02" needed by task "task01" doesn't exist`),
 		},
 		{
 			name: "test circular dependency between 2 tasks a -> b -> a",

--- a/internal/config/jsonnet.go
+++ b/internal/config/jsonnet.go
@@ -17,21 +17,21 @@ package config
 import (
 	"encoding/json"
 
+	"agola.io/agola/internal/errors"
 	"github.com/google/go-jsonnet"
-	errors "golang.org/x/xerrors"
 )
 
 func execJsonnet(configData []byte, configContext *ConfigContext) ([]byte, error) {
 	vm := jsonnet.MakeVM()
 	cj, err := json.Marshal(configContext)
 	if err != nil {
-		return nil, errors.Errorf("failed to marshal config context: %w", err)
+		return nil, errors.Wrapf(err, "failed to marshal config context")
 	}
 
 	vm.TLACode("ctx", string(cj))
 	out, err := vm.EvaluateSnippet("", string(configData))
 	if err != nil {
-		return nil, errors.Errorf("failed to evaluate jsonnet config: %w", err)
+		return nil, errors.Wrapf(err, "failed to evaluate jsonnet config")
 	}
 
 	return []byte(out), nil

--- a/internal/config/starlark_test.go
+++ b/internal/config/starlark_test.go
@@ -16,10 +16,10 @@ package config
 
 import (
 	"bytes"
-	"fmt"
 	"math"
 	"testing"
 
+	"agola.io/agola/internal/errors"
 	"github.com/google/go-cmp/cmp"
 	"go.starlark.net/starlark"
 )
@@ -48,7 +48,7 @@ func TestStarlarkJSON(t *testing.T) {
 				_ = s.SetKey(starlark.MakeInt(10), starlark.String("string01"))
 				return starlark.Value(s)
 			}(),
-			err: fmt.Errorf("cannot convert non-string dict key to JSON"),
+			err: errors.Errorf("cannot convert non-string dict key to JSON"),
 		},
 		{
 			name: "test list",

--- a/internal/datamanager/datamanager.go
+++ b/internal/datamanager/datamanager.go
@@ -21,12 +21,12 @@ import (
 	"strings"
 	"time"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/etcd"
 	"agola.io/agola/internal/objectstorage"
 	"agola.io/agola/internal/sequence"
 
 	"github.com/rs/zerolog"
-	errors "golang.org/x/xerrors"
 )
 
 // TODO(sgotti) handle etcd unwanted changes:
@@ -252,7 +252,7 @@ func (d *DataManager) deleteEtcd(ctx context.Context) error {
 	}
 	for _, prefix := range prefixes {
 		if err := d.e.DeletePrefix(ctx, prefix); err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	}
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,89 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+type werror struct {
+	cause error
+	msg   string
+	*Stack
+}
+
+func (w *werror) Error() string {
+	if w.cause == nil {
+		return w.msg
+	}
+	if w.msg != "" {
+		return w.msg + ": " + w.cause.Error()
+	} else {
+		return w.cause.Error()
+	}
+}
+
+func (w *werror) Format(s fmt.State, verb rune) {
+	_, _ = io.WriteString(s, w.Error())
+}
+
+func (w *werror) Unwrap() error { return w.cause }
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &werror{
+		msg:   message,
+		Stack: Callers(0),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &werror{
+		msg:   fmt.Sprintf(format, args...),
+		Stack: Callers(0),
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &werror{
+		err,
+		"",
+		Callers(0),
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &werror{
+		err,
+		message,
+		Callers(0),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is called, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return &werror{
+		err,
+		fmt.Sprintf(format, args...),
+		Callers(0),
+	}
+}

--- a/internal/errors/format.go
+++ b/internal/errors/format.go
@@ -1,0 +1,47 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+func PrintErrorDetails(err error) []string {
+	type stackTracer interface {
+		StackTrace() StackTrace
+	}
+	type errWithStack struct {
+		err   error
+		msg   string
+		stack StackTrace
+	}
+
+	var stackErrs []errWithStack
+	errCause := err
+	for errCause != nil {
+		stackErr := errWithStack{
+			err: errCause,
+			msg: errCause.Error(),
+		}
+		//nolint:errorlint
+		if s, ok := errCause.(stackTracer); ok {
+			stackErr.stack = s.StackTrace()
+		}
+		stackErrs = append(stackErrs, stackErr)
+		errCause = errors.Unwrap(errCause)
+		if err == nil {
+			break
+		}
+	}
+
+	var lines []string
+	for _, stackErr := range stackErrs {
+		if len(stackErr.stack) > 0 {
+			frame := stackErr.stack[0]
+			lines = append(lines, fmt.Sprintf("(%T) %+v: %s", stackErr.err, frame, stackErr.msg))
+		} else {
+			lines = append(lines, fmt.Sprintf("(%T) %s", stackErr.err, stackErr.msg))
+		}
+	}
+
+	return lines
+}

--- a/internal/errors/go113.go
+++ b/internal/errors/go113.go
@@ -1,0 +1,38 @@
+// +build go1.13
+
+package errors
+
+import (
+	stderrors "errors"
+)
+
+// Is reports whether any error in err's chain matches target.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error is considered to match a target if it is equal to that target or if
+// it implements a method Is(error) bool such that Is(target) returns true.
+func Is(err, target error) bool { return stderrors.Is(err, target) }
+
+// As finds the first error in err's chain that matches target, and if so, sets
+// target to that error value and returns true.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error matches target if the error's concrete value is assignable to the value
+// pointed to by target, or if the error has a method As(interface{}) bool such that
+// As(target) returns true. In the latter case, the As method is responsible for
+// setting target.
+//
+// As will panic if target is not a non-nil pointer to either a type that implements
+// error, or to any interface type. As returns false if err is nil.
+func As(err error, target interface{}) bool { return stderrors.As(err, target) }
+
+// Unwrap returns the result of calling the Unwrap method on err, if err's
+// type contains an Unwrap method returning error.
+// Otherwise, Unwrap returns nil.
+func Unwrap(err error) error {
+	return stderrors.Unwrap(err)
+}

--- a/internal/errors/stack.go
+++ b/internal/errors/stack.go
@@ -1,0 +1,181 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+const (
+	defaultSkip = 3
+)
+
+// Frame represents a program counter inside a stack frame.
+// For historical reasons if Frame is interpreted as a uintptr
+// its value represents the program counter + 1.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// name returns the name of this function, if known.
+func (f Frame) name() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	return fn.Name()
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   function name and path of source file relative to the compile time
+//          GOPATH separated by \n\t (<funcname>\n\t<path>)
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			_, _ = io.WriteString(s, f.name())
+			_, _ = io.WriteString(s, "\n\t")
+			_, _ = io.WriteString(s, f.file())
+		default:
+			_, _ = io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		_, _ = io.WriteString(s, strconv.Itoa(f.line()))
+	case 'n':
+		_, _ = io.WriteString(s, funcname(f.name()))
+	case 'v':
+		f.Format(s, 's')
+		_, _ = io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// MarshalText formats a stacktrace Frame as a text string. The output is the
+// same as that of fmt.Sprintf("%+v", f), but without newlines or tabs.
+func (f Frame) MarshalText() ([]byte, error) {
+	name := f.name()
+	if name == "unknown" {
+		return []byte(name), nil
+	}
+	return []byte(fmt.Sprintf("%s %s:%d", name, f.file(), f.line())), nil
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+// Format formats the stack of Frames according to the fmt.Formatter interface.
+//
+//    %s	lists source files for each Frame in the stack
+//    %v	lists the source file and line number for each Frame in the stack
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+v   Prints filename, function, and line number for each Frame in the stack.
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				_, _ = io.WriteString(s, "\n")
+				f.Format(s, verb)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			st.formatSlice(s, verb)
+		}
+	case 's':
+		st.formatSlice(s, verb)
+	}
+}
+
+// formatSlice will format this StackTrace into the given buffer as a slice of
+// Frame, only valid when called with '%s' or '%v'.
+func (st StackTrace) formatSlice(s fmt.State, verb rune) {
+	_, _ = io.WriteString(s, "[")
+	for i, f := range st {
+		if i > 0 {
+			_, _ = io.WriteString(s, " ")
+		}
+		f.Format(s, verb)
+	}
+	_, _ = io.WriteString(s, "]")
+}
+
+// Stack represents a Stack of program counters.
+type Stack []uintptr
+
+func (s *Stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *Stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func Callers(additionalSkip int) *Stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(defaultSkip+additionalSkip, pcs[:])
+	var st Stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}

--- a/internal/errors/zerolog.go
+++ b/internal/errors/zerolog.go
@@ -1,0 +1,63 @@
+package errors
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// copied from zerolog console writer since they aren't exported
+//nolint
+const (
+	colorBlack = iota + 30
+	colorRed
+	colorGreen
+	colorYellow
+	colorBlue
+	colorMagenta
+	colorCyan
+	colorWhite
+)
+
+// colorize returns the string s wrapped in ANSI code c, unless disabled is true.
+func colorize(s interface{}, c int, disabled bool) string {
+	if disabled {
+		return fmt.Sprintf("%s", s)
+	}
+	return fmt.Sprintf("\x1b[%dm%v\x1b[0m", c, s)
+}
+
+type errorFormat = struct {
+	Error   string
+	Details []string
+}
+
+func FormatErrFieldValue(i interface{}) string {
+	switch d := i.(type) {
+	case []byte:
+		var ed errorFormat
+		if err := json.Unmarshal(d, &ed); err != nil {
+			return fmt.Sprintf("error: %v", err)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%s\n", ed.Error))
+		if len(ed.Details) > 0 {
+			sb.WriteString("error details:\n")
+			for _, l := range ed.Details {
+				sb.WriteString(fmt.Sprintf("%s\n", l))
+			}
+		}
+		return colorize(sb.String(), colorRed, false)
+
+	default:
+		return colorize(fmt.Sprintf("%s", d), colorRed, false)
+	}
+}
+
+func ErrorMarshalFunc(err error) interface{} {
+	ef := errorFormat{
+		Error:   err.Error(),
+		Details: PrintErrorDetails(err),
+	}
+	return ef
+}

--- a/internal/etcd/mutex.go
+++ b/internal/etcd/mutex.go
@@ -16,6 +16,7 @@
 // have the TryLock function not yet available on stable v3.4 client
 // Remove this when updating the client to a version providing TryLock
 
+//nolint:wrapcheck
 package etcd
 
 import (

--- a/internal/git-handler/handler.go
+++ b/internal/git-handler/handler.go
@@ -24,10 +24,10 @@ import (
 	"regexp"
 	"strings"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/util"
 
 	"github.com/rs/zerolog"
-	errors "golang.org/x/xerrors"
 )
 
 var (
@@ -109,21 +109,21 @@ func InfoRefsResponse(ctx context.Context, repoPath, serviceName string) ([]byte
 	git := &util.Git{}
 	out, err := git.Output(ctx, nil, serviceName, "--stateless-rpc", "--advertise-refs", repoPath)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	buf.Write(out)
 
-	return buf.Bytes(), err
+	return buf.Bytes(), errors.WithStack(err)
 }
 
 func gitService(ctx context.Context, w io.Writer, r io.Reader, repoPath, serviceName string) error {
 	git := &util.Git{GitDir: repoPath}
-	return git.Pipe(ctx, w, r, serviceName, "--stateless-rpc", repoPath)
+	return errors.WithStack(git.Pipe(ctx, w, r, serviceName, "--stateless-rpc", repoPath))
 }
 
 func gitFetchFile(ctx context.Context, w io.Writer, r io.Reader, repoPath, ref, path string) error {
 	git := &util.Git{GitDir: repoPath}
-	return git.Pipe(ctx, w, r, "show", fmt.Sprintf("%s:%s", ref, path))
+	return errors.WithStack(git.Pipe(ctx, w, r, "show", fmt.Sprintf("%s:%s", ref, path)))
 }
 
 var ErrWrongRepoPath = errors.New("wrong repository path")

--- a/internal/gitsources/gitea/gitea.go
+++ b/internal/gitsources/gitea/gitea.go
@@ -28,11 +28,11 @@ import (
 	"strings"
 	"time"
 
+	"agola.io/agola/internal/errors"
 	gitsource "agola.io/agola/internal/gitsources"
 
 	"code.gitea.io/sdk/gitea"
 	"golang.org/x/oauth2"
-	errors "golang.org/x/xerrors"
 )
 
 const (
@@ -146,7 +146,7 @@ func (c *Client) RequestOauth2Token(callbackURL, code string) (*oauth2.Token, er
 	var config = c.oauth2Config(callbackURL)
 	token, err := config.Exchange(ctx, code)
 	if err != nil {
-		return nil, errors.Errorf("cannot get oauth2 token: %w", err)
+		return nil, errors.Wrapf(err, "cannot get oauth2 token")
 	}
 	return token, nil
 }
@@ -158,7 +158,9 @@ func (c *Client) RefreshOauth2Token(refreshToken string) (*oauth2.Token, error) 
 	var config = c.oauth2Config("")
 	token := &oauth2.Token{RefreshToken: refreshToken}
 	ts := config.TokenSource(ctx, token)
-	return ts.Token()
+	ntoken, err := ts.Token()
+
+	return ntoken, errors.WithStack(err)
 }
 
 func (c *Client) LoginPassword(username, password, tokenName string) (string, error) {
@@ -172,16 +174,16 @@ func (c *Client) LoginPassword(username, password, tokenName string) (string, er
 	tokens := make([]*gitea.AccessToken, 0, 10)
 	req, err := http.NewRequest("GET", c.APIURL+"/api/v1"+fmt.Sprintf("/users/%s/tokens", username), nil)
 	if err != nil {
-		return "", err
+		return "", errors.WithStack(err)
 	}
 	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(username+":"+password)))
 
 	resp, err := c.oauth2HTTPClient.Do(req)
 	if err != nil {
-		return "", err
+		return "", errors.WithStack(err)
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
-		return "", gitsource.ErrUnauthorized
+		return "", errors.WithStack(gitsource.ErrUnauthorized)
 	}
 	if resp.StatusCode/100 != 2 {
 		return "", errors.Errorf("gitea api status code %d", resp.StatusCode)
@@ -190,7 +192,7 @@ func (c *Client) LoginPassword(username, password, tokenName string) (string, er
 
 	dec := json.NewDecoder(resp.Body)
 	if err := dec.Decode(&tokens); err != nil {
-		return "", err
+		return "", errors.WithStack(err)
 	}
 	for _, token := range tokens {
 		if token.Name == tokenName {
@@ -206,7 +208,7 @@ func (c *Client) LoginPassword(username, password, tokenName string) (string, er
 			gitea.CreateAccessTokenOption{Name: tokenName},
 		)
 		if terr != nil {
-			return "", terr
+			return "", errors.WithStack(terr)
 		}
 		accessToken = token.Token
 	}
@@ -217,7 +219,7 @@ func (c *Client) LoginPassword(username, password, tokenName string) (string, er
 func (c *Client) GetUserInfo() (*gitsource.UserInfo, error) {
 	user, err := c.client.GetMyUserInfo()
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return &gitsource.UserInfo{
 		ID:        strconv.FormatInt(user.ID, 10),
@@ -229,11 +231,11 @@ func (c *Client) GetUserInfo() (*gitsource.UserInfo, error) {
 func (c *Client) GetRepoInfo(repopath string) (*gitsource.RepoInfo, error) {
 	owner, reponame, err := parseRepoPath(repopath)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	rr, err := c.client.GetRepo(owner, reponame)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return fromGiteaRepo(rr), nil
 }
@@ -241,23 +243,23 @@ func (c *Client) GetRepoInfo(repopath string) (*gitsource.RepoInfo, error) {
 func (c *Client) GetFile(repopath, commit, file string) ([]byte, error) {
 	owner, reponame, err := parseRepoPath(repopath)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	data, err := c.client.GetFile(owner, reponame, commit, file)
-	return data, err
+	return data, errors.WithStack(err)
 }
 
 func (c *Client) CreateDeployKey(repopath, title, pubKey string, readonly bool) error {
 	owner, reponame, err := parseRepoPath(repopath)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	if _, err = c.client.CreateDeployKey(owner, reponame, gitea.CreateKeyOption{
 		Title:    title,
 		Key:      pubKey,
 		ReadOnly: readonly,
 	}); err != nil {
-		return errors.Errorf("error creating deploy key: %w", err)
+		return errors.Wrapf(err, "error creating deploy key")
 	}
 
 	return nil
@@ -266,7 +268,7 @@ func (c *Client) CreateDeployKey(repopath, title, pubKey string, readonly bool) 
 func (c *Client) UpdateDeployKey(repopath, title, pubKey string, readonly bool) error {
 	owner, reponame, err := parseRepoPath(repopath)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	// NOTE(sgotti) gitea has a bug where if we delete and remove the same key with
 	// the same value it is correctly readded and the admin must force a
@@ -274,7 +276,7 @@ func (c *Client) UpdateDeployKey(repopath, title, pubKey string, readonly bool) 
 	// when the public key value has changed
 	keys, err := c.client.ListDeployKeys(owner, reponame, gitea.ListDeployKeysOptions{})
 	if err != nil {
-		return errors.Errorf("error retrieving existing deploy keys: %w", err)
+		return errors.Wrapf(err, "error retrieving existing deploy keys")
 	}
 
 	for _, key := range keys {
@@ -283,7 +285,7 @@ func (c *Client) UpdateDeployKey(repopath, title, pubKey string, readonly bool) 
 				return nil
 			}
 			if err := c.client.DeleteDeployKey(owner, reponame, key.ID); err != nil {
-				return errors.Errorf("error removing existing deploy key: %w", err)
+				return errors.Wrapf(err, "error removing existing deploy key")
 			}
 		}
 	}
@@ -293,7 +295,7 @@ func (c *Client) UpdateDeployKey(repopath, title, pubKey string, readonly bool) 
 		Key:      pubKey,
 		ReadOnly: readonly,
 	}); err != nil {
-		return errors.Errorf("error creating deploy key: %w", err)
+		return errors.Wrapf(err, "error creating deploy key")
 	}
 
 	return nil
@@ -302,17 +304,17 @@ func (c *Client) UpdateDeployKey(repopath, title, pubKey string, readonly bool) 
 func (c *Client) DeleteDeployKey(repopath, title string) error {
 	owner, reponame, err := parseRepoPath(repopath)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	keys, err := c.client.ListDeployKeys(owner, reponame, gitea.ListDeployKeysOptions{})
 	if err != nil {
-		return errors.Errorf("error retrieving existing deploy keys: %w", err)
+		return errors.Wrapf(err, "error retrieving existing deploy keys")
 	}
 
 	for _, key := range keys {
 		if key.Title == title {
 			if err := c.client.DeleteDeployKey(owner, reponame, key.ID); err != nil {
-				return errors.Errorf("error removing existing deploy key: %w", err)
+				return errors.Wrapf(err, "error removing existing deploy key")
 			}
 		}
 	}
@@ -323,7 +325,7 @@ func (c *Client) DeleteDeployKey(repopath, title string) error {
 func (c *Client) CreateRepoWebhook(repopath, url, secret string) error {
 	owner, reponame, err := parseRepoPath(repopath)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	opts := gitea.CreateHookOption{
@@ -338,7 +340,7 @@ func (c *Client) CreateRepoWebhook(repopath, url, secret string) error {
 	}
 
 	if _, err = c.client.CreateRepoHook(owner, reponame, opts); err != nil {
-		return errors.Errorf("error creating repository webhook: %w", err)
+		return errors.Wrapf(err, "error creating repository webhook")
 	}
 
 	return nil
@@ -347,11 +349,11 @@ func (c *Client) CreateRepoWebhook(repopath, url, secret string) error {
 func (c *Client) DeleteRepoWebhook(repopath, u string) error {
 	owner, reponame, err := parseRepoPath(repopath)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	hooks, err := c.client.ListRepoHooks(owner, reponame, gitea.ListHooksOptions{})
 	if err != nil {
-		return errors.Errorf("error retrieving repository webhooks: %w", err)
+		return errors.Wrapf(err, "error retrieving repository webhooks")
 	}
 
 	// match the full url so we can have multiple webhooks for different agola
@@ -359,7 +361,7 @@ func (c *Client) DeleteRepoWebhook(repopath, u string) error {
 	for _, hook := range hooks {
 		if hook.Config["url"] == u {
 			if err := c.client.DeleteRepoHook(owner, reponame, hook.ID); err != nil {
-				return errors.Errorf("error deleting existing repository webhook: %w", err)
+				return errors.Wrapf(err, "error deleting existing repository webhook")
 			}
 		}
 	}
@@ -370,7 +372,7 @@ func (c *Client) DeleteRepoWebhook(repopath, u string) error {
 func (c *Client) CreateCommitStatus(repopath, commitSHA string, status gitsource.CommitStatus, targetURL, description, context string) error {
 	owner, reponame, err := parseRepoPath(repopath)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	_, err = c.client.CreateStatus(owner, reponame, commitSHA, gitea.CreateStatusOption{
 		State:       fromCommitStatus(status),
@@ -378,7 +380,7 @@ func (c *Client) CreateCommitStatus(repopath, commitSHA string, status gitsource
 		Description: description,
 		Context:     context,
 	})
-	return err
+	return errors.WithStack(err)
 }
 
 func (c *Client) ListUserRepos() ([]*gitsource.RepoInfo, error) {
@@ -396,7 +398,7 @@ func (c *Client) ListUserRepos() ([]*gitsource.RepoInfo, error) {
 		)
 
 		if err != nil {
-			return []*gitsource.RepoInfo{}, err
+			return []*gitsource.RepoInfo{}, errors.WithStack(err)
 		}
 
 		for _, repo := range remoteRepos {
@@ -429,12 +431,12 @@ func fromGiteaRepo(rr *gitea.Repository) *gitsource.RepoInfo {
 func (c *Client) GetRef(repopath, ref string) (*gitsource.Ref, error) {
 	owner, reponame, err := parseRepoPath(repopath)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	remoteRefs, err := c.client.GetRepoRefs(owner, reponame, ref)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	if len(remoteRefs) == 0 {
 		return nil, errors.Errorf("no ref %q for repository %q", ref, repopath)
@@ -480,12 +482,12 @@ func (c *Client) RefType(ref string) (gitsource.RefType, string, error) {
 func (c *Client) GetCommit(repopath, commitSHA string) (*gitsource.Commit, error) {
 	owner, reponame, err := parseRepoPath(repopath)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	commit, err := c.client.GetSingleCommit(owner, reponame, commitSHA)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	return &gitsource.Commit{

--- a/internal/gitsources/gitea/parse.go
+++ b/internal/gitsources/gitea/parse.go
@@ -27,9 +27,8 @@ import (
 	"strconv"
 	"strings"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/types"
-
-	errors "golang.org/x/xerrors"
 )
 
 const (
@@ -48,7 +47,7 @@ const (
 func (c *Client) ParseWebhook(r *http.Request, secret string) (*types.WebhookData, error) {
 	data, err := ioutil.ReadAll(io.LimitReader(r.Body, 10*1024*1024))
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	// verify signature
@@ -83,7 +82,7 @@ func parsePushHook(data []byte) (*types.WebhookData, error) {
 	push := new(pushHook)
 	err := json.Unmarshal(data, push)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	return webhookDataFromPush(push)
@@ -93,7 +92,7 @@ func parsePullRequestHook(data []byte) (*types.WebhookData, error) {
 	prhook := new(pullRequestHook)
 	err := json.Unmarshal(data, prhook)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	// skip non open pull requests
@@ -144,7 +143,7 @@ func webhookDataFromPush(hook *pushHook) (*types.WebhookData, error) {
 		whd.Message = fmt.Sprintf("Tag %s", whd.Tag)
 	default:
 		// ignore received webhook since it doesn't have a ref we're interested in
-		return nil, fmt.Errorf("unsupported webhook ref %q", hook.Ref)
+		return nil, errors.Errorf("unsupported webhook ref %q", hook.Ref)
 	}
 
 	return whd, nil

--- a/internal/gitsources/github/parse.go
+++ b/internal/gitsources/github/parse.go
@@ -21,10 +21,10 @@ import (
 	"strconv"
 	"strings"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/types"
 
 	"github.com/google/go-github/v29/github"
-	errors "golang.org/x/xerrors"
 )
 
 const (
@@ -37,12 +37,12 @@ const (
 func (c *Client) ParseWebhook(r *http.Request, secret string) (*types.WebhookData, error) {
 	payload, err := github.ValidatePayload(r, []byte(secret))
 	if err != nil {
-		return nil, errors.Errorf("wrong webhook signature: %w", err)
+		return nil, errors.Wrapf(err, "wrong webhook signature")
 	}
 	webHookType := github.WebHookType(r)
 	event, err := github.ParseWebHook(webHookType, payload)
 	if err != nil {
-		return nil, errors.Errorf("failed to parse webhook: %w", err)
+		return nil, errors.Wrapf(err, "failed to parse webhook")
 	}
 	switch event := event.(type) {
 	case *github.PushEvent:
@@ -96,7 +96,7 @@ func webhookDataFromPush(hook *github.PushEvent) (*types.WebhookData, error) {
 
 	default:
 		// ignore received webhook since it doesn't have a ref we're interested in
-		return nil, fmt.Errorf("unsupported webhook ref %q", *hook.Ref)
+		return nil, errors.Errorf("unsupported webhook ref %q", *hook.Ref)
 	}
 
 	return whd, nil

--- a/internal/gitsources/gitsource.go
+++ b/internal/gitsources/gitsource.go
@@ -15,10 +15,11 @@
 package gitsource
 
 import (
-	"errors"
 	"net/http"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/types"
+
 	"golang.org/x/oauth2"
 )
 

--- a/internal/objectstorage/atomic.go
+++ b/internal/objectstorage/atomic.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"agola.io/agola/internal/errors"
 )
 
 // writeFileAtomicFunc atomically writes a file, it achieves this by creating a
@@ -30,7 +32,7 @@ import (
 func writeFileAtomicFunc(p, baseDir, tmpDir string, perm os.FileMode, persist bool, writeFunc func(f io.Writer) error) error {
 	f, err := ioutil.TempFile(tmpDir, "tmpfile")
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	err = writeFunc(f)
 	if persist && err == nil {
@@ -47,7 +49,7 @@ func writeFileAtomicFunc(p, baseDir, tmpDir string, perm os.FileMode, persist bo
 	}
 	if err != nil {
 		os.Remove(f.Name())
-		return err
+		return errors.WithStack(err)
 	}
 
 	if !persist {
@@ -80,7 +82,7 @@ func writeFileAtomic(filename, baseDir, tmpDir string, perm os.FileMode, persist
 	return writeFileAtomicFunc(filename, baseDir, tmpDir, perm, persist,
 		func(f io.Writer) error {
 			_, err := f.Write(data)
-			return err
+			return errors.WithStack(err)
 		})
 }
 */

--- a/internal/objectstorage/objectstorage.go
+++ b/internal/objectstorage/objectstorage.go
@@ -18,7 +18,7 @@ import (
 	"io"
 	"time"
 
-	errors "golang.org/x/xerrors"
+	"agola.io/agola/internal/errors"
 )
 
 type Storage interface {
@@ -36,10 +36,12 @@ type Storage interface {
 
 type ErrNotExist struct {
 	err error
+
+	*errors.Stack
 }
 
 func NewErrNotExist(err error) error {
-	return &ErrNotExist{err: err}
+	return &ErrNotExist{err: err, Stack: errors.Callers(0)}
 }
 
 func (e *ErrNotExist) Error() string {

--- a/internal/objectstorage/posix.go
+++ b/internal/objectstorage/posix.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	errors "golang.org/x/xerrors"
+	"agola.io/agola/internal/errors"
 )
 
 const (
@@ -36,15 +36,15 @@ type PosixStorage struct {
 
 func NewPosix(baseDir string) (*PosixStorage, error) {
 	if err := os.MkdirAll(baseDir, 0770); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	dataDir := filepath.Join(baseDir, dataDirName)
 	tmpDir := filepath.Join(baseDir, tmpDirName)
 	if err := os.MkdirAll(dataDir, 0770); err != nil {
-		return nil, errors.Errorf("failed to create data dir: %w", err)
+		return nil, errors.Wrapf(err, "failed to create data dir")
 	}
 	if err := os.MkdirAll(tmpDir, 0770); err != nil {
-		return nil, errors.Errorf("failed to create tmp dir: %w", err)
+		return nil, errors.Wrapf(err, "failed to create tmp dir")
 	}
 	return &PosixStorage{
 		dataDir: dataDir,
@@ -59,7 +59,7 @@ func (s *PosixStorage) fsPath(p string) (string, error) {
 func (s *PosixStorage) Stat(p string) (*ObjectInfo, error) {
 	fspath, err := s.fsPath(p)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	fi, err := os.Stat(fspath)
@@ -67,7 +67,7 @@ func (s *PosixStorage) Stat(p string) (*ObjectInfo, error) {
 		if os.IsNotExist(err) {
 			return nil, NewErrNotExist(errors.Errorf("object %q doesn't exist", p))
 		}
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	return &ObjectInfo{Path: p, LastModified: fi.ModTime(), Size: fi.Size()}, nil
@@ -76,24 +76,24 @@ func (s *PosixStorage) Stat(p string) (*ObjectInfo, error) {
 func (s *PosixStorage) ReadObject(p string) (ReadSeekCloser, error) {
 	fspath, err := s.fsPath(p)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	f, err := os.Open(fspath)
 	if err != nil && os.IsNotExist(err) {
 		return nil, NewErrNotExist(errors.Errorf("object %q doesn't exist", p))
 	}
-	return f, err
+	return f, errors.WithStack(err)
 }
 
 func (s *PosixStorage) WriteObject(p string, data io.Reader, size int64, persist bool) error {
 	fspath, err := s.fsPath(p)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	if err := os.MkdirAll(path.Dir(fspath), 0770); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	r := data
@@ -102,21 +102,21 @@ func (s *PosixStorage) WriteObject(p string, data io.Reader, size int64, persist
 	}
 	return writeFileAtomicFunc(fspath, s.dataDir, s.tmpDir, 0660, persist, func(f io.Writer) error {
 		_, err := io.Copy(f, r)
-		return err
+		return errors.WithStack(err)
 	})
 }
 
 func (s *PosixStorage) DeleteObject(p string) error {
 	fspath, err := s.fsPath(p)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	if err := os.Remove(fspath); err != nil {
 		if os.IsNotExist(err) {
 			return NewErrNotExist(errors.Errorf("object %q doesn't exist", p))
 		}
-		return err
+		return errors.WithStack(err)
 	}
 
 	// try to remove parent empty dirs
@@ -179,7 +179,7 @@ func (s *PosixStorage) List(prefix, startWith, delimiter string, doneCh <-chan s
 		defer close(objectCh)
 		err := filepath.Walk(root, func(ep string, info os.FileInfo, err error) error {
 			if err != nil && !os.IsNotExist(err) {
-				return err
+				return errors.WithStack(err)
 			}
 			if os.IsNotExist(err) {
 				return nil
@@ -191,7 +191,7 @@ func (s *PosixStorage) List(prefix, startWith, delimiter string, doneCh <-chan s
 
 			p, err = filepath.Rel(s.dataDir, p)
 			if err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 			if !recursive && len(p) > len(prefix) {
 				rel := strings.TrimPrefix(p, prefix)

--- a/internal/objectstorage/posixflat_test.go
+++ b/internal/objectstorage/posixflat_test.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	errors "golang.org/x/xerrors"
+	"agola.io/agola/internal/errors"
 )
 
 func TestEscapeUnescape(t *testing.T) {

--- a/internal/runconfig/runconfig.go
+++ b/internal/runconfig/runconfig.go
@@ -19,12 +19,11 @@ import (
 	"strings"
 
 	"agola.io/agola/internal/config"
+	"agola.io/agola/internal/errors"
 	itypes "agola.io/agola/internal/services/types"
 	"agola.io/agola/internal/util"
 	rstypes "agola.io/agola/services/runservice/types"
 	"agola.io/agola/services/types"
-
-	errors "golang.org/x/xerrors"
 )
 
 const (
@@ -192,7 +191,7 @@ fi
 		return rws
 
 	default:
-		panic(fmt.Errorf("unknown config step type: %s", util.Dump(cs)))
+		panic(errors.Errorf("unknown config step type: %s", util.Dump(cs)))
 	}
 }
 
@@ -461,7 +460,7 @@ func genValue(val config.Value, variables map[string]string) string {
 	case config.ValueTypeFromVariable:
 		return variables[val.Value]
 	default:
-		panic(fmt.Errorf("wrong value type: %q", val.Value))
+		panic(errors.Errorf("wrong value type: %q", val.Value))
 	}
 }
 

--- a/internal/runconfig/runconfig_test.go
+++ b/internal/runconfig/runconfig_test.go
@@ -20,13 +20,13 @@ import (
 	"testing"
 
 	"agola.io/agola/internal/config"
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/util"
 	rstypes "agola.io/agola/services/runservice/types"
 	"agola.io/agola/services/types"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/google/go-cmp/cmp"
-	errors "golang.org/x/xerrors"
 )
 
 var uuid = &util.TestUUIDGenerator{}
@@ -128,7 +128,7 @@ func TestGenTasksLevels(t *testing.T) {
 					},
 				},
 			},
-			err: fmt.Errorf("circular dependency detected"),
+			err: errors.Errorf("circular dependency detected"),
 		},
 		{
 			name: "Test circular dependency between 3 tasks: a -> b -> c -> a",
@@ -155,7 +155,7 @@ func TestGenTasksLevels(t *testing.T) {
 					},
 				},
 			},
-			err: fmt.Errorf("circular dependency detected"),
+			err: errors.Errorf("circular dependency detected"),
 		},
 		{
 			name: "Test circular dependency between 3 tasks: a -> b -> c -> b",
@@ -182,7 +182,7 @@ func TestGenTasksLevels(t *testing.T) {
 					},
 				},
 			},
-			err: fmt.Errorf("circular dependency detected"),
+			err: errors.Errorf("circular dependency detected"),
 		},
 	}
 	for _, tt := range tests {

--- a/internal/sequence/sequence_test.go
+++ b/internal/sequence/sequence_test.go
@@ -15,9 +15,10 @@
 package sequence
 
 import (
-	"errors"
 	"math"
 	"testing"
+
+	"agola.io/agola/internal/errors"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/internal/services/common/gitsource.go
+++ b/internal/services/common/gitsource.go
@@ -15,43 +15,48 @@
 package common
 
 import (
+	"agola.io/agola/internal/errors"
 	gitsource "agola.io/agola/internal/gitsources"
 	"agola.io/agola/internal/gitsources/gitea"
 	"agola.io/agola/internal/gitsources/github"
 	"agola.io/agola/internal/gitsources/gitlab"
 	cstypes "agola.io/agola/services/configstore/types"
-
-	errors "golang.org/x/xerrors"
 )
 
 func newGitea(rs *cstypes.RemoteSource, accessToken string) (*gitea.Client, error) {
-	return gitea.New(gitea.Opts{
+	c, err := gitea.New(gitea.Opts{
 		APIURL:         rs.APIURL,
 		SkipVerify:     rs.SkipVerify,
 		Token:          accessToken,
 		Oauth2ClientID: rs.Oauth2ClientID,
 		Oauth2Secret:   rs.Oauth2ClientSecret,
 	})
+
+	return c, errors.WithStack(err)
 }
 
 func newGitlab(rs *cstypes.RemoteSource, accessToken string) (*gitlab.Client, error) {
-	return gitlab.New(gitlab.Opts{
+	c, err := gitlab.New(gitlab.Opts{
 		APIURL:         rs.APIURL,
 		SkipVerify:     rs.SkipVerify,
 		Token:          accessToken,
 		Oauth2ClientID: rs.Oauth2ClientID,
 		Oauth2Secret:   rs.Oauth2ClientSecret,
 	})
+
+	return c, errors.WithStack(err)
 }
 
 func newGithub(rs *cstypes.RemoteSource, accessToken string) (*github.Client, error) {
-	return github.New(github.Opts{
+	c, err := github.New(github.Opts{
 		APIURL:         rs.APIURL,
 		SkipVerify:     rs.SkipVerify,
 		Token:          accessToken,
 		Oauth2ClientID: rs.Oauth2ClientID,
 		Oauth2Secret:   rs.Oauth2ClientSecret,
 	})
+
+	return c, errors.WithStack(err)
 }
 
 func GetAccessToken(rs *cstypes.RemoteSource, userAccessToken, oauth2AccessToken string) (string, error) {
@@ -71,7 +76,7 @@ func GetGitSource(rs *cstypes.RemoteSource, la *cstypes.LinkedAccount) (gitsourc
 		var err error
 		accessToken, err = GetAccessToken(rs, la.UserAccessToken, la.Oauth2AccessToken)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 	}
 
@@ -88,7 +93,7 @@ func GetGitSource(rs *cstypes.RemoteSource, la *cstypes.LinkedAccount) (gitsourc
 		return nil, errors.Errorf("remote source %s isn't a valid git source", rs.Name)
 	}
 
-	return gitSource, err
+	return gitSource, errors.WithStack(err)
 }
 
 func GetUserSource(rs *cstypes.RemoteSource, accessToken string) (gitsource.UserSource, error) {
@@ -103,7 +108,7 @@ func GetUserSource(rs *cstypes.RemoteSource, accessToken string) (gitsource.User
 		return nil, errors.Errorf("unknown remote source auth type")
 	}
 
-	return userSource, err
+	return userSource, errors.WithStack(err)
 }
 
 func GetOauth2Source(rs *cstypes.RemoteSource, accessToken string) (gitsource.Oauth2Source, error) {
@@ -120,7 +125,7 @@ func GetOauth2Source(rs *cstypes.RemoteSource, accessToken string) (gitsource.Oa
 		return nil, errors.Errorf("remote source %s isn't a valid oauth2 source", rs.Name)
 	}
 
-	return oauth2Source, err
+	return oauth2Source, errors.WithStack(err)
 }
 
 func GetPasswordSource(rs *cstypes.RemoteSource, accessToken string) (gitsource.PasswordSource, error) {
@@ -133,5 +138,5 @@ func GetPasswordSource(rs *cstypes.RemoteSource, accessToken string) (gitsource.
 		return nil, errors.Errorf("remote source %s isn't a valid oauth2 source", rs.Name)
 	}
 
-	return passwordSource, err
+	return passwordSource, errors.WithStack(err)
 }

--- a/internal/services/common/jwt.go
+++ b/internal/services/common/jwt.go
@@ -19,8 +19,8 @@ import (
 	"encoding/json"
 	"time"
 
+	"agola.io/agola/internal/errors"
 	"github.com/golang-jwt/jwt/v4"
-	errors "golang.org/x/xerrors"
 )
 
 type TokenSigningData struct {
@@ -44,13 +44,14 @@ func GenerateGenericJWTToken(sd *TokenSigningData, claims jwt.Claims) (string, e
 		return "", errors.Errorf("unsupported signing method %q", sd.Method.Alg())
 	}
 	// Sign and get the complete encoded token as a string
-	return token.SignedString(key)
+	ts, err := token.SignedString(key)
+	return ts, errors.WithStack(err)
 }
 
 func GenerateOauth2JWTToken(sd *TokenSigningData, remoteSourceName, requestType string, request interface{}) (string, error) {
 	requestj, err := json.Marshal(request)
 	if err != nil {
-		return "", err
+		return "", errors.WithStack(err)
 	}
 
 	return GenerateGenericJWTToken(sd, jwt.MapClaims{

--- a/internal/services/common/run.go
+++ b/internal/services/common/run.go
@@ -15,13 +15,12 @@
 package common
 
 import (
-	"fmt"
 	"net/url"
 	"path"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/types"
 	"agola.io/agola/internal/util"
-	errors "golang.org/x/xerrors"
 )
 
 type GroupType string
@@ -49,7 +48,7 @@ func WebHookEventToRunRefType(we types.WebhookEvent) types.RunRefType {
 		return types.RunRefTypePullRequest
 	}
 
-	panic(fmt.Errorf("invalid webhook event type: %q", we))
+	panic(errors.Errorf("invalid webhook event type: %q", we))
 }
 
 func GenRunGroup(baseGroupType GroupType, baseGroupID string, groupType GroupType, group string) string {

--- a/internal/services/config/config.go
+++ b/internal/services/config/config.go
@@ -18,9 +18,9 @@ import (
 	"io/ioutil"
 	"time"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/util"
 
-	errors "golang.org/x/xerrors"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -273,12 +273,12 @@ var defaultConfig = Config{
 func Parse(configFile string, componentsNames []string) (*Config, error) {
 	configData, err := ioutil.ReadFile(configFile)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	c := &defaultConfig
 	if err := yaml.Unmarshal(configData, &c); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	return c, Validate(c, componentsNames)
@@ -333,7 +333,7 @@ func Validate(c *Config, componentsNames []string) error {
 			return errors.Errorf("gateway runserviceURL is empty")
 		}
 		if err := validateWeb(&c.Gateway.Web); err != nil {
-			return errors.Errorf("gateway web configuration error: %w", err)
+			return errors.Wrapf(err, "gateway web configuration error")
 		}
 	}
 
@@ -343,7 +343,7 @@ func Validate(c *Config, componentsNames []string) error {
 			return errors.Errorf("configstore dataDir is empty")
 		}
 		if err := validateWeb(&c.Configstore.Web); err != nil {
-			return errors.Errorf("configstore web configuration error: %w", err)
+			return errors.Wrapf(err, "configstore web configuration error")
 		}
 	}
 
@@ -353,7 +353,7 @@ func Validate(c *Config, componentsNames []string) error {
 			return errors.Errorf("runservice dataDir is empty")
 		}
 		if err := validateWeb(&c.Runservice.Web); err != nil {
-			return errors.Errorf("runservice web configuration error: %w", err)
+			return errors.Wrapf(err, "runservice web configuration error")
 		}
 	}
 
@@ -379,7 +379,7 @@ func Validate(c *Config, componentsNames []string) error {
 		}
 
 		if err := validateInitImage(&c.Executor.InitImage); err != nil {
-			return errors.Errorf("executor initImage configuration error: %w", err)
+			return errors.Wrapf(err, "executor initImage configuration error")
 		}
 	}
 

--- a/internal/services/config/config_test.go
+++ b/internal/services/config/config_test.go
@@ -20,7 +20,7 @@ import (
 	"path"
 	"testing"
 
-	errors "golang.org/x/xerrors"
+	"agola.io/agola/internal/errors"
 )
 
 func TestParseConfig(t *testing.T) {

--- a/internal/services/configstore/action/action.go
+++ b/internal/services/configstore/action/action.go
@@ -17,13 +17,13 @@ package action
 import (
 	"agola.io/agola/internal/datamanager"
 	"agola.io/agola/internal/db"
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/etcd"
 	"agola.io/agola/internal/services/configstore/readdb"
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/configstore/types"
 
 	"github.com/rs/zerolog"
-	errors "golang.org/x/xerrors"
 )
 
 type ActionHandler struct {
@@ -53,7 +53,7 @@ func (h *ActionHandler) ResolveConfigID(tx *db.Tx, configType types.ConfigType, 
 	case types.ConfigTypeProjectGroup:
 		group, err := h.readDB.GetProjectGroup(tx, ref)
 		if err != nil {
-			return "", err
+			return "", errors.WithStack(err)
 		}
 		if group == nil {
 			return "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("group with ref %q doesn't exists", ref))
@@ -63,7 +63,7 @@ func (h *ActionHandler) ResolveConfigID(tx *db.Tx, configType types.ConfigType, 
 	case types.ConfigTypeProject:
 		project, err := h.readDB.GetProject(tx, ref)
 		if err != nil {
-			return "", err
+			return "", errors.WithStack(err)
 		}
 		if project == nil {
 			return "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with ref %q doesn't exists", ref))

--- a/internal/services/configstore/api/api.go
+++ b/internal/services/configstore/api/api.go
@@ -18,11 +18,11 @@ import (
 	"net/http"
 	"net/url"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/configstore/types"
 
 	"github.com/gorilla/mux"
-	errors "golang.org/x/xerrors"
 )
 
 type ErrorResponse struct {
@@ -33,7 +33,7 @@ func GetConfigTypeRef(r *http.Request) (types.ConfigType, string, error) {
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		return "", "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("wrong projectref %q: %w", vars["projectref"], err))
+		return "", "", util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "wrong projectref %q", vars["projectref"]))
 	}
 	if projectRef != "" {
 		return types.ConfigTypeProject, projectRef, nil
@@ -41,7 +41,7 @@ func GetConfigTypeRef(r *http.Request) (types.ConfigType, string, error) {
 
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		return "", "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("wrong projectgroupref %q: %w", vars["projectgroupref"], err))
+		return "", "", util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "wrong projectgroupref %q", vars["projectgroupref"]))
 	}
 	if projectGroupRef != "" {
 		return types.ConfigTypeProjectGroup, projectGroupRef, nil

--- a/internal/services/configstore/api/org.go
+++ b/internal/services/configstore/api/org.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"agola.io/agola/internal/db"
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/configstore/action"
 	"agola.io/agola/internal/services/configstore/readdb"
 	"agola.io/agola/internal/util"
@@ -28,7 +29,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
-	errors "golang.org/x/xerrors"
 )
 
 type OrgHandler struct {
@@ -49,7 +49,7 @@ func (h *OrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		org, err = h.readDB.GetOrg(tx, orgRef)
-		return err
+		return errors.WithStack(err)
 	})
 	if err != nil {
 		h.log.Err(err).Send()
@@ -146,7 +146,7 @@ func (h *OrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot parse limit: %w", err)))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse limit")))
 			return
 		}
 	}
@@ -168,7 +168,7 @@ func (h *OrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		orgs, err = h.readDB.GetOrgs(tx, start, limit, asc)
-		return err
+		return errors.WithStack(err)
 	})
 	if err != nil {
 		h.log.Err(err).Send()

--- a/internal/services/configstore/api/projectgroup.go
+++ b/internal/services/configstore/api/projectgroup.go
@@ -22,6 +22,8 @@ import (
 	"path"
 
 	"agola.io/agola/internal/db"
+	"agola.io/agola/internal/errors"
+
 	"agola.io/agola/internal/services/configstore/action"
 	"agola.io/agola/internal/services/configstore/readdb"
 	"agola.io/agola/internal/util"
@@ -35,7 +37,7 @@ import (
 func projectGroupResponse(ctx context.Context, readDB *readdb.ReadDB, projectGroup *types.ProjectGroup) (*csapitypes.ProjectGroup, error) {
 	r, err := projectGroupsResponse(ctx, readDB, []*types.ProjectGroup{projectGroup})
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return r[0], nil
 }
@@ -47,18 +49,18 @@ func projectGroupsResponse(ctx context.Context, readDB *readdb.ReadDB, projectGr
 		for i, projectGroup := range projectGroups {
 			pp, err := readDB.GetPath(tx, projectGroup.Parent.Type, projectGroup.Parent.ID)
 			if err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 
 			ownerType, ownerID, err := readDB.GetProjectGroupOwnerID(tx, projectGroup)
 			if err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 
 			// calculate global visibility
 			visibility, err := getGlobalVisibility(readDB, tx, projectGroup.Visibility, &projectGroup.Parent)
 			if err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 
 			// we calculate the path here from parent path since the db could not yet be
@@ -76,7 +78,7 @@ func projectGroupsResponse(ctx context.Context, readDB *readdb.ReadDB, projectGr
 		return nil
 	})
 
-	return resProjectGroups, err
+	return resProjectGroups, errors.WithStack(err)
 }
 
 type ProjectGroupHandler struct {

--- a/internal/services/configstore/api/remotesource.go
+++ b/internal/services/configstore/api/remotesource.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"agola.io/agola/internal/db"
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/configstore/action"
 	"agola.io/agola/internal/services/configstore/readdb"
 	"agola.io/agola/internal/util"
@@ -27,7 +28,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
-	errors "golang.org/x/xerrors"
 )
 
 type RemoteSourceHandler struct {
@@ -48,7 +48,7 @@ func (h *RemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		remoteSource, err = h.readDB.GetRemoteSource(tx, rsRef)
-		return err
+		return errors.WithStack(err)
 	})
 	if err != nil {
 		h.log.Err(err).Send()
@@ -181,7 +181,7 @@ func (h *RemoteSourcesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot parse limit: %w", err)))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse limit")))
 			return
 		}
 	}

--- a/internal/services/configstore/api/secret.go
+++ b/internal/services/configstore/api/secret.go
@@ -19,6 +19,8 @@ import (
 	"net/http"
 
 	"agola.io/agola/internal/db"
+	"agola.io/agola/internal/errors"
+
 	"agola.io/agola/internal/services/configstore/action"
 	"agola.io/agola/internal/services/configstore/readdb"
 	"agola.io/agola/internal/util"
@@ -92,11 +94,11 @@ func (h *SecretsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		for _, s := range resSecrets {
 			pp, err := h.readDB.GetPath(tx, s.Parent.Type, s.Parent.ID)
 			if err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 			s.ParentPath = pp
 		}
-		return err
+		return errors.WithStack(err)
 	})
 	if err != nil {
 		h.log.Err(err).Send()

--- a/internal/services/configstore/api/user.go
+++ b/internal/services/configstore/api/user.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"agola.io/agola/internal/db"
+	"agola.io/agola/internal/errors"
 	action "agola.io/agola/internal/services/configstore/action"
 	"agola.io/agola/internal/services/configstore/readdb"
 	"agola.io/agola/internal/util"
@@ -28,7 +29,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
-	errors "golang.org/x/xerrors"
 )
 
 type UserHandler struct {
@@ -49,7 +49,7 @@ func (h *UserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		user, err = h.readDB.GetUser(tx, userRef)
-		return err
+		return errors.WithStack(err)
 	})
 	if err != nil {
 		h.log.Err(err).Send()
@@ -198,7 +198,7 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot parse limit: %w", err)))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse limit")))
 			return
 		}
 	}
@@ -227,7 +227,7 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 			var err error
 			user, err = h.readDB.GetUserByTokenValue(tx, token)
-			return err
+			return errors.WithStack(err)
 		})
 		if err != nil {
 			h.log.Err(err).Send()
@@ -245,7 +245,7 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 			var err error
 			user, err = h.readDB.GetUserByLinkedAccount(tx, linkedAccountID)
-			return err
+			return errors.WithStack(err)
 		})
 		if err != nil {
 			h.log.Err(err).Send()
@@ -264,7 +264,7 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 			var err error
 			user, err = h.readDB.GetUserByLinkedAccountRemoteUserIDandSource(tx, remoteUserID, remoteSourceID)
-			return err
+			return errors.WithStack(err)
 		})
 		if err != nil {
 			h.log.Err(err).Send()
@@ -281,7 +281,7 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 			var err error
 			users, err = h.readDB.GetUsers(tx, start, limit, asc)
-			return err
+			return errors.WithStack(err)
 		})
 		if err != nil {
 			h.log.Err(err).Send()

--- a/internal/services/configstore/api/variable.go
+++ b/internal/services/configstore/api/variable.go
@@ -19,6 +19,8 @@ import (
 	"net/http"
 
 	"agola.io/agola/internal/db"
+	"agola.io/agola/internal/errors"
+
 	"agola.io/agola/internal/services/configstore/action"
 	"agola.io/agola/internal/services/configstore/readdb"
 	"agola.io/agola/internal/util"
@@ -65,11 +67,11 @@ func (h *VariablesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		for _, v := range resVariables {
 			pp, err := h.readDB.GetPath(tx, v.Parent.Type, v.Parent.ID)
 			if err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 			v.ParentPath = pp
 		}
-		return err
+		return errors.WithStack(err)
 	})
 	if err != nil {
 		h.log.Err(err).Send()

--- a/internal/services/configstore/common/common.go
+++ b/internal/services/configstore/common/common.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"strings"
 
+	"agola.io/agola/internal/errors"
 	"github.com/gofrs/uuid"
 )
 
@@ -38,7 +39,7 @@ const (
 func ParsePathRef(ref string) (RefType, error) {
 	ref, err := url.PathUnescape(ref)
 	if err != nil {
-		return -1, err
+		return -1, errors.WithStack(err)
 	}
 	if strings.Contains(ref, "/") {
 		return RefTypePath, nil

--- a/internal/services/configstore/configstore_test.go
+++ b/internal/services/configstore/configstore_test.go
@@ -28,6 +28,8 @@ import (
 	"time"
 
 	"agola.io/agola/internal/db"
+	"agola.io/agola/internal/errors"
+
 	"agola.io/agola/internal/services/config"
 	"agola.io/agola/internal/services/configstore/action"
 	"agola.io/agola/internal/testutil"
@@ -106,9 +108,9 @@ func getProjects(ctx context.Context, cs *Configstore) ([]*types.Project, error)
 	err := cs.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		projects, err = cs.readDB.GetAllProjects(tx)
-		return err
+		return errors.WithStack(err)
 	})
-	return projects, err
+	return projects, errors.WithStack(err)
 }
 
 func getUsers(ctx context.Context, cs *Configstore) ([]*types.User, error) {
@@ -116,9 +118,9 @@ func getUsers(ctx context.Context, cs *Configstore) ([]*types.User, error) {
 	err := cs.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 		users, err = cs.readDB.GetUsers(tx, "", 0, true)
-		return err
+		return errors.WithStack(err)
 	})
-	return users, err
+	return users, errors.WithStack(err)
 }
 
 func TestResync(t *testing.T) {
@@ -1320,7 +1322,7 @@ func TestRemoteSource(t *testing.T) {
 					t.Fatalf("unexpected err: %v", err)
 				}
 
-				expectedError := util.NewAPIError(util.ErrBadRequest, fmt.Errorf(`remotesource "rs01" already exists`))
+				expectedError := util.NewAPIError(util.ErrBadRequest, errors.Errorf(`remotesource "rs01" already exists`))
 				_, err = cs.ah.CreateRemoteSource(ctx, rs)
 				if err.Error() != expectedError.Error() {
 					t.Fatalf("expected err: %v, got err: %v", expectedError.Error(), err.Error())
@@ -1409,7 +1411,7 @@ func TestRemoteSource(t *testing.T) {
 					t.Fatalf("unexpected err: %v", err)
 				}
 
-				expectedError := util.NewAPIError(util.ErrBadRequest, fmt.Errorf(`remotesource "rs02" already exists`))
+				expectedError := util.NewAPIError(util.ErrBadRequest, errors.Errorf(`remotesource "rs02" already exists`))
 				rs01.Name = "rs02"
 				req := &action.UpdateRemoteSourceRequest{
 					RemoteSourceRef: "rs01",

--- a/internal/services/executor/driver/docker.go
+++ b/internal/services/executor/driver/docker.go
@@ -28,9 +28,9 @@ import (
 	"strings"
 	"time"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/executor/registry"
 	"agola.io/agola/services/types"
-	errors "golang.org/x/xerrors"
 
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -56,7 +56,7 @@ type DockerDriver struct {
 func NewDockerDriver(log zerolog.Logger, executorID, toolboxPath, initImage string, initDockerConfig *registry.DockerConfig) (*DockerDriver, error) {
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.26"))
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	return &DockerDriver{
@@ -76,7 +76,7 @@ func (d *DockerDriver) Setup(ctx context.Context) error {
 
 func (d *DockerDriver) createToolboxVolume(ctx context.Context, podID string, out io.Writer) (*dockertypes.Volume, error) {
 	if err := d.fetchImage(ctx, d.initImage, false, d.initDockerConfig, out); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	labels := map[string]string{}
@@ -85,7 +85,7 @@ func (d *DockerDriver) createToolboxVolume(ctx context.Context, podID string, ou
 	labels[podIDKey] = podID
 	toolboxVol, err := d.client.VolumeCreate(ctx, volume.VolumeCreateBody{Driver: "local", Labels: labels})
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	resp, err := d.client.ContainerCreate(ctx, &container.Config{
@@ -96,28 +96,28 @@ func (d *DockerDriver) createToolboxVolume(ctx context.Context, podID string, ou
 		Binds: []string{fmt.Sprintf("%s:%s", toolboxVol.Name, "/tmp/agola")},
 	}, nil, "")
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	containerID := resp.ID
 
 	if err := d.client.ContainerStart(ctx, containerID, dockertypes.ContainerStartOptions{}); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	toolboxExecPath, err := toolboxExecPath(d.toolboxPath, d.arch)
 	if err != nil {
-		return nil, errors.Errorf("failed to get toolbox path for arch %q: %w", d.arch, err)
+		return nil, errors.Wrapf(err, "failed to get toolbox path for arch %q", d.arch)
 	}
 	srcInfo, err := archive.CopyInfoSourcePath(toolboxExecPath, false)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	srcInfo.RebaseName = "agola-toolbox"
 
 	srcArchive, err := archive.TarResource(srcInfo)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	defer srcArchive.Close()
 
@@ -127,7 +127,7 @@ func (d *DockerDriver) createToolboxVolume(ctx context.Context, podID string, ou
 	}
 
 	if err := d.client.CopyToContainer(ctx, containerID, "/tmp/agola", srcArchive, options); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	// ignore remove error
@@ -148,14 +148,14 @@ func (d *DockerDriver) NewPod(ctx context.Context, podConfig *PodConfig, out io.
 
 	toolboxVol, err := d.createToolboxVolume(ctx, podConfig.ID, out)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	var mainContainerID string
 	for cindex := range podConfig.Containers {
 		resp, err := d.createContainer(ctx, cindex, podConfig, mainContainerID, toolboxVol, out)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 
 		containerID := resp.ID
@@ -165,7 +165,7 @@ func (d *DockerDriver) NewPod(ctx context.Context, podConfig *PodConfig, out io.
 		}
 
 		if err := d.client.ContainerStart(ctx, containerID, dockertypes.ContainerStartOptions{}); err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 	}
 
@@ -184,7 +184,7 @@ func (d *DockerDriver) NewPod(ctx context.Context, podConfig *PodConfig, out io.
 			Filters: args,
 		})
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	if len(containers) == 0 {
 		return nil, errors.Errorf("no container with labels %s", searchLabels)
@@ -236,7 +236,7 @@ func (d *DockerDriver) NewPod(ctx context.Context, podConfig *PodConfig, out io.
 func (d *DockerDriver) fetchImage(ctx context.Context, image string, alwaysFetch bool, registryConfig *registry.DockerConfig, out io.Writer) error {
 	regName, err := registry.GetRegistry(image)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	var registryAuth registry.DockerConfigAuth
 	if registryConfig != nil {
@@ -246,20 +246,20 @@ func (d *DockerDriver) fetchImage(ctx context.Context, image string, alwaysFetch
 	}
 	buf, err := json.Marshal(registryAuth)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	registryAuthEnc := base64.URLEncoding.EncodeToString(buf)
 
 	tag, err := registry.GetImageTagOrDigest(image)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	args := filters.NewArgs()
 	args.Add("reference", image)
 	img, err := d.client.ImageList(ctx, dockertypes.ImageListOptions{Filters: args})
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	exists := len(img) > 0
 
@@ -267,11 +267,11 @@ func (d *DockerDriver) fetchImage(ctx context.Context, image string, alwaysFetch
 	if alwaysFetch || tag == "latest" || !exists {
 		reader, err := d.client.ImagePull(ctx, image, dockertypes.ImagePullOptions{RegistryAuth: registryAuthEnc})
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 
 		_, err = io.Copy(out, reader)
-		return err
+		return errors.WithStack(err)
 	}
 
 	return nil
@@ -283,7 +283,7 @@ func (d *DockerDriver) createContainer(ctx context.Context, index int, podConfig
 	// by default always try to pull the image so we are sure only authorized users can fetch them
 	// see https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#alwayspullimages
 	if err := d.fetchImage(ctx, containerConfig.Image, true, podConfig.DockerConfig, out); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	labels := map[string]string{}
@@ -340,7 +340,7 @@ func (d *DockerDriver) createContainer(ctx context.Context, index int, podConfig
 	}
 
 	resp, err := d.client.ContainerCreate(ctx, cliContainerConfig, cliHostConfig, nil, "")
-	return &resp, err
+	return &resp, errors.WithStack(err)
 }
 
 func (d *DockerDriver) ExecutorGroup(ctx context.Context) (string, error) {
@@ -361,12 +361,12 @@ func (d *DockerDriver) GetPods(ctx context.Context, all bool) ([]Pod, error) {
 			All:     all,
 		})
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	volumes, err := d.client.VolumeList(ctx, args)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	podsMap := map[string]*DockerPod{}
@@ -549,11 +549,12 @@ type Stdin struct {
 }
 
 func (s *Stdin) Write(p []byte) (int, error) {
-	return s.hresp.Conn.Write(p)
+	n, err := s.hresp.Conn.Write(p)
+	return n, errors.WithStack(err)
 }
 
 func (s *Stdin) Close() error {
-	return s.hresp.CloseWrite()
+	return errors.WithStack(s.hresp.CloseWrite())
 }
 
 func (dp *DockerPod) Exec(ctx context.Context, execConfig *ExecConfig) (ContainerExec, error) {
@@ -564,7 +565,7 @@ func (dp *DockerPod) Exec(ctx context.Context, execConfig *ExecConfig) (Containe
 	// Use a toolbox command that will set them up and then exec the real command.
 	envj, err := json.Marshal(execConfig.Env)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	cmd := []string{filepath.Join(dp.initVolumeDir, "agola-toolbox"), "exec", "-e", string(envj), "-w", execConfig.WorkingDir, "--"}
@@ -581,7 +582,7 @@ func (dp *DockerPod) Exec(ctx context.Context, execConfig *ExecConfig) (Containe
 
 	response, err := dp.client.ContainerExecCreate(ctx, dp.containers[0].ID, dockerExecConfig)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	execStartCheck := dockertypes.ExecStartCheck{
 		Detach: dockerExecConfig.Detach,
@@ -589,7 +590,7 @@ func (dp *DockerPod) Exec(ctx context.Context, execConfig *ExecConfig) (Containe
 	}
 	hresp, err := dp.client.ContainerExecAttach(ctx, response.ID, execStartCheck)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	stdout := execConfig.Stdout
@@ -629,7 +630,7 @@ func (e *DockerContainerExec) Wait(ctx context.Context) (int, error) {
 	// ignore error, we'll use the exit code of the exec
 	select {
 	case <-ctx.Done():
-		return 0, ctx.Err()
+		return 0, errors.WithStack(ctx.Err())
 	case <-e.endCh:
 	}
 
@@ -637,7 +638,7 @@ func (e *DockerContainerExec) Wait(ctx context.Context) (int, error) {
 	for {
 		resp, err := e.client.ContainerExecInspect(ctx, e.execID)
 		if err != nil {
-			return -1, err
+			return -1, errors.WithStack(err)
 		}
 		if !resp.Running {
 			exitCode = resp.ExitCode

--- a/internal/services/executor/driver/driver.go
+++ b/internal/services/executor/driver/driver.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/executor/registry"
 	"agola.io/agola/services/types"
 )
@@ -121,7 +122,7 @@ func toolboxExecPath(toolboxDir string, arch types.Arch) (string, error) {
 	toolboxPath := filepath.Join(toolboxDir, fmt.Sprintf("%s-linux-%s", toolboxPrefix, arch))
 	_, err := os.Stat(toolboxPath)
 	if err != nil {
-		return "", err
+		return "", errors.WithStack(err)
 	}
 	return toolboxPath, nil
 }

--- a/internal/services/gateway/action/org.go
+++ b/internal/services/gateway/action/org.go
@@ -17,11 +17,10 @@ package action
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
 	cstypes "agola.io/agola/services/configstore/types"
-
-	errors "golang.org/x/xerrors"
 )
 
 func (h *ActionHandler) GetOrg(ctx context.Context, orgRef string) (*cstypes.Organization, error) {
@@ -110,7 +109,7 @@ func (h *ActionHandler) CreateOrg(ctx context.Context, req *CreateOrgRequest) (*
 	h.log.Info().Msgf("creating organization")
 	org, _, err := h.configstoreClient.CreateOrg(ctx, org)
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to create organization: %w", err))
+		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create organization"))
 	}
 	h.log.Info().Msgf("organization %s created, ID: %s", org.Name, org.ID)
 
@@ -125,14 +124,14 @@ func (h *ActionHandler) DeleteOrg(ctx context.Context, orgRef string) error {
 
 	isOrgOwner, err := h.IsOrgOwner(ctx, org.ID)
 	if err != nil {
-		return errors.Errorf("failed to determine ownership: %w", err)
+		return errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isOrgOwner {
 		return util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
 	}
 
 	if _, err := h.configstoreClient.DeleteOrg(ctx, orgRef); err != nil {
-		return util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to delete org: %w", err))
+		return util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to delete org"))
 	}
 	return nil
 }
@@ -155,7 +154,7 @@ func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string
 
 	isOrgOwner, err := h.IsOrgOwner(ctx, org.ID)
 	if err != nil {
-		return nil, errors.Errorf("failed to determine ownership: %w", err)
+		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isOrgOwner {
 		return nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
@@ -163,7 +162,7 @@ func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string
 
 	orgmember, _, err := h.configstoreClient.AddOrgMember(ctx, orgRef, userRef, role)
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to add/update organization member: %w", err))
+		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to add/update organization member"))
 	}
 
 	return &AddOrgMemberResponse{
@@ -181,14 +180,14 @@ func (h *ActionHandler) RemoveOrgMember(ctx context.Context, orgRef, userRef str
 
 	isOrgOwner, err := h.IsOrgOwner(ctx, org.ID)
 	if err != nil {
-		return errors.Errorf("failed to determine ownership: %w", err)
+		return errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isOrgOwner {
 		return util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
 	}
 
 	if _, err = h.configstoreClient.RemoveOrgMember(ctx, orgRef, userRef); err != nil {
-		return util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to remove organization member: %w", err))
+		return util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to remove organization member"))
 	}
 
 	return nil

--- a/internal/services/gateway/action/projectgroup.go
+++ b/internal/services/gateway/action/projectgroup.go
@@ -18,11 +18,10 @@ import (
 	"context"
 	"path"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/util"
 	csapitypes "agola.io/agola/services/configstore/api/types"
 	cstypes "agola.io/agola/services/configstore/types"
-
-	errors "golang.org/x/xerrors"
 )
 
 func (h *ActionHandler) GetProjectGroup(ctx context.Context, projectGroupRef string) (*csapitypes.ProjectGroup, error) {
@@ -63,12 +62,12 @@ func (h *ActionHandler) CreateProjectGroup(ctx context.Context, req *CreateProje
 
 	pg, _, err := h.configstoreClient.GetProjectGroup(ctx, req.ParentRef)
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to get project group %q: %w", req.ParentRef, err))
+		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project group %q", req.ParentRef))
 	}
 
 	isProjectOwner, err := h.IsProjectOwner(ctx, pg.OwnerType, pg.OwnerID)
 	if err != nil {
-		return nil, errors.Errorf("failed to determine ownership: %w", err)
+		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isProjectOwner {
 		return nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
@@ -76,7 +75,7 @@ func (h *ActionHandler) CreateProjectGroup(ctx context.Context, req *CreateProje
 
 	user, _, err := h.configstoreClient.GetUser(ctx, req.CurrentUserID)
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to get user %q: %w", req.CurrentUserID, err))
+		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get user %q", req.CurrentUserID))
 	}
 
 	parentRef := req.ParentRef
@@ -97,7 +96,7 @@ func (h *ActionHandler) CreateProjectGroup(ctx context.Context, req *CreateProje
 	h.log.Info().Msgf("creating projectGroup")
 	rp, _, err := h.configstoreClient.CreateProjectGroup(ctx, p)
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to create projectGroup: %w", err))
+		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create projectGroup"))
 	}
 	h.log.Info().Msgf("projectGroup %s created, ID: %s", rp.Name, rp.ID)
 
@@ -114,12 +113,12 @@ type UpdateProjectGroupRequest struct {
 func (h *ActionHandler) UpdateProjectGroup(ctx context.Context, projectGroupRef string, req *UpdateProjectGroupRequest) (*csapitypes.ProjectGroup, error) {
 	pg, _, err := h.configstoreClient.GetProjectGroup(ctx, projectGroupRef)
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to get project group %q: %w", projectGroupRef, err))
+		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project group %q", projectGroupRef))
 	}
 
 	isProjectOwner, err := h.IsProjectOwner(ctx, pg.OwnerType, pg.OwnerID)
 	if err != nil {
-		return nil, errors.Errorf("failed to determine ownership: %w", err)
+		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isProjectOwner {
 		return nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
@@ -138,7 +137,7 @@ func (h *ActionHandler) UpdateProjectGroup(ctx context.Context, projectGroupRef 
 	h.log.Info().Msgf("updating project group")
 	rp, _, err := h.configstoreClient.UpdateProjectGroup(ctx, pg.ID, pg.ProjectGroup)
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to update project group: %w", err))
+		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to update project group"))
 	}
 	h.log.Info().Msgf("project group %q updated, ID: %s", pg.Name, pg.ID)
 
@@ -148,12 +147,12 @@ func (h *ActionHandler) UpdateProjectGroup(ctx context.Context, projectGroupRef 
 func (h *ActionHandler) DeleteProjectGroup(ctx context.Context, projectRef string) error {
 	p, _, err := h.configstoreClient.GetProjectGroup(ctx, projectRef)
 	if err != nil {
-		return util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to get project %q: %w", projectRef, err))
+		return util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project %q", projectRef))
 	}
 
 	isProjectOwner, err := h.IsProjectOwner(ctx, p.OwnerType, p.OwnerID)
 	if err != nil {
-		return errors.Errorf("failed to determine ownership: %w", err)
+		return errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isProjectOwner {
 		return util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))

--- a/internal/services/gateway/action/remotesource.go
+++ b/internal/services/gateway/action/remotesource.go
@@ -17,17 +17,16 @@ package action
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
 	cstypes "agola.io/agola/services/configstore/types"
-
-	errors "golang.org/x/xerrors"
 )
 
 func (h *ActionHandler) GetRemoteSource(ctx context.Context, rsRef string) (*cstypes.RemoteSource, error) {
 	rs, _, err := h.configstoreClient.GetRemoteSource(ctx, rsRef)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return rs, nil
 }
@@ -41,7 +40,7 @@ type GetRemoteSourcesRequest struct {
 func (h *ActionHandler) GetRemoteSources(ctx context.Context, req *GetRemoteSourcesRequest) ([]*cstypes.RemoteSource, error) {
 	remoteSources, _, err := h.configstoreClient.GetRemoteSources(ctx, req.Start, req.Limit, req.Asc)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return remoteSources, nil
 }
@@ -113,7 +112,7 @@ func (h *ActionHandler) CreateRemoteSource(ctx context.Context, req *CreateRemot
 	h.log.Info().Msgf("creating remotesource")
 	rs, _, err := h.configstoreClient.CreateRemoteSource(ctx, rs)
 	if err != nil {
-		return nil, errors.Errorf("failed to create remotesource: %w", err)
+		return nil, errors.Wrapf(err, "failed to create remotesource")
 	}
 	h.log.Info().Msgf("remotesource %s created, ID: %s", rs.Name, rs.ID)
 
@@ -141,7 +140,7 @@ func (h *ActionHandler) UpdateRemoteSource(ctx context.Context, req *UpdateRemot
 
 	rs, _, err := h.configstoreClient.GetRemoteSource(ctx, req.RemoteSourceRef)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	if req.Name != nil {
@@ -175,7 +174,7 @@ func (h *ActionHandler) UpdateRemoteSource(ctx context.Context, req *UpdateRemot
 	h.log.Info().Msgf("updating remotesource")
 	rs, _, err = h.configstoreClient.UpdateRemoteSource(ctx, req.RemoteSourceRef, rs)
 	if err != nil {
-		return nil, errors.Errorf("failed to update remotesource: %w", err)
+		return nil, errors.Wrapf(err, "failed to update remotesource")
 	}
 	h.log.Info().Msgf("remotesource %s updated", rs.Name)
 
@@ -188,7 +187,7 @@ func (h *ActionHandler) DeleteRemoteSource(ctx context.Context, rsRef string) er
 	}
 
 	if _, err := h.configstoreClient.DeleteRemoteSource(ctx, rsRef); err != nil {
-		return errors.Errorf("failed to delete remote source: %w", err)
+		return errors.Wrapf(err, "failed to delete remote source")
 	}
 	return nil
 }

--- a/internal/services/gateway/action/secret.go
+++ b/internal/services/gateway/action/secret.go
@@ -17,12 +17,11 @@ package action
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/common"
 	"agola.io/agola/internal/util"
 	csapitypes "agola.io/agola/services/configstore/api/types"
 	cstypes "agola.io/agola/services/configstore/types"
-
-	errors "golang.org/x/xerrors"
 )
 
 type GetSecretsRequest struct {
@@ -73,7 +72,7 @@ type CreateSecretRequest struct {
 func (h *ActionHandler) CreateSecret(ctx context.Context, req *CreateSecretRequest) (*csapitypes.Secret, error) {
 	isVariableOwner, err := h.IsVariableOwner(ctx, req.ParentType, req.ParentRef)
 	if err != nil {
-		return nil, errors.Errorf("failed to determine ownership: %w", err)
+		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isVariableOwner {
 		return nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
@@ -99,7 +98,7 @@ func (h *ActionHandler) CreateSecret(ctx context.Context, req *CreateSecretReque
 		rs, _, err = h.configstoreClient.CreateProjectSecret(ctx, req.ParentRef, s)
 	}
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to create secret: %w", err))
+		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create secret"))
 	}
 	h.log.Info().Msgf("secret %s created, ID: %s", rs.Name, rs.ID)
 
@@ -127,7 +126,7 @@ type UpdateSecretRequest struct {
 func (h *ActionHandler) UpdateSecret(ctx context.Context, req *UpdateSecretRequest) (*csapitypes.Secret, error) {
 	isVariableOwner, err := h.IsVariableOwner(ctx, req.ParentType, req.ParentRef)
 	if err != nil {
-		return nil, errors.Errorf("failed to determine ownership: %w", err)
+		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isVariableOwner {
 		return nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
@@ -153,7 +152,7 @@ func (h *ActionHandler) UpdateSecret(ctx context.Context, req *UpdateSecretReque
 		rs, _, err = h.configstoreClient.UpdateProjectSecret(ctx, req.ParentRef, req.SecretName, s)
 	}
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to update secret: %w", err))
+		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to update secret"))
 	}
 	h.log.Info().Msgf("secret %s updated, ID: %s", rs.Name, rs.ID)
 
@@ -163,7 +162,7 @@ func (h *ActionHandler) UpdateSecret(ctx context.Context, req *UpdateSecretReque
 func (h *ActionHandler) DeleteSecret(ctx context.Context, parentType cstypes.ConfigType, parentRef, name string) error {
 	isVariableOwner, err := h.IsVariableOwner(ctx, parentType, parentRef)
 	if err != nil {
-		return errors.Errorf("failed to determine ownership: %w", err)
+		return errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isVariableOwner {
 		return util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
@@ -178,7 +177,7 @@ func (h *ActionHandler) DeleteSecret(ctx context.Context, parentType cstypes.Con
 		_, err = h.configstoreClient.DeleteProjectSecret(ctx, parentRef, name)
 	}
 	if err != nil {
-		return util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to delete secret: %w", err))
+		return util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to delete secret"))
 	}
 	return nil
 }

--- a/internal/services/gateway/action/variable.go
+++ b/internal/services/gateway/action/variable.go
@@ -17,11 +17,11 @@ package action
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/common"
 	"agola.io/agola/internal/util"
 	csapitypes "agola.io/agola/services/configstore/api/types"
 	cstypes "agola.io/agola/services/configstore/types"
-	errors "golang.org/x/xerrors"
 )
 
 type GetVariablesRequest struct {
@@ -79,7 +79,7 @@ type CreateVariableRequest struct {
 func (h *ActionHandler) CreateVariable(ctx context.Context, req *CreateVariableRequest) (*csapitypes.Variable, []*csapitypes.Secret, error) {
 	isVariableOwner, err := h.IsVariableOwner(ctx, req.ParentType, req.ParentRef)
 	if err != nil {
-		return nil, nil, errors.Errorf("failed to determine ownership: %w", err)
+		return nil, nil, errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isVariableOwner {
 		return nil, nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
@@ -110,25 +110,25 @@ func (h *ActionHandler) CreateVariable(ctx context.Context, req *CreateVariableR
 		var err error
 		cssecrets, _, err = h.configstoreClient.GetProjectGroupSecrets(ctx, req.ParentRef, true)
 		if err != nil {
-			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to get project group %q secrets: %w", req.ParentRef, err))
+			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project group %q secrets", req.ParentRef))
 		}
 
 		h.log.Info().Msgf("creating project group variable")
 		rv, _, err = h.configstoreClient.CreateProjectGroupVariable(ctx, req.ParentRef, v)
 		if err != nil {
-			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to create variable: %w", err))
+			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create variable"))
 		}
 	case cstypes.ConfigTypeProject:
 		var err error
 		cssecrets, _, err = h.configstoreClient.GetProjectSecrets(ctx, req.ParentRef, true)
 		if err != nil {
-			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to get project %q secrets: %w", req.ParentRef, err))
+			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project %q secrets", req.ParentRef))
 		}
 
 		h.log.Info().Msgf("creating project variable")
 		rv, _, err = h.configstoreClient.CreateProjectVariable(ctx, req.ParentRef, v)
 		if err != nil {
-			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to create variable: %w", err))
+			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create variable"))
 		}
 	}
 	h.log.Info().Msgf("variable %s created, ID: %s", rv.Name, rv.ID)
@@ -150,7 +150,7 @@ type UpdateVariableRequest struct {
 func (h *ActionHandler) UpdateVariable(ctx context.Context, req *UpdateVariableRequest) (*csapitypes.Variable, []*csapitypes.Secret, error) {
 	isVariableOwner, err := h.IsVariableOwner(ctx, req.ParentType, req.ParentRef)
 	if err != nil {
-		return nil, nil, errors.Errorf("failed to determine ownership: %w", err)
+		return nil, nil, errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isVariableOwner {
 		return nil, nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
@@ -181,25 +181,25 @@ func (h *ActionHandler) UpdateVariable(ctx context.Context, req *UpdateVariableR
 		var err error
 		cssecrets, _, err = h.configstoreClient.GetProjectGroupSecrets(ctx, req.ParentRef, true)
 		if err != nil {
-			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to get project group %q secrets: %w", req.ParentRef, err))
+			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project group %q secrets", req.ParentRef))
 		}
 
 		h.log.Info().Msgf("creating project group variable")
 		rv, _, err = h.configstoreClient.UpdateProjectGroupVariable(ctx, req.ParentRef, req.VariableName, v)
 		if err != nil {
-			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to create variable: %w", err))
+			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create variable"))
 		}
 	case cstypes.ConfigTypeProject:
 		var err error
 		cssecrets, _, err = h.configstoreClient.GetProjectSecrets(ctx, req.ParentRef, true)
 		if err != nil {
-			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to get project %q secrets: %w", req.ParentRef, err))
+			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project %q secrets", req.ParentRef))
 		}
 
 		h.log.Info().Msgf("creating project variable")
 		rv, _, err = h.configstoreClient.UpdateProjectVariable(ctx, req.ParentRef, req.VariableName, v)
 		if err != nil {
-			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to create variable: %w", err))
+			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create variable"))
 		}
 	}
 	h.log.Info().Msgf("variable %s created, ID: %s", rv.Name, rv.ID)
@@ -210,7 +210,7 @@ func (h *ActionHandler) UpdateVariable(ctx context.Context, req *UpdateVariableR
 func (h *ActionHandler) DeleteVariable(ctx context.Context, parentType cstypes.ConfigType, parentRef, name string) error {
 	isVariableOwner, err := h.IsVariableOwner(ctx, parentType, parentRef)
 	if err != nil {
-		return errors.Errorf("failed to determine ownership: %w", err)
+		return errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isVariableOwner {
 		return util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
@@ -225,7 +225,7 @@ func (h *ActionHandler) DeleteVariable(ctx context.Context, parentType cstypes.C
 		_, err = h.configstoreClient.DeleteProjectVariable(ctx, parentRef, name)
 	}
 	if err != nil {
-		return util.NewAPIError(util.KindFromRemoteError(err), errors.Errorf("failed to delete variable: %w", err))
+		return util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to delete variable"))
 	}
 	return nil
 }

--- a/internal/services/gateway/api/api.go
+++ b/internal/services/gateway/api/api.go
@@ -18,18 +18,18 @@ import (
 	"net/http"
 	"net/url"
 
+	"agola.io/agola/internal/errors"
 	util "agola.io/agola/internal/util"
 	cstypes "agola.io/agola/services/configstore/types"
 
 	"github.com/gorilla/mux"
-	errors "golang.org/x/xerrors"
 )
 
 func GetConfigTypeRef(r *http.Request) (cstypes.ConfigType, string, error) {
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		return "", "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("wrong projectref %q: %w", vars["projectref"], err))
+		return "", "", util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "wrong projectref %q", vars["projectref"]))
 	}
 	if projectRef != "" {
 		return cstypes.ConfigTypeProject, projectRef, nil
@@ -37,7 +37,7 @@ func GetConfigTypeRef(r *http.Request) (cstypes.ConfigType, string, error) {
 
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		return "", "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("wrong projectgroupref %q: %w", vars["projectgroupref"], err))
+		return "", "", util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "wrong projectgroupref %q", vars["projectgroupref"]))
 	}
 	if projectGroupRef != "" {
 		return cstypes.ConfigTypeProjectGroup, projectGroupRef, nil

--- a/internal/services/gateway/api/org.go
+++ b/internal/services/gateway/api/org.go
@@ -19,12 +19,12 @@ import (
 	"net/http"
 	"strconv"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
 	cstypes "agola.io/agola/services/configstore/types"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
-	errors "golang.org/x/xerrors"
 
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
@@ -148,7 +148,7 @@ func (h *OrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot parse limit: %w", err)))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse limit")))
 			return
 		}
 	}

--- a/internal/services/gateway/api/projectgroup.go
+++ b/internal/services/gateway/api/projectgroup.go
@@ -19,13 +19,13 @@ import (
 	"net/http"
 	"net/url"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
 	csapitypes "agola.io/agola/services/configstore/api/types"
 	cstypes "agola.io/agola/services/configstore/types"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
-	errors "golang.org/x/xerrors"
 
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"

--- a/internal/services/gateway/api/remoterepo.go
+++ b/internal/services/gateway/api/remoterepo.go
@@ -17,6 +17,7 @@ package api
 import (
 	"net/http"
 
+	"agola.io/agola/internal/errors"
 	gitsource "agola.io/agola/internal/gitsources"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/services/gateway/common"
@@ -27,7 +28,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
-	errors "golang.org/x/xerrors"
 )
 
 func createRemoteRepoResponse(r *gitsource.RepoInfo) *gwapitypes.RemoteRepoResponse {
@@ -95,7 +95,7 @@ func (h *UserRemoteReposHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	remoteRepos, err := gitsource.ListUserRepos()
 	if err != nil {
-		err := util.NewAPIError(util.ErrBadRequest, errors.Errorf("failed to get user repositories from git source: %w", err))
+		err := util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "failed to get user repositories from git source"))
 		util.HTTPError(w, err)
 		h.log.Err(err).Send()
 		return

--- a/internal/services/gateway/api/remotesource.go
+++ b/internal/services/gateway/api/remotesource.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/util"
 	cstypes "agola.io/agola/services/configstore/types"
@@ -26,7 +27,6 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/gorilla/mux"
-	errors "golang.org/x/xerrors"
 )
 
 type CreateRemoteSourceHandler struct {
@@ -175,7 +175,7 @@ func (h *RemoteSourcesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot parse limit: %w", err)))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse limit")))
 			return
 		}
 	}

--- a/internal/services/gateway/api/run.go
+++ b/internal/services/gateway/api/run.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/util"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
@@ -27,7 +28,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
-	errors "golang.org/x/xerrors"
 )
 
 func createRunResponse(r *rstypes.Run, rc *rstypes.RunConfig) *gwapitypes.RunResponse {
@@ -269,7 +269,7 @@ func (h *RunsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot parse limit: %w", err)))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse limit")))
 			return
 		}
 	}
@@ -427,7 +427,7 @@ func (h *LogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		step, err = strconv.Atoi(stepStr)
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot parse step number: %w", err)))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse step number")))
 			return
 		}
 	}
@@ -487,7 +487,7 @@ func sendLogs(w io.Writer, r io.Reader) error {
 		n, err := r.Read(buf)
 		if err != nil {
 			if err != io.EOF {
-				return err
+				return errors.WithStack(err)
 			}
 			if n == 0 {
 				return nil
@@ -495,7 +495,7 @@ func sendLogs(w io.Writer, r io.Reader) error {
 			stop = true
 		}
 		if _, err := w.Write(buf[:n]); err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 		if flusher != nil {
 			flusher.Flush()
@@ -544,7 +544,7 @@ func (h *LogsDeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		step, err = strconv.Atoi(stepStr)
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot parse step number: %w", err)))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse step number")))
 			return
 		}
 	}

--- a/internal/services/gateway/api/user.go
+++ b/internal/services/gateway/api/user.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strconv"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
@@ -30,7 +31,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
-	errors "golang.org/x/xerrors"
 )
 
 type CreateUserHandler struct {
@@ -193,7 +193,7 @@ func (h *UsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot parse limit: %w", err)))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse limit")))
 			return
 		}
 	}
@@ -273,7 +273,7 @@ func (h *CreateUserLAHandler) createUserLA(ctx context.Context, userRef string, 
 	h.log.Info().Msgf("creating linked account")
 	cresp, err := h.ah.HandleRemoteSourceAuth(ctx, req.RemoteSourceName, req.RemoteSourceLoginName, req.RemoteSourceLoginPassword, action.RemoteSourceRequestTypeCreateUserLA, creq)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	if cresp.Oauth2Redirect != "" {
 		return &gwapitypes.CreateUserLAResponse{
@@ -427,7 +427,7 @@ func (h *RegisterUserHandler) registerUser(ctx context.Context, req *gwapitypes.
 
 	cresp, err := h.ah.HandleRemoteSourceAuth(ctx, req.CreateUserLARequest.RemoteSourceName, req.CreateUserLARequest.RemoteSourceLoginName, req.CreateUserLARequest.RemoteSourceLoginPassword, action.RemoteSourceRequestTypeRegisterUser, creq)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	if cresp.Oauth2Redirect != "" {
 		return &gwapitypes.RegisterUserResponse{
@@ -477,7 +477,7 @@ func (h *AuthorizeHandler) authorize(ctx context.Context, req *gwapitypes.LoginU
 
 	cresp, err := h.ah.HandleRemoteSourceAuth(ctx, req.RemoteSourceName, req.LoginName, req.LoginPassword, action.RemoteSourceRequestTypeAuthorize, creq)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	if cresp.Oauth2Redirect != "" {
 		return &gwapitypes.AuthorizeResponse{
@@ -535,7 +535,7 @@ func (h *LoginUserHandler) loginUser(ctx context.Context, req *gwapitypes.LoginU
 	h.log.Info().Msgf("logging in user")
 	cresp, err := h.ah.HandleRemoteSourceAuth(ctx, req.RemoteSourceName, req.LoginName, req.LoginPassword, action.RemoteSourceRequestTypeLoginUser, creq)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	if cresp.Oauth2Redirect != "" {
 		return &gwapitypes.LoginUserResponse{

--- a/internal/services/gateway/handlers/auth.go
+++ b/internal/services/gateway/handlers/auth.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"strings"
 
+	"agola.io/agola/internal/errors"
 	scommon "agola.io/agola/internal/services/common"
 	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
@@ -27,7 +28,6 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 	jwtrequest "github.com/golang-jwt/jwt/v4/request"
 	"github.com/rs/zerolog"
-	errors "golang.org/x/xerrors"
 )
 
 type AuthHandler struct {

--- a/internal/services/gitserver/gitserver_test.go
+++ b/internal/services/gitserver/gitserver_test.go
@@ -16,13 +16,13 @@ package gitserver
 
 import (
 	"context"
-	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/config"
 	"agola.io/agola/internal/testutil"
 	"agola.io/agola/internal/util"

--- a/internal/services/notification/commitstatus.go
+++ b/internal/services/notification/commitstatus.go
@@ -19,12 +19,11 @@ import (
 	"fmt"
 	"net/url"
 
+	"agola.io/agola/internal/errors"
 	gitsource "agola.io/agola/internal/gitsources"
 	"agola.io/agola/internal/services/common"
 	"agola.io/agola/internal/services/gateway/action"
 	rstypes "agola.io/agola/services/runservice/types"
-
-	errors "golang.org/x/xerrors"
 )
 
 func (n *NotificationService) updateCommitStatus(ctx context.Context, ev *rstypes.RunEvent) error {
@@ -55,11 +54,11 @@ func (n *NotificationService) updateCommitStatus(ctx context.Context, ev *rstype
 
 	run, _, err := n.runserviceClient.GetRun(ctx, ev.RunID, nil)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	groupType, groupID, err := common.GroupTypeIDFromRunGroup(run.RunConfig.Group)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	// ignore user direct runs
@@ -69,12 +68,12 @@ func (n *NotificationService) updateCommitStatus(ctx context.Context, ev *rstype
 
 	project, _, err := n.configstoreClient.GetProject(ctx, groupID)
 	if err != nil {
-		return errors.Errorf("failed to get project %s: %w", groupID, err)
+		return errors.Wrapf(err, "failed to get project %s", groupID)
 	}
 
 	user, _, err := n.configstoreClient.GetUserByLinkedAccount(ctx, project.LinkedAccountID)
 	if err != nil {
-		return errors.Errorf("failed to get user by linked account %q: %w", project.LinkedAccountID, err)
+		return errors.Wrapf(err, "failed to get user by linked account %q", project.LinkedAccountID)
 	}
 	la := user.LinkedAccounts[project.LinkedAccountID]
 	if la == nil {
@@ -82,24 +81,24 @@ func (n *NotificationService) updateCommitStatus(ctx context.Context, ev *rstype
 	}
 	rs, _, err := n.configstoreClient.GetRemoteSource(ctx, la.RemoteSourceID)
 	if err != nil {
-		return errors.Errorf("failed to get remote source %q: %w", la.RemoteSourceID, err)
+		return errors.Wrapf(err, "failed to get remote source %q", la.RemoteSourceID)
 	}
 
 	// TODO(sgotti) handle refreshing oauth2 tokens
 	gitSource, err := common.GetGitSource(rs, la)
 	if err != nil {
-		return errors.Errorf("failed to create gitea client: %w", err)
+		return errors.Wrapf(err, "failed to create gitea client")
 	}
 
 	targetURL, err := webRunURL(n.c.WebExposedURL, project.ID, run.Run.ID)
 	if err != nil {
-		return errors.Errorf("failed to generate commit status target url: %w", err)
+		return errors.Wrapf(err, "failed to generate commit status target url")
 	}
 	description := statusDescription(commitStatus)
 	context := fmt.Sprintf("%s/%s/%s", n.gc.ID, project.Name, run.RunConfig.Name)
 
 	if err := gitSource.CreateCommitStatus(project.RepositoryPath, run.Run.Annotations[action.AnnotationCommitSHA], commitStatus, targetURL, description, context); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	return nil
@@ -108,7 +107,7 @@ func (n *NotificationService) updateCommitStatus(ctx context.Context, ev *rstype
 func webRunURL(webExposedURL, projectID, runID string) (string, error) {
 	u, err := url.Parse(webExposedURL + "/run")
 	if err != nil {
-		return "", err
+		return "", errors.WithStack(err)
 	}
 	q := url.Values{}
 	q.Set("projectref", projectID)

--- a/internal/services/notification/notification.go
+++ b/internal/services/notification/notification.go
@@ -18,6 +18,8 @@ import (
 	"context"
 
 	"agola.io/agola/internal/common"
+	"agola.io/agola/internal/errors"
+
 	"agola.io/agola/internal/etcd"
 	"agola.io/agola/internal/services/config"
 	csclient "agola.io/agola/services/configstore/client"
@@ -46,7 +48,7 @@ func NewNotificationService(ctx context.Context, log zerolog.Logger, gc *config.
 
 	e, err := common.NewEtcd(&c.Etcd, log, "notification")
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	configstoreClient := csclient.NewClient(c.ConfigstoreURL)

--- a/internal/services/runservice/action/maintenance.go
+++ b/internal/services/runservice/action/maintenance.go
@@ -18,17 +18,16 @@ import (
 	"context"
 	"io"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/etcd"
 	"agola.io/agola/internal/services/runservice/common"
 	"agola.io/agola/internal/util"
-
-	errors "golang.org/x/xerrors"
 )
 
 func (h *ActionHandler) MaintenanceMode(ctx context.Context, enable bool) error {
 	resp, err := h.e.Get(ctx, common.EtcdMaintenanceKey, 0)
 	if err != nil && !errors.Is(err, etcd.ErrKeyNotFound) {
-		return err
+		return errors.WithStack(err)
 	}
 
 	if enable && len(resp.Kvs) > 0 {
@@ -41,7 +40,7 @@ func (h *ActionHandler) MaintenanceMode(ctx context.Context, enable bool) error 
 	if enable {
 		txResp, err := h.e.AtomicPut(ctx, common.EtcdMaintenanceKey, []byte{}, 0, nil)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 		if !txResp.Succeeded {
 			return errors.Errorf("failed to create maintenance mode key due to concurrent update")
@@ -51,7 +50,7 @@ func (h *ActionHandler) MaintenanceMode(ctx context.Context, enable bool) error 
 	if !enable {
 		txResp, err := h.e.AtomicDelete(ctx, common.EtcdMaintenanceKey, resp.Kvs[0].ModRevision)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 		if !txResp.Succeeded {
 			return errors.Errorf("failed to delete maintenance mode key due to concurrent update")
@@ -62,12 +61,12 @@ func (h *ActionHandler) MaintenanceMode(ctx context.Context, enable bool) error 
 }
 
 func (h *ActionHandler) Export(ctx context.Context, w io.Writer) error {
-	return h.dm.Export(ctx, w)
+	return errors.WithStack(h.dm.Export(ctx, w))
 }
 
 func (h *ActionHandler) Import(ctx context.Context, r io.Reader) error {
 	if !h.maintenanceMode {
 		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("not in maintenance mode"))
 	}
-	return h.dm.Import(ctx, r)
+	return errors.WithStack(h.dm.Import(ctx, r))
 }

--- a/internal/services/runservice/common/common.go
+++ b/internal/services/runservice/common/common.go
@@ -15,10 +15,10 @@
 package common
 
 import (
-	"fmt"
 	"path"
 	"sort"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/runconfig"
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/runservice/types"
@@ -84,7 +84,7 @@ const (
 func OSTSubGroupsAndGroupTypes(group string) []string {
 	h := util.PathHierarchy(group)
 	if len(h)%2 != 1 {
-		panic(fmt.Errorf("wrong group path %q", group))
+		panic(errors.Errorf("wrong group path %q", group))
 	}
 
 	return h
@@ -93,7 +93,7 @@ func OSTSubGroupsAndGroupTypes(group string) []string {
 func OSTRootGroup(group string) string {
 	pl := util.PathList(group)
 	if len(pl) < 2 {
-		panic(fmt.Errorf("cannot determine root group name, wrong group path %q", group))
+		panic(errors.Errorf("cannot determine root group name, wrong group path %q", group))
 	}
 
 	return pl[1]
@@ -102,7 +102,7 @@ func OSTRootGroup(group string) string {
 func OSTSubGroups(group string) []string {
 	h := util.PathHierarchy(group)
 	if len(h)%2 != 1 {
-		panic(fmt.Errorf("wrong group path %q", group))
+		panic(errors.Errorf("wrong group path %q", group))
 	}
 
 	// remove group types
@@ -119,7 +119,7 @@ func OSTSubGroups(group string) []string {
 func OSTSubGroupTypes(group string) []string {
 	h := util.PathHierarchy(group)
 	if len(h)%2 != 1 {
-		panic(fmt.Errorf("wrong group path %q", group))
+		panic(errors.Errorf("wrong group path %q", group))
 	}
 
 	// remove group names

--- a/internal/services/runservice/common/events.go
+++ b/internal/services/runservice/common/events.go
@@ -17,6 +17,7 @@ package common
 import (
 	"context"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/etcd"
 	"agola.io/agola/internal/sequence"
 	"agola.io/agola/services/runservice/types"
@@ -25,7 +26,7 @@ import (
 func NewRunEvent(ctx context.Context, e *etcd.Store, runID string, phase types.RunPhase, result types.RunResult) (*types.RunEvent, error) {
 	seq, err := sequence.IncSequence(ctx, e, EtcdRunEventSequenceKey)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return &types.RunEvent{Sequence: seq.String(), RunID: runID, Phase: phase, Result: result}, nil
 }

--- a/internal/services/runservice/store/store_test.go
+++ b/internal/services/runservice/store/store_test.go
@@ -15,8 +15,9 @@
 package store
 
 import (
-	"fmt"
 	"testing"
+
+	"agola.io/agola/internal/errors"
 )
 
 func TestOSTRunTaskIDFromArchivePath(t *testing.T) {
@@ -29,17 +30,17 @@ func TestOSTRunTaskIDFromArchivePath(t *testing.T) {
 		{
 			name:        "test no runs 1",
 			archivePath: "aaaa",
-			err:         fmt.Errorf("wrong archive path %q", "aaaa"),
+			err:         errors.Errorf("wrong archive path %q", "aaaa"),
 		},
 		{
 			name:        "test no runs 1",
 			archivePath: "workspacearchives",
-			err:         fmt.Errorf("wrong archive path %q", "workspacearchives"),
+			err:         errors.Errorf("wrong archive path %q", "workspacearchives"),
 		},
 		{
 			name:        "test no runs 1",
 			archivePath: "/workspacearchives/",
-			err:         fmt.Errorf("wrong archive path %q", "/workspacearchives/"),
+			err:         errors.Errorf("wrong archive path %q", "/workspacearchives/"),
 		},
 		{
 			name:        "test no runs 1",

--- a/internal/testutil/env.go
+++ b/internal/testutil/env.go
@@ -16,10 +16,11 @@ package testutil
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"strings"
 	"unicode"
+
+	"agola.io/agola/internal/errors"
 )
 
 func ParseEnv(envvar string) (string, string, error) {
@@ -27,11 +28,11 @@ func ParseEnv(envvar string) (string, string, error) {
 	envvar = strings.TrimLeftFunc(envvar, unicode.IsSpace)
 	arr := strings.SplitN(envvar, "=", 2)
 	if len(arr) == 0 {
-		return "", "", fmt.Errorf("invalid environment variable definition: %s", envvar)
+		return "", "", errors.Errorf("invalid environment variable definition: %s", envvar)
 	}
 	varname := arr[0]
 	if varname == "" {
-		return "", "", fmt.Errorf("invalid environment variable definition: %s", envvar)
+		return "", "", errors.Errorf("invalid environment variable definition: %s", envvar)
 	}
 	if len(arr) == 1 {
 		return varname, "", nil
@@ -46,12 +47,12 @@ func ParseEnvs(r io.Reader) (map[string]string, error) {
 	for scanner.Scan() {
 		envname, envvalue, err := ParseEnv(scanner.Text())
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		envs[envname] = envvalue
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	return envs, nil

--- a/internal/toolbox/unarchive/unarchive.go
+++ b/internal/toolbox/unarchive/unarchive.go
@@ -16,13 +16,13 @@ package unarchive
 
 import (
 	"archive/tar"
-	"errors"
-	"fmt"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"runtime"
+
+	"agola.io/agola/internal/errors"
 )
 
 const (
@@ -33,19 +33,27 @@ func Unarchive(source io.Reader, destDir string, overwrite, removeDestDir bool) 
 	var err error
 	destDir, err = filepath.Abs(destDir)
 	if err != nil {
-		return fmt.Errorf("failed to calculate destination dir absolute path: %w", err)
+		return errors.Wrapf(err, "failed to calculate destination dir absolute path")
 	}
 	// don't follow destdir if it's a symlink
 	fi, err := os.Lstat(destDir)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to lstat destination dir: %w", err)
+		return errors.Wrapf(err, "failed to lstat destination dir")
 	}
 	if fi != nil && !fi.IsDir() {
-		return fmt.Errorf("destination path %q already exists and it's not a directory (mode: %q)", destDir, fi.Mode().String())
+		return errors.Errorf(
+			"destination path %q already exists and it's not a directory (mode: %q)",
+			destDir,
+			fi.Mode().String(),
+		)
 	}
 	if fi != nil && fi.IsDir() && removeDestDir {
 		if err := os.RemoveAll(destDir); err != nil {
-			return fmt.Errorf("destination path %q already exists and it's not a directory (mode: %q)", destDir, fi.Mode().String())
+			return errors.Errorf(
+				"destination path %q already exists and it's not a directory (mode: %q)",
+				destDir,
+				fi.Mode().String(),
+			)
 		}
 	}
 
@@ -57,7 +65,7 @@ func Unarchive(source io.Reader, destDir string, overwrite, removeDestDir bool) 
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("error reading file in tar archive: %w", err)
+			return errors.Wrapf(err, "error reading file in tar archive")
 		}
 	}
 
@@ -67,61 +75,61 @@ func Unarchive(source io.Reader, destDir string, overwrite, removeDestDir bool) 
 func untarNext(tr *tar.Reader, destDir string, overwrite bool) error {
 	hdr, err := tr.Next()
 	if err != nil {
-		return err // don't wrap error; calling loop must break on io.EOF
+		return errors.WithStack(err)
 	}
 	destPath := filepath.Join(destDir, hdr.Name)
 	log.Printf("file: %q", destPath)
 
 	// do not overwrite existing files, if configured
 	if !overwrite && fileExists(destPath) {
-		return fmt.Errorf("file already exists: %s", destPath)
+		return errors.Errorf("file already exists: %s", destPath)
 	}
 	// if "to" is a file and now exits and it's not a file then remove it
 	if err := os.RemoveAll(destPath); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	switch hdr.Typeflag {
 	case tar.TypeDir:
 		fi, err := os.Lstat(destPath)
 		if err != nil && !os.IsNotExist(err) {
-			return err
+			return errors.WithStack(err)
 		}
 		if fi != nil && !fi.IsDir() {
 			if err := os.RemoveAll(destPath); err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 		}
 		return mkdir(destPath, hdr.FileInfo().Mode())
 	case tar.TypeReg, tar.TypeRegA, tar.TypeChar, tar.TypeBlock, tar.TypeFifo:
 		fi, err := os.Lstat(destPath)
 		if err != nil && !os.IsNotExist(err) {
-			return err
+			return errors.WithStack(err)
 		}
 		if fi != nil && !fi.Mode().IsRegular() {
 			if err := os.RemoveAll(destPath); err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 		}
 		return writeNewFile(destPath, tr, hdr.FileInfo().Mode())
 	case tar.TypeSymlink:
 		if fileExists(destPath) {
 			if err := os.RemoveAll(destPath); err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 		}
 		return writeNewSymbolicLink(destPath, hdr.Linkname)
 	case tar.TypeLink:
 		if fileExists(destPath) {
 			if err := os.RemoveAll(destPath); err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 		}
 		return writeNewHardLink(destPath, filepath.Join(destPath, hdr.Linkname))
 	case tar.TypeXGlobalHeader:
 		return nil // ignore the pax global header from git-generated tarballs
 	default:
-		return fmt.Errorf("%s: unknown type flag: %c", hdr.Name, hdr.Typeflag)
+		return errors.Errorf("%s: unknown type flag: %c", hdr.Name, hdr.Typeflag)
 	}
 }
 
@@ -133,7 +141,7 @@ func fileExists(name string) bool {
 func mkdir(dirPath string, mode os.FileMode) error {
 	err := os.MkdirAll(dirPath, mode)
 	if err != nil {
-		return fmt.Errorf("%s: making directory: %w", dirPath, err)
+		return errors.Wrapf(err, "%s: making directory", dirPath)
 	}
 	return nil
 }
@@ -141,23 +149,23 @@ func mkdir(dirPath string, mode os.FileMode) error {
 func writeNewFile(fpath string, in io.Reader, mode os.FileMode) error {
 	err := os.MkdirAll(filepath.Dir(fpath), defaultDirPerm)
 	if err != nil {
-		return fmt.Errorf("%s: making directory for file: %w", fpath, err)
+		return errors.Wrapf(err, "%s: making directory for file", fpath)
 	}
 
 	out, err := os.Create(fpath)
 	if err != nil {
-		return fmt.Errorf("%s: creating new file: %w", fpath, err)
+		return errors.Wrapf(err, "%s: creating new file", fpath)
 	}
 	defer out.Close()
 
 	err = out.Chmod(mode)
 	if err != nil && runtime.GOOS != "windows" {
-		return fmt.Errorf("%s: changing file mode: %w", fpath, err)
+		return errors.Wrapf(err, "%s: changing file mode", fpath)
 	}
 
 	_, err = io.Copy(out, in)
 	if err != nil {
-		return fmt.Errorf("%s: writing file: %w", fpath, err)
+		return errors.Wrapf(err, "%s: writing file", fpath)
 	}
 	return nil
 }
@@ -165,11 +173,11 @@ func writeNewFile(fpath string, in io.Reader, mode os.FileMode) error {
 func writeNewSymbolicLink(fpath string, target string) error {
 	err := os.MkdirAll(filepath.Dir(fpath), defaultDirPerm)
 	if err != nil {
-		return fmt.Errorf("%s: making directory for file: %w", fpath, err)
+		return errors.Wrapf(err, "%s: making directory for file", fpath)
 	}
 	err = os.Symlink(target, fpath)
 	if err != nil {
-		return fmt.Errorf("%s: making symbolic link for: %w", fpath, err)
+		return errors.Wrapf(err, "%s: making symbolic link for", fpath)
 	}
 	return nil
 }
@@ -177,11 +185,11 @@ func writeNewSymbolicLink(fpath string, target string) error {
 func writeNewHardLink(fpath string, target string) error {
 	err := os.MkdirAll(filepath.Dir(fpath), defaultDirPerm)
 	if err != nil {
-		return fmt.Errorf("%s: making directory for file: %w", fpath, err)
+		return errors.Wrapf(err, "%s: making directory for file", fpath)
 	}
 	err = os.Link(target, fpath)
 	if err != nil {
-		return fmt.Errorf("%s: making hard link for: %w", fpath, err)
+		return errors.Wrapf(err, "%s: making hard link for", fpath)
 	}
 	return nil
 }

--- a/internal/util/backoff.go
+++ b/internal/util/backoff.go
@@ -16,9 +16,10 @@ package util
 
 import (
 	"context"
-	"errors"
 	"math/rand"
 	"time"
+
+	"agola.io/agola/internal/errors"
 )
 
 // DefaultRetry is the recommended retry for a conflict where multiple clients
@@ -105,7 +106,7 @@ func ExponentialBackoff(ctx context.Context, backoff Backoff, condition Conditio
 			duration = time.Duration(float64(duration) * backoff.Factor)
 		}
 		if ok, err := condition(); err != nil || ok {
-			return err
+			return errors.WithStack(err)
 		}
 	}
 	return ErrWaitTimeout

--- a/internal/util/buffer.go
+++ b/internal/util/buffer.go
@@ -17,6 +17,8 @@ package util
 import (
 	"bytes"
 	"io"
+
+	"agola.io/agola/internal/errors"
 )
 
 type LimitedBuffer struct {
@@ -24,11 +26,13 @@ type LimitedBuffer struct {
 	cap int
 }
 
-func (b *LimitedBuffer) Write(p []byte) (n int, err error) {
+func (b *LimitedBuffer) Write(p []byte) (int, error) {
 	if len(p)+b.Len() > b.cap {
 		return 0, io.EOF
 	}
-	return b.Buffer.Write(p)
+	n, err := b.Buffer.Write(p)
+
+	return n, errors.WithStack(err)
 }
 
 func NewLimitedBuffer(cap int) *LimitedBuffer {

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -15,9 +15,10 @@
 package util
 
 import (
-	"errors"
 	"fmt"
 	"strings"
+
+	"agola.io/agola/internal/errors"
 )
 
 // Errors is an error that contains multiple errors
@@ -92,10 +93,12 @@ type APIError struct {
 	Kind    ErrorKind
 	Code    ErrorCode
 	Message string
+
+	*errors.Stack
 }
 
 func NewAPIError(kind ErrorKind, err error, options ...APIErrorOption) error {
-	derr := &APIError{err: err, Kind: kind}
+	derr := &APIError{err: err, Kind: kind, Stack: errors.Callers(0)}
 
 	for _, opt := range options {
 		opt(derr)

--- a/internal/util/http.go
+++ b/internal/util/http.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	errors "golang.org/x/xerrors"
+	"agola.io/agola/internal/errors"
 )
 
 func HTTPResponse(w http.ResponseWriter, code int, res interface{}) error {
@@ -16,11 +16,11 @@ func HTTPResponse(w http.ResponseWriter, code int, res interface{}) error {
 		resj, err := json.Marshal(res)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
-			return err
+			return errors.WithStack(err)
 		}
 		w.WriteHeader(code)
 		_, err = w.Write(resj)
-		return err
+		return errors.WithStack(err)
 	}
 
 	w.WriteHeader(code)
@@ -96,7 +96,7 @@ func ErrFromRemote(resp *http.Response) error {
 
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	// Re-populate error response body so it can be parsed by the caller if needed

--- a/internal/util/password.go
+++ b/internal/util/password.go
@@ -15,14 +15,14 @@
 package util
 
 import (
-	"golang.org/x/crypto/bcrypt"
+	"agola.io/agola/internal/errors"
 
-	errors "golang.org/x/xerrors"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func PasswordHash(password string) (string, error) {
 	passwordHash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
-	return string(passwordHash), err
+	return string(passwordHash), errors.WithStack(err)
 }
 
 func CompareHashAndPassword(passwordHash, password string) (bool, error) {
@@ -30,7 +30,7 @@ func CompareHashAndPassword(passwordHash, password string) (bool, error) {
 		if errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
 			return false, nil
 		}
-		return false, err
+		return false, errors.WithStack(err)
 	}
 	return true, nil
 }

--- a/internal/util/ssh.go
+++ b/internal/util/ssh.go
@@ -20,8 +20,8 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"errors"
 
+	"agola.io/agola/internal/errors"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -30,12 +30,12 @@ import (
 func GenSSHKeyPair(bits int) ([]byte, []byte, error) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, bits)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.WithStack(err)
 	}
 
 	err = privateKey.Validate()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.WithStack(err)
 	}
 	privateKeyPEM := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)}
 

--- a/internal/util/string.go
+++ b/internal/util/string.go
@@ -18,6 +18,8 @@ import (
 	"bufio"
 	"io"
 	"strings"
+
+	"agola.io/agola/internal/errors"
 )
 
 func CountLines(s string) (uint, error) {
@@ -34,7 +36,7 @@ func CountLines(s string) (uint, error) {
 		_, err := br.ReadBytes('\n')
 		if err != nil {
 			if err != io.EOF {
-				return 0, err
+				return 0, errors.WithStack(err)
 			}
 			stop = true
 		}

--- a/internal/util/tls.go
+++ b/internal/util/tls.go
@@ -19,6 +19,8 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"io/ioutil"
+
+	"agola.io/agola/internal/errors"
 )
 
 func NewTLSConfig(certFile, keyFile, caFile string, insecureSkipVerify bool) (*tls.Config, error) {
@@ -28,7 +30,7 @@ func NewTLSConfig(certFile, keyFile, caFile string, insecureSkipVerify bool) (*t
 	if caFile != "" {
 		pemBytes, err := ioutil.ReadFile(caFile)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		roots := x509.NewCertPool()
 
@@ -40,7 +42,7 @@ func NewTLSConfig(certFile, keyFile, caFile string, insecureSkipVerify bool) (*t
 			}
 			cert, err := x509.ParseCertificate(block.Bytes)
 			if err != nil {
-				return nil, err
+				return nil, errors.WithStack(err)
 			}
 			roots.AddCert(cert)
 		}
@@ -53,7 +55,7 @@ func NewTLSConfig(certFile, keyFile, caFile string, insecureSkipVerify bool) (*t
 	if certFile != "" && keyFile != "" {
 		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
 	}

--- a/internal/util/validation.go
+++ b/internal/util/validation.go
@@ -15,8 +15,9 @@
 package util
 
 import (
-	"errors"
 	"regexp"
+
+	"agola.io/agola/internal/errors"
 
 	"github.com/gofrs/uuid"
 )

--- a/services/configstore/types/types.go
+++ b/services/configstore/types/types.go
@@ -16,9 +16,9 @@ package types
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/services/types"
 	"agola.io/agola/util"
 )
@@ -189,7 +189,7 @@ func (rs *RemoteSource) UnmarshalJSON(b []byte) error {
 	trs := (*remoteSource)(rs)
 
 	if err := json.Unmarshal(b, &trs); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	if trs.RegistrationEnabled == nil {
@@ -212,7 +212,7 @@ func SourceSupportedAuthTypes(rsType RemoteSourceType) []RemoteSourceAuthType {
 		return []RemoteSourceAuthType{RemoteSourceAuthTypeOauth2}
 
 	default:
-		panic(fmt.Errorf("unsupported remote source type: %q", rsType))
+		panic(errors.Errorf("unsupported remote source type: %q", rsType))
 	}
 }
 

--- a/services/runservice/types/types.go
+++ b/services/runservice/types/types.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/services/types"
 	"agola.io/agola/util"
 
@@ -568,20 +569,20 @@ func (et *Steps) UnmarshalJSON(b []byte) error {
 
 	var rs rawSteps
 	if err := json.Unmarshal(b, &rs); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	steps := make(Steps, len(rs))
 	for i, step := range rs {
 		var bs BaseStep
 		if err := json.Unmarshal(step, &bs); err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 		switch bs.Type {
 		case "run":
 			var s RunStep
 			if err := json.Unmarshal(step, &s); err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 			if s.Tty == nil {
 				s.Tty = util.BoolP(true)
@@ -590,25 +591,25 @@ func (et *Steps) UnmarshalJSON(b []byte) error {
 		case "save_to_workspace":
 			var s SaveToWorkspaceStep
 			if err := json.Unmarshal(step, &s); err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 			steps[i] = &s
 		case "restore_workspace":
 			var s RestoreWorkspaceStep
 			if err := json.Unmarshal(step, &s); err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 			steps[i] = &s
 		case "save_cache":
 			var s SaveCacheStep
 			if err := json.Unmarshal(step, &s); err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 			steps[i] = &s
 		case "restore_cache":
 			var s RestoreCacheStep
 			if err := json.Unmarshal(step, &s); err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 			steps[i] = &s
 		}
@@ -629,7 +630,7 @@ type ChangeGroupsRevisions map[string]int64
 func MarshalChangeGroupsUpdateToken(t *ChangeGroupsUpdateToken) (string, error) {
 	tj, err := json.Marshal(t)
 	if err != nil {
-		return "", err
+		return "", errors.WithStack(err)
 	}
 	return base64.StdEncoding.EncodeToString(tj), nil
 }
@@ -641,11 +642,11 @@ func UnmarshalChangeGroupsUpdateToken(s string) (*ChangeGroupsUpdateToken, error
 
 	tj, err := base64.StdEncoding.DecodeString(s)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	var t *ChangeGroupsUpdateToken
 	if err := json.Unmarshal(tj, &t); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return t, nil
 }

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/config"
 	"agola.io/agola/internal/services/configstore"
 	"agola.io/agola/internal/services/executor"
@@ -44,7 +45,6 @@ import (
 	"code.gitea.io/sdk/gitea"
 	"github.com/google/go-cmp/cmp"
 	"github.com/rs/zerolog"
-	errors "golang.org/x/xerrors"
 	"gopkg.in/src-d/go-billy.v4/memfs"
 	"gopkg.in/src-d/go-billy.v4/osfs"
 	"gopkg.in/src-d/go-git.v4"
@@ -140,37 +140,37 @@ func shutdownGitea(tgitea *testutil.TestGitea) {
 func startAgola(ctx context.Context, t *testing.T, log zerolog.Logger, dir string, c *config.Config) (<-chan error, error) {
 	rs, err := rsscheduler.NewRunservice(ctx, log, &c.Runservice)
 	if err != nil {
-		return nil, errors.Errorf("failed to start run service scheduler: %w", err)
+		return nil, errors.Wrapf(err, "failed to start run service scheduler")
 	}
 
 	ex, err := executor.NewExecutor(ctx, log, &c.Executor)
 	if err != nil {
-		return nil, errors.Errorf("failed to start run service executor: %w", err)
+		return nil, errors.Wrapf(err, "failed to start run service executor")
 	}
 
 	cs, err := configstore.NewConfigstore(ctx, log, &c.Configstore)
 	if err != nil {
-		return nil, errors.Errorf("failed to start config store: %w", err)
+		return nil, errors.Wrapf(err, "failed to start config store")
 	}
 
 	sched, err := scheduler.NewScheduler(ctx, log, &c.Scheduler)
 	if err != nil {
-		return nil, errors.Errorf("failed to start scheduler: %w", err)
+		return nil, errors.Wrapf(err, "failed to start scheduler")
 	}
 
 	ns, err := notification.NewNotificationService(ctx, log, c)
 	if err != nil {
-		return nil, errors.Errorf("failed to start notification service: %w", err)
+		return nil, errors.Wrapf(err, "failed to start notification service")
 	}
 
 	gw, err := gateway.NewGateway(ctx, log, c)
 	if err != nil {
-		return nil, errors.Errorf("failed to start gateway: %w", err)
+		return nil, errors.Wrapf(err, "failed to start gateway")
 	}
 
 	gs, err := gitserver.NewGitserver(ctx, log, &c.Gitserver)
 	if err != nil {
-		return nil, errors.Errorf("failed to start git server: %w", err)
+		return nil, errors.Wrapf(err, "failed to start git server")
 	}
 
 	errCh := make(chan error)
@@ -358,7 +358,7 @@ func setup(ctx context.Context, t *testing.T, dir string) (*testutil.TestEmbedde
 	go func() {
 		err := <-errCh
 		if err != nil {
-			panic(fmt.Errorf("agola component returned error: %w", err))
+			panic(errors.Wrap(err, "agola component returned error: %w"))
 		}
 	}()
 


### PR DESCRIPTION
Implement a new error handling library based on pkg/errors. It provides
stack saving on wrapping and exports some function to add stack saving
also to external errors.
It also implements custom zerolog error formatting without adding too
much verbosity by just printing the chain error file:line without a full
stack trace of every error.

* Add a --detailed-errors options to print error with their full chain
* Wrap all error returns. Use errors.WithStack to wrap without adding a
  new messsage and error.Wrap[f] to add a message.
* Add golangci-lint wrapcheck to check that external packages errors are
  wrapped. This won't check that internal packages error are wrapped.
  But we want also to ensure this case so we'll have to find something
  else to check also these.
