### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/internal/datamanager/datamanager_test.go
+++ b/internal/datamanager/datamanager_test.go
@@ -58,12 +58,7 @@ func shutdownEtcd(tetcd *testutil.TestEmbeddedEtcd) {
 }
 
 func TestEtcdReset(t *testing.T) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	log := testutil.NewLogger(t)
 
 	etcdDir, err := ioutil.TempDir(dir, "etcd")
@@ -167,12 +162,7 @@ func TestEtcdReset(t *testing.T) {
 }
 
 func TestEtcdResetWalsGap(t *testing.T) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	log := testutil.NewLogger(t)
 
 	etcdDir, err := ioutil.TempDir(dir, "etcd")
@@ -295,12 +285,7 @@ func TestEtcdResetWalsGap(t *testing.T) {
 }
 
 func TestConcurrentUpdate(t *testing.T) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	log := testutil.NewLogger(t)
 
 	etcdDir, err := ioutil.TempDir(dir, "etcd")
@@ -388,12 +373,7 @@ func TestConcurrentUpdate(t *testing.T) {
 }
 
 func TestEtcdWalCleaner(t *testing.T) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	log := testutil.NewLogger(t)
 
 	etcdDir, err := ioutil.TempDir(dir, "etcd")
@@ -464,12 +444,7 @@ func TestEtcdWalCleaner(t *testing.T) {
 }
 
 func TestReadObject(t *testing.T) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	log := testutil.NewLogger(t)
 
 	etcdDir, err := ioutil.TempDir(dir, "etcd")
@@ -759,12 +734,7 @@ func TestCheckpoint(t *testing.T) {
 }
 
 func testCheckpoint(t *testing.T, basePath string) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	log := testutil.NewLogger(t)
 
 	etcdDir, err := ioutil.TempDir(dir, "etcd")
@@ -977,12 +947,7 @@ func testCheckpoint(t *testing.T, basePath string) {
 }
 
 func TestRead(t *testing.T) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	log := testutil.NewLogger(t)
 
 	etcdDir, err := ioutil.TempDir(dir, "etcd")
@@ -1093,12 +1058,7 @@ func TestClean(t *testing.T) {
 }
 
 func testClean(t *testing.T, basePath string) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	log := testutil.NewLogger(t)
 
 	etcdDir, err := ioutil.TempDir(dir, "etcd")
@@ -1213,12 +1173,7 @@ func TestCleanConcurrentCheckpoint(t *testing.T) {
 }
 
 func testCleanConcurrentCheckpoint(t *testing.T, basePath string) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	log := testutil.NewLogger(t)
 
 	etcdDir, err := ioutil.TempDir(dir, "etcd")
@@ -1344,12 +1299,7 @@ func TestStorageWalCleaner(t *testing.T) {
 }
 
 func testStorageWalCleaner(t *testing.T, basePath string) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	log := testutil.NewLogger(t)
 
 	etcdDir, err := ioutil.TempDir(dir, "etcd")
@@ -1486,12 +1436,7 @@ func testStorageWalCleaner(t *testing.T, basePath string) {
 }
 
 func TestExportImport(t *testing.T) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	log := testutil.NewLogger(t)
 
 	etcdDir, err := ioutil.TempDir(dir, "etcd")

