### PR TITLE
gateway: move all the authn/authz logic from api to action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 bin/
 tools/
 webbundle/bindata.go
+.vscode/

--- a/internal/services/gateway/action/projectgroup.go
+++ b/internal/services/gateway/action/projectgroup.go
@@ -19,6 +19,7 @@ import (
 	"path"
 
 	"agola.io/agola/internal/errors"
+	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
 	csapitypes "agola.io/agola/services/configstore/api/types"
 	cstypes "agola.io/agola/services/configstore/types"
@@ -56,6 +57,11 @@ type CreateProjectGroupRequest struct {
 }
 
 func (h *ActionHandler) CreateProjectGroup(ctx context.Context, req *CreateProjectGroupRequest) (*csapitypes.ProjectGroup, error) {
+	userID := common.CurrentUserID(ctx)
+	if userID == "" {
+		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user not authenticated"))
+	}
+	req.CurrentUserID = userID
 	if !util.ValidateName(req.Name) {
 		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid projectGroup name %q", req.Name))
 	}

--- a/internal/services/gateway/action/user.go
+++ b/internal/services/gateway/action/user.go
@@ -74,6 +74,10 @@ func (h *ActionHandler) GetUser(ctx context.Context, userRef string) (*cstypes.U
 		return nil, errors.Errorf("user not logged in")
 	}
 
+	if userRef == "" {
+		return nil, errors.Errorf("user not authenticated")
+	}
+
 	user, _, err := h.configstoreClient.GetUser(ctx, userRef)
 	if err != nil {
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
@@ -81,12 +85,17 @@ func (h *ActionHandler) GetUser(ctx context.Context, userRef string) (*cstypes.U
 	return user, nil
 }
 
-func (h *ActionHandler) GetUserOrgs(ctx context.Context, userRef string) ([]*csapitypes.UserOrgsResponse, error) {
+func (h *ActionHandler) GetUserOrgs(ctx context.Context) ([]*csapitypes.UserOrgsResponse, error) {
 	if !common.IsUserLogged(ctx) {
 		return nil, errors.Errorf("user not logged in")
 	}
 
-	orgs, _, err := h.configstoreClient.GetUserOrgs(ctx, userRef)
+	userID := common.CurrentUserID(ctx)
+	if userID == "" {
+		return nil, errors.Errorf("user not authenticated")
+	}
+
+	orgs, _, err := h.configstoreClient.GetUserOrgs(ctx, userID)
 	if err != nil {
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
 	}

--- a/internal/services/gateway/api/projectgroup.go
+++ b/internal/services/gateway/api/projectgroup.go
@@ -19,9 +19,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/gateway/action"
-	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
 	csapitypes "agola.io/agola/services/configstore/api/types"
 	cstypes "agola.io/agola/services/configstore/types"
@@ -50,17 +48,11 @@ func (h *CreateProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	userID := common.CurrentUserID(ctx)
-	if userID == "" {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user not authenticated")))
-		return
-	}
-
 	creq := &action.CreateProjectGroupRequest{
 		Name:          req.Name,
 		ParentRef:     req.ParentRef,
 		Visibility:    cstypes.Visibility(req.Visibility),
-		CurrentUserID: userID,
+		CurrentUserID: "",
 	}
 
 	projectGroup, err := h.ah.CreateProjectGroup(ctx, creq)

--- a/internal/services/gateway/api/user.go
+++ b/internal/services/gateway/api/user.go
@@ -106,10 +106,6 @@ func (h *CurrentUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	userID := common.CurrentUserID(ctx)
-	if userID == "" {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user not authenticated")))
-		return
-	}
 
 	user, tokens, linkedAccounts, err := h.ah.GetCurrentUser(ctx, userID)
 	if util.HTTPError(w, err) {
@@ -613,13 +609,7 @@ func NewUserOrgsHandler(log zerolog.Logger, ah *action.ActionHandler) *UserOrgsH
 func (h *UserOrgsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	userID := common.CurrentUserID(ctx)
-	if userID == "" {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user not authenticated")))
-		return
-	}
-
-	userOrgs, err := h.ah.GetUserOrgs(ctx, userID)
+	userOrgs, err := h.ah.GetUserOrgs(ctx)
 	if util.HTTPError(w, err) {
 		h.log.Err(err).Send()
 		return


### PR DESCRIPTION
removed the method  that verifies is the user is not authenticated from api to action. Can you please review it ? 
generated from issue #307 