--- a/internal/objectstorage/objectstorage_test.go
+++ b/internal/objectstorage/objectstorage_test.go
@@ -17,7 +17,6 @@ package objectstorage
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -47,11 +46,7 @@ func setupS3(t *testing.T, dir string) (*S3Storage, error) {
 }
 
 func TestList(t *testing.T) {
-	dir, err := ioutil.TempDir("", "objectstorage")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	ps, err := setupPosix(t, dir)
 	if err != nil {
@@ -302,11 +297,7 @@ func TestList(t *testing.T) {
 }
 
 func TestWriteObject(t *testing.T) {
-	dir, err := ioutil.TempDir("", "objectstorage")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	ps, err := setupPosix(t, dir)
 	if err != nil {

--- a/internal/objectstorage/posix_test.go
+++ b/internal/objectstorage/posix_test.go
@@ -16,7 +16,6 @@ package objectstorage
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,11 +24,7 @@ import (
 func TestPosixDeleteObject(t *testing.T) {
 	objects := []string{"☺☺☺☺a☺☺☺☺☺☺b☺☺☺☺", "s3/is/nota/fil.fa", "s3/is/not/a/file///system/fi%l%%e01"}
 
-	dir, err := ioutil.TempDir("", "objectstorage")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	//defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	ls, err := NewPosix(dir)
 	if err != nil {

--- a/internal/objectstorage/posixflat_test.go
+++ b/internal/objectstorage/posixflat_test.go
@@ -16,7 +16,6 @@ package objectstorage
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -82,11 +81,7 @@ func TestEscapeUnescape(t *testing.T) {
 func TestPosixFlatDeleteObject(t *testing.T) {
 	objects := []string{"/", "//", "☺☺☺☺a☺☺☺☺☺☺b☺☺☺☺", "s3/is/nota/fil.fa", "s3/is/not/a/file///system/fi%l%%e01"}
 
-	dir, err := ioutil.TempDir("", "objectstorage")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	//defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	ls, err := NewPosixFlat(dir)
 	if err != nil {

--- a/internal/services/config/config_test.go
+++ b/internal/services/config/config_test.go
@@ -16,7 +16,6 @@ package config
 
 import (
 	"io/ioutil"
-	"os"
 	"path"
 	"testing"
 
@@ -229,14 +228,10 @@ gitserver:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "ParseConfig")
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			content := []byte(tt.in)
-			err = ioutil.WriteFile(path.Join(dir, "config.yml"), content, 0644)
+			err := ioutil.WriteFile(path.Join(dir, "config.yml"), content, 0644)
 			if err != nil {
 				t.Fatalf("unexpected err: %v", err)
 			}

--- a/internal/services/configstore/configstore_test.go
+++ b/internal/services/configstore/configstore_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-	"os"
 	"path"
 	"reflect"
 	"sync"
@@ -124,12 +123,7 @@ func getUsers(ctx context.Context, cs *Configstore) ([]*types.User, error) {
 }
 
 func TestResync(t *testing.T) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	log := testutil.NewLogger(t)
 
 	etcdDir, err := ioutil.TempDir(dir, "etcd")
@@ -300,12 +294,7 @@ func TestResync(t *testing.T) {
 }
 
 func TestExportImport(t *testing.T) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	log := testutil.NewLogger(t)
 
 	etcdDir, err := ioutil.TempDir(dir, "etcd")
@@ -549,12 +538,7 @@ func compareUsers(u1, u2 []*types.User) bool {
 }
 
 func TestUser(t *testing.T) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	ctx := context.Background()
 	log := testutil.NewLogger(t)
 
@@ -617,12 +601,7 @@ func TestUser(t *testing.T) {
 }
 
 func TestProjectGroupsAndProjectsCreate(t *testing.T) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	ctx := context.Background()
 	log := testutil.NewLogger(t)
 
@@ -765,12 +744,7 @@ func TestProjectGroupsAndProjectsCreate(t *testing.T) {
 }
 
 func TestProjectUpdate(t *testing.T) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	ctx := context.Background()
 	log := testutil.NewLogger(t)
 
@@ -842,12 +816,7 @@ func TestProjectUpdate(t *testing.T) {
 }
 
 func TestProjectGroupUpdate(t *testing.T) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	ctx := context.Background()
 	log := testutil.NewLogger(t)
 
@@ -993,12 +962,7 @@ func TestProjectGroupUpdate(t *testing.T) {
 }
 
 func TestProjectGroupDelete(t *testing.T) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	ctx := context.Background()
 	log := testutil.NewLogger(t)
 
@@ -1050,12 +1014,7 @@ func TestProjectGroupDelete(t *testing.T) {
 }
 
 func TestProjectGroupDeleteDontSeeOldChildObjects(t *testing.T) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	ctx := context.Background()
 	log := testutil.NewLogger(t)
 
@@ -1186,12 +1145,7 @@ func TestProjectGroupDeleteDontSeeOldChildObjects(t *testing.T) {
 }
 
 func TestOrgMembers(t *testing.T) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	ctx := context.Background()
 	log := testutil.NewLogger(t)
 
@@ -1277,12 +1231,7 @@ func TestOrgMembers(t *testing.T) {
 }
 
 func TestRemoteSource(t *testing.T) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	log := testutil.NewLogger(t)
 
 	tests := []struct {

--- a/internal/services/gitserver/gitserver_test.go
+++ b/internal/services/gitserver/gitserver_test.go
@@ -16,7 +16,6 @@ package gitserver
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -87,12 +86,7 @@ func TestRepoCleaner(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			log := testutil.NewLogger(t)
-
-			dir, err := ioutil.TempDir("", "agola")
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -369,11 +369,7 @@ func setup(ctx context.Context, t *testing.T, dir string, gitea bool) (*testutil
 }
 
 func TestCreateLinkedAccount(t *testing.T) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -445,11 +441,7 @@ func createLinkedAccount(ctx context.Context, t *testing.T, tgitea *testutil.Tes
 }
 
 func TestCreateProject(t *testing.T) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -491,11 +483,7 @@ func TestUpdateProject(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		dir, err := ioutil.TempDir("", "agola")
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -797,11 +785,7 @@ func TestPush(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			dir, err := ioutil.TempDir("", "agola")
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -988,11 +972,7 @@ func TestDirectRun(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "agola")
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -1136,11 +1116,7 @@ func TestDirectRunVariables(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "agola")
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			if err := ioutil.WriteFile(filepath.Join(dir, "varfile01.yml"), []byte(varfile01), 0644); err != nil {
 				t.Fatalf("unexpected err: %v", err)
@@ -1310,11 +1286,7 @@ func TestDirectRunLogs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "agola")
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -1489,11 +1461,7 @@ func TestPullRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			dir, err := ioutil.TempDir("", "agola")
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -1828,11 +1796,7 @@ def main(ctx):
 					config = starlarkConfig
 				}
 
-				dir, err := ioutil.TempDir("", "agola")
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
-				defer os.RemoveAll(dir)
+				dir := t.TempDir()
 
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
@@ -1936,11 +1900,7 @@ def main(ctx):
 }
 
 func TestUserOrgs(t *testing.T) {
-	dir, err := ioutil.TempDir("", "agola")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
A small testing enhancement.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

~~**Note:** `T.TempDir` requires Go 1.15 or higher, hence the `go` directive in `go.mod` is bumped to `1.16` since the project has been updated to Go 1.16 in #257.~~

Reference: https://pkg.go.dev/testing#T.TempDir