### PR TITLE
configstore: update api and action request types

### DIFF
--- a/internal/services/configstore/action/remotesource.go
+++ b/internal/services/configstore/action/remotesource.go
@@ -28,36 +28,36 @@ import (
 	"github.com/gofrs/uuid"
 )
 
-func (h *ActionHandler) ValidateRemoteSource(ctx context.Context, remoteSource *types.RemoteSource) error {
-	if remoteSource.Name == "" {
+func (h *ActionHandler) ValidateRemoteSourceReq(ctx context.Context, req *CreateUpdateRemoteSourceRequest) error {
+	if req.Name == "" {
 		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource name required"))
 	}
-	if !util.ValidateName(remoteSource.Name) {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid remotesource name %q", remoteSource.Name))
+	if !util.ValidateName(req.Name) {
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid remotesource name %q", req.Name))
 	}
 
-	if remoteSource.Name == "" {
+	if req.Name == "" {
 		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource name required"))
 	}
-	if remoteSource.APIURL == "" {
+	if req.APIURL == "" {
 		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource api url required"))
 	}
-	if remoteSource.Type == "" {
+	if req.Type == "" {
 		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource type required"))
 	}
-	if remoteSource.AuthType == "" {
+	if req.AuthType == "" {
 		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource auth type required"))
 	}
 
 	// validate if the remotesource type supports the required auth type
-	if !types.SourceSupportsAuthType(types.RemoteSourceType(remoteSource.Type), types.RemoteSourceAuthType(remoteSource.AuthType)) {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource type %q doesn't support auth type %q", remoteSource.Type, remoteSource.AuthType))
+	if !types.SourceSupportsAuthType(types.RemoteSourceType(req.Type), types.RemoteSourceAuthType(req.AuthType)) {
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource type %q doesn't support auth type %q", req.Type, req.AuthType))
 	}
-	if remoteSource.AuthType == types.RemoteSourceAuthTypeOauth2 {
-		if remoteSource.Oauth2ClientID == "" {
+	if req.AuthType == types.RemoteSourceAuthTypeOauth2 {
+		if req.Oauth2ClientID == "" {
 			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource oauth2clientid required for auth type %q", types.RemoteSourceAuthTypeOauth2))
 		}
-		if remoteSource.Oauth2ClientSecret == "" {
+		if req.Oauth2ClientSecret == "" {
 			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource oauth2clientsecret required for auth type %q", types.RemoteSourceAuthTypeOauth2))
 		}
 	}
@@ -65,14 +65,28 @@ func (h *ActionHandler) ValidateRemoteSource(ctx context.Context, remoteSource *
 	return nil
 }
 
-func (h *ActionHandler) CreateRemoteSource(ctx context.Context, remoteSource *types.RemoteSource) (*types.RemoteSource, error) {
-	if err := h.ValidateRemoteSource(ctx, remoteSource); err != nil {
+type CreateUpdateRemoteSourceRequest struct {
+	Name                string
+	APIURL              string
+	SkipVerify          bool
+	Type                types.RemoteSourceType
+	AuthType            types.RemoteSourceAuthType
+	Oauth2ClientID      string
+	Oauth2ClientSecret  string
+	SSHHostKey          string
+	SkipSSHHostKeyCheck bool
+	RegistrationEnabled *bool
+	LoginEnabled        *bool
+}
+
+func (h *ActionHandler) CreateRemoteSource(ctx context.Context, req *CreateUpdateRemoteSourceRequest) (*types.RemoteSource, error) {
+	if err := h.ValidateRemoteSourceReq(ctx, req); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
 	var cgt *datamanager.ChangeGroupsUpdateToken
 	// changegroup is the remotesource name
-	cgNames := []string{util.EncodeSha256Hex("remotesourcename-" + remoteSource.Name)}
+	cgNames := []string{util.EncodeSha256Hex("remotesourcename-" + req.Name)}
 
 	// must do all the checks in a single transaction to avoid concurrent changes
 	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
@@ -83,7 +97,7 @@ func (h *ActionHandler) CreateRemoteSource(ctx context.Context, remoteSource *ty
 		}
 
 		// check duplicate remoteSource name
-		u, err := h.readDB.GetRemoteSourceByName(tx, remoteSource.Name)
+		u, err := h.readDB.GetRemoteSourceByName(tx, req.Name)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -96,7 +110,19 @@ func (h *ActionHandler) CreateRemoteSource(ctx context.Context, remoteSource *ty
 		return nil, errors.WithStack(err)
 	}
 
+	remoteSource := &types.RemoteSource{}
 	remoteSource.ID = uuid.Must(uuid.NewV4()).String()
+	remoteSource.Name = req.Name
+	remoteSource.APIURL = req.APIURL
+	remoteSource.SkipVerify = req.SkipVerify
+	remoteSource.Type = req.Type
+	remoteSource.AuthType = req.AuthType
+	remoteSource.Oauth2ClientID = req.Oauth2ClientID
+	remoteSource.Oauth2ClientSecret = req.Oauth2ClientSecret
+	remoteSource.SSHHostKey = req.SSHHostKey
+	remoteSource.SkipSSHHostKeyCheck = req.SkipSSHHostKeyCheck
+	remoteSource.RegistrationEnabled = req.RegistrationEnabled
+	remoteSource.LoginEnabled = req.LoginEnabled
 
 	rsj, err := json.Marshal(remoteSource)
 	if err != nil {
@@ -115,36 +141,30 @@ func (h *ActionHandler) CreateRemoteSource(ctx context.Context, remoteSource *ty
 	return remoteSource, errors.WithStack(err)
 }
 
-type UpdateRemoteSourceRequest struct {
-	RemoteSourceRef string
-
-	RemoteSource *types.RemoteSource
-}
-
-func (h *ActionHandler) UpdateRemoteSource(ctx context.Context, req *UpdateRemoteSourceRequest) (*types.RemoteSource, error) {
-	if err := h.ValidateRemoteSource(ctx, req.RemoteSource); err != nil {
+func (h *ActionHandler) UpdateRemoteSource(ctx context.Context, remoteSourceRef string, req *CreateUpdateRemoteSourceRequest) (*types.RemoteSource, error) {
+	if err := h.ValidateRemoteSourceReq(ctx, req); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	var curRemoteSource *types.RemoteSource
 	var cgt *datamanager.ChangeGroupsUpdateToken
 
+	var remoteSource *types.RemoteSource
 	// must do all the checks in a single transaction to avoid concurrent changes
 	err := h.readDB.Do(ctx, func(tx *db.Tx) error {
 		var err error
 
 		// check remotesource exists
-		curRemoteSource, err = h.readDB.GetRemoteSourceByName(tx, req.RemoteSourceRef)
+		remoteSource, err = h.readDB.GetRemoteSourceByName(tx, remoteSourceRef)
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		if curRemoteSource == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource with ref %q doesn't exist", req.RemoteSourceRef))
+		if remoteSource == nil {
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource with ref %q doesn't exist", remoteSourceRef))
 		}
 
-		if curRemoteSource.Name != req.RemoteSource.Name {
+		if remoteSource.Name != req.Name {
 			// check duplicate remoteSource name
-			u, err := h.readDB.GetRemoteSourceByName(tx, req.RemoteSource.Name)
+			u, err := h.readDB.GetRemoteSourceByName(tx, req.Name)
 			if err != nil {
 				return errors.WithStack(err)
 			}
@@ -153,12 +173,21 @@ func (h *ActionHandler) UpdateRemoteSource(ctx context.Context, req *UpdateRemot
 			}
 		}
 
-		// set/override ID that must be kept from the current remote source
-		req.RemoteSource.ID = curRemoteSource.ID
+		remoteSource.Name = req.Name
+		remoteSource.APIURL = req.APIURL
+		remoteSource.SkipVerify = req.SkipVerify
+		remoteSource.Type = req.Type
+		remoteSource.AuthType = req.AuthType
+		remoteSource.Oauth2ClientID = req.Oauth2ClientID
+		remoteSource.Oauth2ClientSecret = req.Oauth2ClientSecret
+		remoteSource.SSHHostKey = req.SSHHostKey
+		remoteSource.SkipSSHHostKeyCheck = req.SkipSSHHostKeyCheck
+		remoteSource.RegistrationEnabled = req.RegistrationEnabled
+		remoteSource.LoginEnabled = req.LoginEnabled
 
 		// changegroup is the remotesource id and also name since we could change the
 		// name so concurrently updating on the new name
-		cgNames := []string{util.EncodeSha256Hex("remotesourcename-" + req.RemoteSource.Name), util.EncodeSha256Hex("remotesourceid-" + req.RemoteSource.ID)}
+		cgNames := []string{util.EncodeSha256Hex("remotesourcename-" + remoteSource.Name), util.EncodeSha256Hex("remotesourceid-" + remoteSource.ID)}
 		cgt, err = h.readDB.GetChangeGroupsUpdateTokens(tx, cgNames)
 		if err != nil {
 			return errors.WithStack(err)
@@ -169,7 +198,7 @@ func (h *ActionHandler) UpdateRemoteSource(ctx context.Context, req *UpdateRemot
 		return nil, errors.WithStack(err)
 	}
 
-	rsj, err := json.Marshal(req.RemoteSource)
+	rsj, err := json.Marshal(remoteSource)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to marshal remotesource")
 	}
@@ -177,13 +206,13 @@ func (h *ActionHandler) UpdateRemoteSource(ctx context.Context, req *UpdateRemot
 		{
 			ActionType: datamanager.ActionTypePut,
 			DataType:   string(types.ConfigTypeRemoteSource),
-			ID:         req.RemoteSource.ID,
+			ID:         remoteSource.ID,
 			Data:       rsj,
 		},
 	}
 
 	_, err = h.dm.WriteWal(ctx, actions, cgt)
-	return req.RemoteSource, errors.WithStack(err)
+	return remoteSource, errors.WithStack(err)
 }
 
 func (h *ActionHandler) DeleteRemoteSource(ctx context.Context, remoteSourceName string) error {

--- a/internal/services/configstore/api/org.go
+++ b/internal/services/configstore/api/org.go
@@ -79,14 +79,20 @@ func NewCreateOrgHandler(log zerolog.Logger, ah *action.ActionHandler) *CreateOr
 func (h *CreateOrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	var req types.Organization
+	var req *csapitypes.CreateOrgRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
 		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
-	org, err := h.ah.CreateOrg(ctx, &req)
+	creq := &action.CreateOrgRequest{
+		Name:          req.Name,
+		Visibility:    req.Visibility,
+		CreatorUserID: req.CreatorUserID,
+	}
+
+	org, err := h.ah.CreateOrg(ctx, creq)
 	if util.HTTPError(w, err) {
 		h.log.Err(err).Send()
 		return
@@ -197,7 +203,7 @@ func (h *AddOrgMemberHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	orgRef := vars["orgref"]
 	userRef := vars["userref"]
 
-	var req csapitypes.AddOrgMemberRequest
+	var req *csapitypes.AddOrgMemberRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
 		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))

--- a/internal/services/configstore/api/project.go
+++ b/internal/services/configstore/api/project.go
@@ -162,14 +162,28 @@ func NewCreateProjectHandler(log zerolog.Logger, ah *action.ActionHandler, readD
 func (h *CreateProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	var req types.Project
+	var req *csapitypes.CreateUpdateProjectRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
 		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
-	project, err := h.ah.CreateProject(ctx, &req)
+	areq := &action.CreateUpdateProjectRequest{
+		Name:                       req.Name,
+		Parent:                     req.Parent,
+		Visibility:                 req.Visibility,
+		RemoteRepositoryConfigType: req.RemoteRepositoryConfigType,
+		RemoteSourceID:             req.RemoteSourceID,
+		LinkedAccountID:            req.LinkedAccountID,
+		RepositoryID:               req.RepositoryID,
+		RepositoryPath:             req.RepositoryPath,
+		SSHPrivateKey:              req.SSHPrivateKey,
+		SkipSSHHostKeyCheck:        req.SkipSSHHostKeyCheck,
+		PassVarsToForkedPR:         req.PassVarsToForkedPR,
+	}
+
+	project, err := h.ah.CreateProject(ctx, areq)
 	if util.HTTPError(w, err) {
 		h.log.Err(err).Send()
 		return
@@ -206,18 +220,28 @@ func (h *UpdateProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	var project *types.Project
+	var req *csapitypes.CreateUpdateProjectRequest
 	d := json.NewDecoder(r.Body)
-	if err := d.Decode(&project); err != nil {
+	if err := d.Decode(&req); err != nil {
 		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
-	areq := &action.UpdateProjectRequest{
-		ProjectRef: projectRef,
-		Project:    project,
+	areq := &action.CreateUpdateProjectRequest{
+		Name:                       req.Name,
+		Parent:                     req.Parent,
+		Visibility:                 req.Visibility,
+		RemoteRepositoryConfigType: req.RemoteRepositoryConfigType,
+		RemoteSourceID:             req.RemoteSourceID,
+		LinkedAccountID:            req.LinkedAccountID,
+		RepositoryID:               req.RepositoryID,
+		RepositoryPath:             req.RepositoryPath,
+		SSHPrivateKey:              req.SSHPrivateKey,
+		SkipSSHHostKeyCheck:        req.SkipSSHHostKeyCheck,
+		PassVarsToForkedPR:         req.PassVarsToForkedPR,
 	}
-	project, err = h.ah.UpdateProject(ctx, areq)
+
+	project, err := h.ah.UpdateProject(ctx, projectRef, areq)
 	if util.HTTPError(w, err) {
 		h.log.Err(err).Send()
 		return

--- a/internal/services/configstore/api/projectgroup.go
+++ b/internal/services/configstore/api/projectgroup.go
@@ -204,14 +204,20 @@ func NewCreateProjectGroupHandler(log zerolog.Logger, ah *action.ActionHandler, 
 func (h *CreateProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	var req types.ProjectGroup
+	var req *csapitypes.CreateUpdateProjectGroupRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
 		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
-	projectGroup, err := h.ah.CreateProjectGroup(ctx, &req)
+	areq := &action.CreateUpdateProjectGroupRequest{
+		Name:       req.Name,
+		Parent:     req.Parent,
+		Visibility: req.Visibility,
+	}
+
+	projectGroup, err := h.ah.CreateProjectGroup(ctx, areq)
 	if util.HTTPError(w, err) {
 		h.log.Err(err).Send()
 		return
@@ -248,18 +254,20 @@ func (h *UpdateProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	var projectGroup *types.ProjectGroup
+	var req *csapitypes.CreateUpdateProjectGroupRequest
 	d := json.NewDecoder(r.Body)
-	if err := d.Decode(&projectGroup); err != nil {
+	if err := d.Decode(&req); err != nil {
 		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
-	areq := &action.UpdateProjectGroupRequest{
-		ProjectGroupRef: projectGroupRef,
-		ProjectGroup:    projectGroup,
+	areq := &action.CreateUpdateProjectGroupRequest{
+		Name:       req.Name,
+		Parent:     req.Parent,
+		Visibility: req.Visibility,
 	}
-	projectGroup, err = h.ah.UpdateProjectGroup(ctx, areq)
+
+	projectGroup, err := h.ah.UpdateProjectGroup(ctx, projectGroupRef, areq)
 	if util.HTTPError(w, err) {
 		h.log.Err(err).Send()
 		return

--- a/internal/services/configstore/api/remotesource.go
+++ b/internal/services/configstore/api/remotesource.go
@@ -24,6 +24,7 @@ import (
 	"agola.io/agola/internal/services/configstore/action"
 	"agola.io/agola/internal/services/configstore/readdb"
 	"agola.io/agola/internal/util"
+	csapitypes "agola.io/agola/services/configstore/api/types"
 	"agola.io/agola/services/configstore/types"
 
 	"github.com/gorilla/mux"
@@ -78,14 +79,27 @@ func NewCreateRemoteSourceHandler(log zerolog.Logger, ah *action.ActionHandler) 
 func (h *CreateRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	var req types.RemoteSource
+	var req *csapitypes.CreateUpdateRemoteSourceRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
 		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
-	remoteSource, err := h.ah.CreateRemoteSource(ctx, &req)
+	areq := &action.CreateUpdateRemoteSourceRequest{
+		Name:                req.Name,
+		APIURL:              req.APIURL,
+		SkipVerify:          req.SkipVerify,
+		Type:                req.Type,
+		AuthType:            req.AuthType,
+		Oauth2ClientID:      req.Oauth2ClientID,
+		Oauth2ClientSecret:  req.Oauth2ClientSecret,
+		SkipSSHHostKeyCheck: req.SkipSSHHostKeyCheck,
+		RegistrationEnabled: req.RegistrationEnabled,
+		LoginEnabled:        req.LoginEnabled,
+	}
+
+	remoteSource, err := h.ah.CreateRemoteSource(ctx, areq)
 	if util.HTTPError(w, err) {
 		h.log.Err(err).Send()
 		return
@@ -111,18 +125,26 @@ func (h *UpdateRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	vars := mux.Vars(r)
 	rsRef := vars["remotesourceref"]
 
-	var remoteSource *types.RemoteSource
+	var req *csapitypes.CreateUpdateRemoteSourceRequest
 	d := json.NewDecoder(r.Body)
-	if err := d.Decode(&remoteSource); err != nil {
+	if err := d.Decode(&req); err != nil {
 		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
-	areq := &action.UpdateRemoteSourceRequest{
-		RemoteSourceRef: rsRef,
-		RemoteSource:    remoteSource,
+	areq := &action.CreateUpdateRemoteSourceRequest{
+		Name:                req.Name,
+		APIURL:              req.APIURL,
+		SkipVerify:          req.SkipVerify,
+		Type:                req.Type,
+		AuthType:            req.AuthType,
+		Oauth2ClientID:      req.Oauth2ClientID,
+		Oauth2ClientSecret:  req.Oauth2ClientSecret,
+		SkipSSHHostKeyCheck: req.SkipSSHHostKeyCheck,
+		RegistrationEnabled: req.RegistrationEnabled,
+		LoginEnabled:        req.LoginEnabled,
 	}
-	remoteSource, err := h.ah.UpdateRemoteSource(ctx, areq)
+	remoteSource, err := h.ah.UpdateRemoteSource(ctx, rsRef, areq)
 	if util.HTTPError(w, err) {
 		h.log.Err(err).Send()
 		return

--- a/internal/services/configstore/api/secret.go
+++ b/internal/services/configstore/api/secret.go
@@ -128,17 +128,26 @@ func (h *CreateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	var secret *types.Secret
+	var req *csapitypes.CreateUpdateSecretRequest
 	d := json.NewDecoder(r.Body)
-	if err := d.Decode(&secret); err != nil {
+	if err := d.Decode(&req); err != nil {
 		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
-	secret.Parent.Type = parentType
-	secret.Parent.ID = parentRef
+	areq := &action.CreateUpdateSecretRequest{
+		Name: req.Name,
+		Parent: types.Parent{
+			Type: parentType,
+			ID:   parentRef,
+		},
+		Type:             req.Type,
+		Data:             req.Data,
+		SecretProviderID: req.SecretProviderID,
+		Path:             req.Path,
+	}
 
-	secret, err = h.ah.CreateSecret(ctx, secret)
+	secret, err := h.ah.CreateSecret(ctx, areq)
 	if util.HTTPError(w, err) {
 		h.log.Err(err).Send()
 		return
@@ -169,21 +178,26 @@ func (h *UpdateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	var secret *types.Secret
+	var req *csapitypes.CreateUpdateSecretRequest
 	d := json.NewDecoder(r.Body)
-	if err := d.Decode(&secret); err != nil {
+	if err := d.Decode(&req); err != nil {
 		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
-	secret.Parent.Type = parentType
-	secret.Parent.ID = parentRef
-
-	areq := &action.UpdateSecretRequest{
-		SecretName: secretName,
-		Secret:     secret,
+	areq := &action.CreateUpdateSecretRequest{
+		Name: req.Name,
+		Parent: types.Parent{
+			Type: parentType,
+			ID:   parentRef,
+		},
+		Type:             req.Type,
+		Data:             req.Data,
+		SecretProviderID: req.SecretProviderID,
+		Path:             req.Path,
 	}
-	secret, err = h.ah.UpdateSecret(ctx, areq)
+
+	secret, err := h.ah.UpdateSecret(ctx, secretName, areq)
 	if util.HTTPError(w, err) {
 		h.log.Err(err).Send()
 		return

--- a/internal/services/configstore/api/variable.go
+++ b/internal/services/configstore/api/variable.go
@@ -101,17 +101,23 @@ func (h *CreateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	var variable *types.Variable
+	var req *csapitypes.CreateUpdateVariableRequest
 	d := json.NewDecoder(r.Body)
-	if err := d.Decode(&variable); err != nil {
+	if err := d.Decode(&req); err != nil {
 		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
-	variable.Parent.Type = parentType
-	variable.Parent.ID = parentRef
+	areq := &action.CreateUpdateVariableRequest{
+		Name: req.Name,
+		Parent: types.Parent{
+			Type: parentType,
+			ID:   parentRef,
+		},
+		Values: req.Values,
+	}
 
-	variable, err = h.ah.CreateVariable(ctx, variable)
+	variable, err := h.ah.CreateVariable(ctx, areq)
 	if util.HTTPError(w, err) {
 		h.log.Err(err).Send()
 		return
@@ -142,21 +148,23 @@ func (h *UpdateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	var variable *types.Variable
+	var req *csapitypes.CreateUpdateVariableRequest
 	d := json.NewDecoder(r.Body)
-	if err := d.Decode(&variable); err != nil {
+	if err := d.Decode(&req); err != nil {
 		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
 		return
 	}
 
-	variable.Parent.Type = parentType
-	variable.Parent.ID = parentRef
-
-	areq := &action.UpdateVariableRequest{
-		VariableName: variableName,
-		Variable:     variable,
+	areq := &action.CreateUpdateVariableRequest{
+		Name: req.Name,
+		Parent: types.Parent{
+			Type: parentType,
+			ID:   parentRef,
+		},
+		Values: req.Values,
 	}
-	variable, err = h.ah.UpdateVariable(ctx, areq)
+
+	variable, err := h.ah.UpdateVariable(ctx, variableName, areq)
 	if util.HTTPError(w, err) {
 		h.log.Err(err).Send()
 		return

--- a/internal/services/configstore/configstore_test.go
+++ b/internal/services/configstore/configstore_test.go
@@ -620,7 +620,7 @@ func TestProjectGroupsAndProjectsCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	org, err := cs.ah.CreateOrg(ctx, &types.Organization{Name: "org01", Visibility: types.VisibilityPublic})
+	org, err := cs.ah.CreateOrg(ctx, &action.CreateOrgRequest{Name: "org01", Visibility: types.VisibilityPublic})
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -629,37 +629,37 @@ func TestProjectGroupsAndProjectsCreate(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	t.Run("create a project in user root project group", func(t *testing.T) {
-		_, err := cs.ah.CreateProject(ctx, &types.Project{Name: "project01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
+		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
 	})
 	t.Run("create a project in org root project group", func(t *testing.T) {
-		_, err := cs.ah.CreateProject(ctx, &types.Project{Name: "project01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
+		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
 	})
 	t.Run("create a projectgroup in user root project group", func(t *testing.T) {
-		_, err := cs.ah.CreateProjectGroup(ctx, &types.ProjectGroup{Name: "projectgroup01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic})
+		_, err := cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "projectgroup01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic})
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
 	})
 	t.Run("create a projectgroup in org root project group", func(t *testing.T) {
-		_, err := cs.ah.CreateProjectGroup(ctx, &types.ProjectGroup{Name: "projectgroup01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic})
+		_, err := cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "projectgroup01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic})
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
 	})
 	t.Run("create a project in user non root project group with same name as a root project", func(t *testing.T) {
-		_, err := cs.ah.CreateProject(ctx, &types.Project{Name: "project01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
+		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
 	})
 	t.Run("create a project in org non root project group with same name as a root project", func(t *testing.T) {
-		_, err := cs.ah.CreateProject(ctx, &types.Project{Name: "project01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("org", org.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
+		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("org", org.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
@@ -668,7 +668,7 @@ func TestProjectGroupsAndProjectsCreate(t *testing.T) {
 	t.Run("create duplicated project in user root project group", func(t *testing.T) {
 		projectName := "project01"
 		expectedErr := fmt.Sprintf("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, projectName))
-		_, err := cs.ah.CreateProject(ctx, &types.Project{Name: projectName, Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
+		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: projectName, Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		if err.Error() != expectedErr {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
@@ -676,7 +676,7 @@ func TestProjectGroupsAndProjectsCreate(t *testing.T) {
 	t.Run("create duplicated project in org root project group", func(t *testing.T) {
 		projectName := "project01"
 		expectedErr := fmt.Sprintf("project with name %q, path %q already exists", projectName, path.Join("org", org.Name, projectName))
-		_, err := cs.ah.CreateProject(ctx, &types.Project{Name: projectName, Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
+		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: projectName, Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		if err.Error() != expectedErr {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
@@ -685,7 +685,7 @@ func TestProjectGroupsAndProjectsCreate(t *testing.T) {
 	t.Run("create duplicated project in user non root project group", func(t *testing.T) {
 		projectName := "project01"
 		expectedErr := fmt.Sprintf("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, "projectgroup01", projectName))
-		_, err := cs.ah.CreateProject(ctx, &types.Project{Name: projectName, Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
+		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: projectName, Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		if err.Error() != expectedErr {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
@@ -693,7 +693,7 @@ func TestProjectGroupsAndProjectsCreate(t *testing.T) {
 	t.Run("create duplicated project in org non root project group", func(t *testing.T) {
 		projectName := "project01"
 		expectedErr := fmt.Sprintf("project with name %q, path %q already exists", projectName, path.Join("org", org.Name, "projectgroup01", projectName))
-		_, err := cs.ah.CreateProject(ctx, &types.Project{Name: projectName, Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("org", org.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
+		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: projectName, Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("org", org.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		if err.Error() != expectedErr {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
@@ -701,14 +701,14 @@ func TestProjectGroupsAndProjectsCreate(t *testing.T) {
 
 	t.Run("create project in unexistent project group", func(t *testing.T) {
 		expectedErr := `project group with id "unexistentid" doesn't exist`
-		_, err := cs.ah.CreateProject(ctx, &types.Project{Name: "project01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: "unexistentid"}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
+		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: "unexistentid"}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		if err.Error() != expectedErr {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
 	})
 	t.Run("create project without parent id specified", func(t *testing.T) {
 		expectedErr := "project parent id required"
-		_, err := cs.ah.CreateProject(ctx, &types.Project{Name: "project01", Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
+		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		if err.Error() != expectedErr {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
@@ -724,7 +724,7 @@ func TestProjectGroupsAndProjectsCreate(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			wg.Add(1)
 			go func() {
-				_, _ = cs.ah.CreateProject(ctx, &types.Project{Name: "project02", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
+				_, _ = cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project02", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 			}()
 			wg.Done()
 		}
@@ -767,30 +767,26 @@ func TestProjectUpdate(t *testing.T) {
 	// TODO(sgotti) change the sleep with a real check that user is in readdb
 	time.Sleep(2 * time.Second)
 
-	_, err = cs.ah.CreateProjectGroup(ctx, &types.ProjectGroup{Name: "projectgroup01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic})
-	if err != nil {
+	if _, err := cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "projectgroup01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic}); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	p01 := &types.Project{Name: "project01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual}
-	_, err = cs.ah.CreateProject(ctx, p01)
-	if err != nil {
+	p01 := &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual}
+	if _, err := cs.ah.CreateProject(ctx, p01); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	p02 := &types.Project{Name: "project01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual}
-	_, err = cs.ah.CreateProject(ctx, p02)
-	if err != nil {
+	p02 := &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual}
+	if _, err := cs.ah.CreateProject(ctx, p02); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	p03 := &types.Project{Name: "project02", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual}
-	_, err = cs.ah.CreateProject(ctx, p03)
-	if err != nil {
+	p03 := &action.CreateUpdateProjectRequest{Name: "project02", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual}
+	if _, err := cs.ah.CreateProject(ctx, p03); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 
 	t.Run("rename project keeping same parent", func(t *testing.T) {
 		projectName := "project02"
 		p03.Name = "newproject02"
-		_, err := cs.ah.UpdateProject(ctx, &action.UpdateProjectRequest{ProjectRef: path.Join("user", user.Name, "projectgroup01", projectName), Project: p03})
+		_, err := cs.ah.UpdateProject(ctx, path.Join("user", user.Name, "projectgroup01", projectName), p03)
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
@@ -799,7 +795,7 @@ func TestProjectUpdate(t *testing.T) {
 		projectName := "project01"
 		expectedErr := fmt.Sprintf("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, projectName))
 		p02.Parent.ID = path.Join("user", user.Name)
-		_, err := cs.ah.UpdateProject(ctx, &action.UpdateProjectRequest{ProjectRef: path.Join("user", user.Name, "projectgroup01", projectName), Project: p02})
+		_, err := cs.ah.UpdateProject(ctx, path.Join("user", user.Name, "projectgroup01", projectName), p02)
 		if err.Error() != expectedErr {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
@@ -808,7 +804,7 @@ func TestProjectUpdate(t *testing.T) {
 		projectName := "project01"
 		p02.Name = "newproject01"
 		p02.Parent.ID = path.Join("user", user.Name)
-		_, err := cs.ah.UpdateProject(ctx, &action.UpdateProjectRequest{ProjectRef: path.Join("user", user.Name, "projectgroup01", projectName), Project: p02})
+		_, err := cs.ah.UpdateProject(ctx, path.Join("user", user.Name, "projectgroup01", projectName), p02)
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
@@ -839,63 +835,65 @@ func TestProjectGroupUpdate(t *testing.T) {
 	// TODO(sgotti) change the sleep with a real check that user is in readdb
 	time.Sleep(2 * time.Second)
 
-	pg01 := &types.ProjectGroup{Name: "pg01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic}
-	pg01, err = cs.ah.CreateProjectGroup(ctx, pg01)
+	rootPG, err := cs.ah.GetProjectGroup(ctx, path.Join("user", user.Name))
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	pg02 := &types.ProjectGroup{Name: "pg02", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic}
-	pg02, err = cs.ah.CreateProjectGroup(ctx, pg02)
-	if err != nil {
+
+	pg01req := &action.CreateUpdateProjectGroupRequest{Name: "pg01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic}
+	if _, err := cs.ah.CreateProjectGroup(ctx, pg01req); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	pg03 := &types.ProjectGroup{Name: "pg03", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic}
-	pg03, err = cs.ah.CreateProjectGroup(ctx, pg03)
-	if err != nil {
+	pg02req := &action.CreateUpdateProjectGroupRequest{Name: "pg02", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic}
+	if _, err := cs.ah.CreateProjectGroup(ctx, pg02req); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	pg04 := &types.ProjectGroup{Name: "pg01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name, "pg01")}, Visibility: types.VisibilityPublic}
-	_, err = cs.ah.CreateProjectGroup(ctx, pg04)
-	if err != nil {
+	pg03req := &action.CreateUpdateProjectGroupRequest{Name: "pg03", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic}
+	if _, err := cs.ah.CreateProjectGroup(ctx, pg03req); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	pg05 := &types.ProjectGroup{Name: "pg01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name, "pg02")}, Visibility: types.VisibilityPublic}
-	pg05, err = cs.ah.CreateProjectGroup(ctx, pg05)
-	if err != nil {
+	pg04req := &action.CreateUpdateProjectGroupRequest{Name: "pg01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name, "pg01")}, Visibility: types.VisibilityPublic}
+	if _, err := cs.ah.CreateProjectGroup(ctx, pg04req); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	pg05req := &action.CreateUpdateProjectGroupRequest{Name: "pg01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("user", user.Name, "pg02")}, Visibility: types.VisibilityPublic}
+	if _, err := cs.ah.CreateProjectGroup(ctx, pg05req); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 
 	t.Run("rename project group keeping same parent", func(t *testing.T) {
 		projectGroupName := "pg03"
-		pg03.Name = "newpg03"
-		_, err := cs.ah.UpdateProjectGroup(ctx, &action.UpdateProjectGroupRequest{ProjectGroupRef: path.Join("user", user.Name, projectGroupName), ProjectGroup: pg03})
-		if err != nil {
+		pg03req.Name = "newpg03"
+		if _, err := cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name, projectGroupName), pg03req); err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
 	})
 	t.Run("move project to project group having project with same name", func(t *testing.T) {
 		projectGroupName := "pg01"
 		expectedErr := fmt.Sprintf("project group with name %q, path %q already exists", projectGroupName, path.Join("user", user.Name, projectGroupName))
-		pg05.Parent.ID = path.Join("user", user.Name)
-		_, err := cs.ah.UpdateProjectGroup(ctx, &action.UpdateProjectGroupRequest{ProjectGroupRef: path.Join("user", user.Name, "pg02", projectGroupName), ProjectGroup: pg05})
+		pg05req.Parent.ID = path.Join("user", user.Name)
+		_, err := cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name, "pg02", projectGroupName), pg05req)
 		if err.Error() != expectedErr {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
 	})
-	t.Run("move project group to project group changing name", func(t *testing.T) {
+	t.Run("move project group to root project group changing name", func(t *testing.T) {
 		projectGroupName := "pg01"
-		pg05.Name = "newpg01"
-		pg05.Parent.ID = path.Join("user", user.Name)
-		_, err := cs.ah.UpdateProjectGroup(ctx, &action.UpdateProjectGroupRequest{ProjectGroupRef: path.Join("user", user.Name, "pg02", projectGroupName), ProjectGroup: pg05})
+		pg05req.Name = "newpg01"
+		pg05req.Parent.ID = path.Join("user", user.Name)
+		pg05, err := cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name, "pg02", projectGroupName), pg05req)
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
+		}
+		if pg05.Parent.ID != rootPG.ID {
+			t.Fatalf("expected project group parent id as root project group id")
 		}
 	})
 	t.Run("move project group inside itself", func(t *testing.T) {
 		projectGroupName := "pg02"
 		expectedErr := "cannot move project group inside itself or child project group"
-		pg02.Parent.ID = path.Join("user", user.Name, "pg02")
-		_, err := cs.ah.UpdateProjectGroup(ctx, &action.UpdateProjectGroupRequest{ProjectGroupRef: path.Join("user", user.Name, projectGroupName), ProjectGroup: pg02})
+		pg02req.Parent.ID = path.Join("user", user.Name, "pg02")
+		_, err := cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name, projectGroupName), pg02req)
 		if err.Error() != expectedErr {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
@@ -903,14 +901,28 @@ func TestProjectGroupUpdate(t *testing.T) {
 	t.Run("move project group to child project group", func(t *testing.T) {
 		projectGroupName := "pg01"
 		expectedErr := "cannot move project group inside itself or child project group"
-		pg01.Parent.ID = path.Join("user", user.Name, "pg01", "pg01")
-		_, err := cs.ah.UpdateProjectGroup(ctx, &action.UpdateProjectGroupRequest{ProjectGroupRef: path.Join("user", user.Name, projectGroupName), ProjectGroup: pg01})
+		pg01req.Parent.ID = path.Join("user", user.Name, "pg01", "pg01")
+		_, err := cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name, projectGroupName), pg01req)
 		if err.Error() != expectedErr {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
 	})
-	t.Run("change root project group parent", func(t *testing.T) {
+	t.Run("change root project group parent type", func(t *testing.T) {
+		var rootPG *types.ProjectGroup
+		rootPG, err := cs.ah.GetProjectGroup(ctx, path.Join("user", user.Name))
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		rootPG.Parent.Type = types.ConfigTypeProjectGroup
+		rootPG.Name = "rootpg"
 
+		expectedErr := "changing project group parent type isn't supported"
+		_, err = cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name), &action.CreateUpdateProjectGroupRequest{Name: rootPG.Name, Parent: rootPG.Parent, Visibility: rootPG.Visibility})
+		if err.Error() != expectedErr {
+			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
+		}
+	})
+	t.Run("change root project group parent id", func(t *testing.T) {
 		var rootPG *types.ProjectGroup
 		rootPG, err := cs.ah.GetProjectGroup(ctx, path.Join("user", user.Name))
 		if err != nil {
@@ -919,7 +931,7 @@ func TestProjectGroupUpdate(t *testing.T) {
 		rootPG.Parent.ID = path.Join("user", user.Name, "pg01")
 
 		expectedErr := "cannot change root project group parent type or id"
-		_, err = cs.ah.UpdateProjectGroup(ctx, &action.UpdateProjectGroupRequest{ProjectGroupRef: path.Join("user", user.Name), ProjectGroup: rootPG})
+		_, err = cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name), &action.CreateUpdateProjectGroupRequest{Name: rootPG.Name, Parent: rootPG.Parent, Visibility: rootPG.Visibility})
 		if err.Error() != expectedErr {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
@@ -933,7 +945,7 @@ func TestProjectGroupUpdate(t *testing.T) {
 		rootPG.Name = "rootpgnewname"
 
 		expectedErr := "project group name for root project group must be empty"
-		_, err = cs.ah.UpdateProjectGroup(ctx, &action.UpdateProjectGroupRequest{ProjectGroupRef: path.Join("user", user.Name), ProjectGroup: rootPG})
+		_, err = cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name), &action.CreateUpdateProjectGroupRequest{Name: rootPG.Name, Parent: rootPG.Parent, Visibility: rootPG.Visibility})
 		if err.Error() != expectedErr {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
@@ -946,8 +958,7 @@ func TestProjectGroupUpdate(t *testing.T) {
 		}
 		rootPG.Visibility = types.VisibilityPrivate
 
-		_, err = cs.ah.UpdateProjectGroup(ctx, &action.UpdateProjectGroupRequest{ProjectGroupRef: path.Join("user", user.Name), ProjectGroup: rootPG})
-		if err != nil {
+		if _, err := cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name), &action.CreateUpdateProjectGroupRequest{Name: rootPG.Name, Parent: rootPG.Parent, Visibility: rootPG.Visibility}); err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
 
@@ -977,7 +988,7 @@ func TestProjectGroupDelete(t *testing.T) {
 	// TODO(sgotti) change the sleep with a real check that all is ready
 	time.Sleep(2 * time.Second)
 
-	org, err := cs.ah.CreateOrg(ctx, &types.Organization{Name: "org01", Visibility: types.VisibilityPublic})
+	org, err := cs.ah.CreateOrg(ctx, &action.CreateOrgRequest{Name: "org01", Visibility: types.VisibilityPublic})
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -986,14 +997,13 @@ func TestProjectGroupDelete(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// create a projectgroup in org root project group
-	pg01, err := cs.ah.CreateProjectGroup(ctx, &types.ProjectGroup{Name: "projectgroup01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic})
+	pg01, err := cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "projectgroup01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic})
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 
 	// create a child projectgroup in org root project group
-	_, err = cs.ah.CreateProjectGroup(ctx, &types.ProjectGroup{Name: "subprojectgroup01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: pg01.ID}, Visibility: types.VisibilityPublic})
-	if err != nil {
+	if _, err := cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "subprojectgroup01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: pg01.ID}, Visibility: types.VisibilityPublic}); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 
@@ -1029,7 +1039,7 @@ func TestProjectGroupDeleteDontSeeOldChildObjects(t *testing.T) {
 	// TODO(sgotti) change the sleep with a real check that all is ready
 	time.Sleep(2 * time.Second)
 
-	org, err := cs.ah.CreateOrg(ctx, &types.Organization{Name: "org01", Visibility: types.VisibilityPublic})
+	org, err := cs.ah.CreateOrg(ctx, &action.CreateOrgRequest{Name: "org01", Visibility: types.VisibilityPublic})
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -1038,57 +1048,55 @@ func TestProjectGroupDeleteDontSeeOldChildObjects(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// create a projectgroup in org root project group
-	pg01, err := cs.ah.CreateProjectGroup(ctx, &types.ProjectGroup{Name: "projectgroup01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic})
+	pg01, err := cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "projectgroup01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic})
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 
 	// create a child projectgroup in org root project group
-	spg01, err := cs.ah.CreateProjectGroup(ctx, &types.ProjectGroup{Name: "subprojectgroup01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: pg01.ID}, Visibility: types.VisibilityPublic})
+	spg01, err := cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "subprojectgroup01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: pg01.ID}, Visibility: types.VisibilityPublic})
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 
 	// create a project inside child projectgroup
-	project, err := cs.ah.CreateProject(ctx, &types.Project{Name: "project01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: spg01.ID}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
+	project, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: spg01.ID}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 
 	// create project secret
-	_, err = cs.ah.CreateSecret(ctx, &types.Secret{Name: "secret01", Parent: types.Parent{Type: types.ConfigTypeProject, ID: project.ID}, Type: types.SecretTypeInternal, Data: map[string]string{"secret01": "secretvar01"}})
-	if err != nil {
+	if _, err := cs.ah.CreateSecret(ctx, &action.CreateUpdateSecretRequest{Name: "secret01", Parent: types.Parent{Type: types.ConfigTypeProject, ID: project.ID}, Type: types.SecretTypeInternal, Data: map[string]string{"secret01": "secretvar01"}}); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	// create project variable
-	_, err = cs.ah.CreateVariable(ctx, &types.Variable{Name: "variable01", Parent: types.Parent{Type: types.ConfigTypeProject, ID: project.ID}, Values: []types.VariableValue{{SecretName: "secret01", SecretVar: "secretvar01"}}})
-	if err != nil {
+	if _, err := cs.ah.CreateVariable(ctx, &action.CreateUpdateVariableRequest{Name: "variable01", Parent: types.Parent{Type: types.ConfigTypeProject, ID: project.ID}, Values: []types.VariableValue{{SecretName: "secret01", SecretVar: "secretvar01"}}}); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 
 	// delete projectgroup
-	if err = cs.ah.DeleteProjectGroup(ctx, pg01.ID); err != nil {
+	if err := cs.ah.DeleteProjectGroup(ctx, pg01.ID); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 
 	// recreate the same hierarchj using the paths
-	pg01, err = cs.ah.CreateProjectGroup(ctx, &types.ProjectGroup{Name: "projectgroup01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic})
+	pg01, err = cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "projectgroup01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic})
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	spg01, err = cs.ah.CreateProjectGroup(ctx, &types.ProjectGroup{Name: "subprojectgroup01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("org", org.Name, pg01.Name)}, Visibility: types.VisibilityPublic})
+	spg01, err = cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "subprojectgroup01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("org", org.Name, pg01.Name)}, Visibility: types.VisibilityPublic})
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	project, err = cs.ah.CreateProject(ctx, &types.Project{Name: "project01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("org", org.Name, pg01.Name, spg01.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
+	project, err = cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Type: types.ConfigTypeProjectGroup, ID: path.Join("org", org.Name, pg01.Name, spg01.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	secret, err := cs.ah.CreateSecret(ctx, &types.Secret{Name: "secret01", Parent: types.Parent{Type: types.ConfigTypeProject, ID: path.Join("org", org.Name, pg01.Name, spg01.Name, project.Name)}, Type: types.SecretTypeInternal, Data: map[string]string{"secret01": "secretvar01"}})
+	secret, err := cs.ah.CreateSecret(ctx, &action.CreateUpdateSecretRequest{Name: "secret01", Parent: types.Parent{Type: types.ConfigTypeProject, ID: path.Join("org", org.Name, pg01.Name, spg01.Name, project.Name)}, Type: types.SecretTypeInternal, Data: map[string]string{"secret01": "secretvar01"}})
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	variable, err := cs.ah.CreateVariable(ctx, &types.Variable{Name: "variable01", Parent: types.Parent{Type: types.ConfigTypeProject, ID: path.Join("org", org.Name, pg01.Name, spg01.Name, project.Name)}, Values: []types.VariableValue{{SecretName: "secret01", SecretVar: "secretvar01"}}})
+	variable, err := cs.ah.CreateVariable(ctx, &action.CreateUpdateVariableRequest{Name: "variable01", Parent: types.Parent{Type: types.ConfigTypeProject, ID: path.Join("org", org.Name, pg01.Name, spg01.Name, project.Name)}, Values: []types.VariableValue{{SecretName: "secret01", SecretVar: "secretvar01"}}})
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -1162,7 +1170,7 @@ func TestOrgMembers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	org, err := cs.ah.CreateOrg(ctx, &types.Organization{Name: "org01", Visibility: types.VisibilityPublic, CreatorUserID: user.ID})
+	org, err := cs.ah.CreateOrg(ctx, &action.CreateOrgRequest{Name: "org01", Visibility: types.VisibilityPublic, CreatorUserID: user.ID})
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -1188,7 +1196,7 @@ func TestOrgMembers(t *testing.T) {
 
 	orgs := []*types.Organization{}
 	for i := 0; i < 10; i++ {
-		org, err := cs.ah.CreateOrg(ctx, &types.Organization{Name: fmt.Sprintf("org%d", i), Visibility: types.VisibilityPublic, CreatorUserID: user.ID})
+		org, err := cs.ah.CreateOrg(ctx, &action.CreateOrgRequest{Name: fmt.Sprintf("org%d", i), Visibility: types.VisibilityPublic, CreatorUserID: user.ID})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -1241,7 +1249,7 @@ func TestRemoteSource(t *testing.T) {
 		{
 			name: "test create remote source",
 			f: func(ctx context.Context, t *testing.T, cs *Configstore) {
-				rs := &types.RemoteSource{
+				rsreq := &action.CreateUpdateRemoteSourceRequest{
 					Name:               "rs01",
 					APIURL:             "https://api.example.com",
 					Type:               types.RemoteSourceTypeGitea,
@@ -1249,8 +1257,7 @@ func TestRemoteSource(t *testing.T) {
 					Oauth2ClientID:     "clientid",
 					Oauth2ClientSecret: "clientsecret",
 				}
-				_, err := cs.ah.CreateRemoteSource(ctx, rs)
-				if err != nil {
+				if _, err := cs.ah.CreateRemoteSource(ctx, rsreq); err != nil {
 					t.Fatalf("unexpected err: %v", err)
 				}
 			},
@@ -1258,7 +1265,7 @@ func TestRemoteSource(t *testing.T) {
 		{
 			name: "test create duplicate remote source",
 			f: func(ctx context.Context, t *testing.T, cs *Configstore) {
-				rs := &types.RemoteSource{
+				rsreq := &action.CreateUpdateRemoteSourceRequest{
 					Name:               "rs01",
 					APIURL:             "https://api.example.com",
 					Type:               types.RemoteSourceTypeGitea,
@@ -1266,13 +1273,12 @@ func TestRemoteSource(t *testing.T) {
 					Oauth2ClientID:     "clientid",
 					Oauth2ClientSecret: "clientsecret",
 				}
-				rs, err := cs.ah.CreateRemoteSource(ctx, rs)
-				if err != nil {
+				if _, err := cs.ah.CreateRemoteSource(ctx, rsreq); err != nil {
 					t.Fatalf("unexpected err: %v", err)
 				}
 
 				expectedError := util.NewAPIError(util.ErrBadRequest, errors.Errorf(`remotesource "rs01" already exists`))
-				_, err = cs.ah.CreateRemoteSource(ctx, rs)
+				_, err := cs.ah.CreateRemoteSource(ctx, rsreq)
 				if err.Error() != expectedError.Error() {
 					t.Fatalf("expected err: %v, got err: %v", expectedError.Error(), err.Error())
 				}
@@ -1281,7 +1287,7 @@ func TestRemoteSource(t *testing.T) {
 		{
 			name: "test rename remote source",
 			f: func(ctx context.Context, t *testing.T, cs *Configstore) {
-				rs := &types.RemoteSource{
+				rsreq := &action.CreateUpdateRemoteSourceRequest{
 					Name:               "rs01",
 					APIURL:             "https://api.example.com",
 					Type:               types.RemoteSourceTypeGitea,
@@ -1289,18 +1295,12 @@ func TestRemoteSource(t *testing.T) {
 					Oauth2ClientID:     "clientid",
 					Oauth2ClientSecret: "clientsecret",
 				}
-				rs, err := cs.ah.CreateRemoteSource(ctx, rs)
-				if err != nil {
+				if _, err := cs.ah.CreateRemoteSource(ctx, rsreq); err != nil {
 					t.Fatalf("unexpected err: %v", err)
 				}
 
-				rs.Name = "rs02"
-				req := &action.UpdateRemoteSourceRequest{
-					RemoteSourceRef: "rs01",
-					RemoteSource:    rs,
-				}
-				_, err = cs.ah.UpdateRemoteSource(ctx, req)
-				if err != nil {
+				rsreq.Name = "rs02"
+				if _, err := cs.ah.UpdateRemoteSource(ctx, "rs01", rsreq); err != nil {
 					t.Fatalf("unexpected err: %v", err)
 				}
 			},
@@ -1308,7 +1308,7 @@ func TestRemoteSource(t *testing.T) {
 		{
 			name: "test update remote source keeping same name",
 			f: func(ctx context.Context, t *testing.T, cs *Configstore) {
-				rs01 := &types.RemoteSource{
+				rsreq := &action.CreateUpdateRemoteSourceRequest{
 					Name:               "rs01",
 					APIURL:             "https://api.example.com",
 					Type:               types.RemoteSourceTypeGitea,
@@ -1316,18 +1316,12 @@ func TestRemoteSource(t *testing.T) {
 					Oauth2ClientID:     "clientid",
 					Oauth2ClientSecret: "clientsecret",
 				}
-				rs01, err := cs.ah.CreateRemoteSource(ctx, rs01)
-				if err != nil {
+				if _, err := cs.ah.CreateRemoteSource(ctx, rsreq); err != nil {
 					t.Fatalf("unexpected err: %v", err)
 				}
 
-				rs01.APIURL = "https://api01.example.com"
-				req := &action.UpdateRemoteSourceRequest{
-					RemoteSourceRef: "rs01",
-					RemoteSource:    rs01,
-				}
-				_, err = cs.ah.UpdateRemoteSource(ctx, req)
-				if err != nil {
+				rsreq.APIURL = "https://api01.example.com"
+				if _, err := cs.ah.UpdateRemoteSource(ctx, "rs01", rsreq); err != nil {
 					t.Fatalf("unexpected err: %v", err)
 				}
 			},
@@ -1335,7 +1329,7 @@ func TestRemoteSource(t *testing.T) {
 		{
 			name: "test rename remote source to an already existing name",
 			f: func(ctx context.Context, t *testing.T, cs *Configstore) {
-				rs01 := &types.RemoteSource{
+				rs01req := &action.CreateUpdateRemoteSourceRequest{
 					Name:               "rs01",
 					APIURL:             "https://api.example.com",
 					Type:               types.RemoteSourceTypeGitea,
@@ -1343,12 +1337,11 @@ func TestRemoteSource(t *testing.T) {
 					Oauth2ClientID:     "clientid",
 					Oauth2ClientSecret: "clientsecret",
 				}
-				rs01, err := cs.ah.CreateRemoteSource(ctx, rs01)
-				if err != nil {
+				if _, err := cs.ah.CreateRemoteSource(ctx, rs01req); err != nil {
 					t.Fatalf("unexpected err: %v", err)
 				}
 
-				rs02 := &types.RemoteSource{
+				rs02req := &action.CreateUpdateRemoteSourceRequest{
 					Name:               "rs02",
 					APIURL:             "https://api.example.com",
 					Type:               types.RemoteSourceTypeGitea,
@@ -1356,17 +1349,13 @@ func TestRemoteSource(t *testing.T) {
 					Oauth2ClientID:     "clientid",
 					Oauth2ClientSecret: "clientsecret",
 				}
-				if _, err = cs.ah.CreateRemoteSource(ctx, rs02); err != nil {
+				if _, err := cs.ah.CreateRemoteSource(ctx, rs02req); err != nil {
 					t.Fatalf("unexpected err: %v", err)
 				}
 
 				expectedError := util.NewAPIError(util.ErrBadRequest, errors.Errorf(`remotesource "rs02" already exists`))
-				rs01.Name = "rs02"
-				req := &action.UpdateRemoteSourceRequest{
-					RemoteSourceRef: "rs01",
-					RemoteSource:    rs01,
-				}
-				_, err = cs.ah.UpdateRemoteSource(ctx, req)
+				rs01req.Name = "rs02"
+				_, err := cs.ah.UpdateRemoteSource(ctx, "rs01", rs01req)
 				if err.Error() != expectedError.Error() {
 					t.Fatalf("expected err: %v, got err: %v", expectedError.Error(), err.Error())
 				}

--- a/internal/services/gateway/action/org.go
+++ b/internal/services/gateway/action/org.go
@@ -20,6 +20,7 @@ import (
 	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
+	csapitypes "agola.io/agola/services/configstore/api/types"
 	cstypes "agola.io/agola/services/configstore/types"
 )
 
@@ -98,16 +99,16 @@ func (h *ActionHandler) CreateOrg(ctx context.Context, req *CreateOrgRequest) (*
 		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid organization name %q", req.Name))
 	}
 
-	org := &cstypes.Organization{
+	creq := &csapitypes.CreateOrgRequest{
 		Name:       req.Name,
 		Visibility: req.Visibility,
 	}
 	if req.CreatorUserID != "" {
-		org.CreatorUserID = req.CreatorUserID
+		creq.CreatorUserID = req.CreatorUserID
 	}
 
 	h.log.Info().Msgf("creating organization")
-	org, _, err := h.configstoreClient.CreateOrg(ctx, org)
+	org, _, err := h.configstoreClient.CreateOrg(ctx, creq)
 	if err != nil {
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create organization"))
 	}

--- a/internal/services/gateway/action/project.go
+++ b/internal/services/gateway/action/project.go
@@ -135,7 +135,7 @@ func (h *ActionHandler) CreateProject(ctx context.Context, req *CreateProjectReq
 		return nil, errors.Wrapf(err, "failed to generate ssh key pair")
 	}
 
-	p := &cstypes.Project{
+	creq := &csapitypes.CreateUpdateProjectRequest{
 		Name: req.Name,
 		Parent: cstypes.Parent{
 			Type: cstypes.ConfigTypeProjectGroup,
@@ -147,13 +147,13 @@ func (h *ActionHandler) CreateProject(ctx context.Context, req *CreateProjectReq
 		LinkedAccountID:            la.ID,
 		RepositoryID:               repo.ID,
 		RepositoryPath:             req.RepoPath,
-		SkipSSHHostKeyCheck:        req.SkipSSHHostKeyCheck,
 		SSHPrivateKey:              string(privateKey),
+		SkipSSHHostKeyCheck:        req.SkipSSHHostKeyCheck,
 		PassVarsToForkedPR:         req.PassVarsToForkedPR,
 	}
 
 	h.log.Info().Msgf("creating project")
-	rp, _, err := h.configstoreClient.CreateProject(ctx, p)
+	rp, _, err := h.configstoreClient.CreateProject(ctx, creq)
 	if err != nil {
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create project"))
 	}
@@ -213,8 +213,22 @@ func (h *ActionHandler) UpdateProject(ctx context.Context, projectRef string, re
 		p.PassVarsToForkedPR = *req.PassVarsToForkedPR
 	}
 
+	creq := &csapitypes.CreateUpdateProjectRequest{
+		Name:                       p.Name,
+		Parent:                     p.Parent,
+		Visibility:                 p.Visibility,
+		RemoteRepositoryConfigType: p.RemoteRepositoryConfigType,
+		RemoteSourceID:             p.RemoteSourceID,
+		LinkedAccountID:            p.LinkedAccountID,
+		RepositoryID:               p.RepositoryID,
+		RepositoryPath:             p.RepositoryPath,
+		SSHPrivateKey:              p.SSHPrivateKey,
+		SkipSSHHostKeyCheck:        p.SkipSSHHostKeyCheck,
+		PassVarsToForkedPR:         p.PassVarsToForkedPR,
+	}
+
 	h.log.Info().Msgf("updating project")
-	rp, _, err := h.configstoreClient.UpdateProject(ctx, p.ID, p.Project)
+	rp, _, err := h.configstoreClient.UpdateProject(ctx, p.ID, creq)
 	if err != nil {
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to update project"))
 	}
@@ -272,8 +286,22 @@ func (h *ActionHandler) ProjectUpdateRepoLinkedAccount(ctx context.Context, proj
 
 	p.LinkedAccountID = la.ID
 
+	creq := &csapitypes.CreateUpdateProjectRequest{
+		Name:                       p.Name,
+		Parent:                     p.Parent,
+		Visibility:                 p.Visibility,
+		RemoteRepositoryConfigType: p.RemoteRepositoryConfigType,
+		RemoteSourceID:             p.RemoteSourceID,
+		LinkedAccountID:            p.LinkedAccountID,
+		RepositoryID:               p.RepositoryID,
+		RepositoryPath:             p.RepositoryPath,
+		SSHPrivateKey:              p.SSHPrivateKey,
+		SkipSSHHostKeyCheck:        p.SkipSSHHostKeyCheck,
+		PassVarsToForkedPR:         p.PassVarsToForkedPR,
+	}
+
 	h.log.Info().Msgf("updating project")
-	rp, _, err := h.configstoreClient.UpdateProject(ctx, p.ID, p.Project)
+	rp, _, err := h.configstoreClient.UpdateProject(ctx, p.ID, creq)
 	if err != nil {
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to update project"))
 	}

--- a/internal/services/gateway/action/projectgroup.go
+++ b/internal/services/gateway/action/projectgroup.go
@@ -84,7 +84,7 @@ func (h *ActionHandler) CreateProjectGroup(ctx context.Context, req *CreateProje
 		parentRef = path.Join("user", user.Name)
 	}
 
-	p := &cstypes.ProjectGroup{
+	creq := &csapitypes.CreateUpdateProjectGroupRequest{
 		Name: req.Name,
 		Parent: cstypes.Parent{
 			Type: cstypes.ConfigTypeProjectGroup,
@@ -94,7 +94,7 @@ func (h *ActionHandler) CreateProjectGroup(ctx context.Context, req *CreateProje
 	}
 
 	h.log.Info().Msgf("creating projectGroup")
-	rp, _, err := h.configstoreClient.CreateProjectGroup(ctx, p)
+	rp, _, err := h.configstoreClient.CreateProjectGroup(ctx, creq)
 	if err != nil {
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create projectGroup"))
 	}
@@ -134,8 +134,14 @@ func (h *ActionHandler) UpdateProjectGroup(ctx context.Context, projectGroupRef 
 		pg.Visibility = *req.Visibility
 	}
 
+	creq := &csapitypes.CreateUpdateProjectGroupRequest{
+		Name:       pg.Name,
+		Parent:     pg.Parent,
+		Visibility: pg.Visibility,
+	}
+
 	h.log.Info().Msgf("updating project group")
-	rp, _, err := h.configstoreClient.UpdateProjectGroup(ctx, pg.ID, pg.ProjectGroup)
+	rp, _, err := h.configstoreClient.UpdateProjectGroup(ctx, pg.ID, creq)
 	if err != nil {
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to update project group"))
 	}

--- a/internal/services/gateway/action/remotesource.go
+++ b/internal/services/gateway/action/remotesource.go
@@ -20,6 +20,7 @@ import (
 	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
+	csapitypes "agola.io/agola/services/configstore/api/types"
 	cstypes "agola.io/agola/services/configstore/types"
 )
 
@@ -95,7 +96,7 @@ func (h *ActionHandler) CreateRemoteSource(ctx context.Context, req *CreateRemot
 		}
 	}
 
-	rs := &cstypes.RemoteSource{
+	creq := &csapitypes.CreateUpdateRemoteSourceRequest{
 		Name:                req.Name,
 		Type:                cstypes.RemoteSourceType(req.Type),
 		AuthType:            cstypes.RemoteSourceAuthType(req.AuthType),
@@ -110,7 +111,7 @@ func (h *ActionHandler) CreateRemoteSource(ctx context.Context, req *CreateRemot
 	}
 
 	h.log.Info().Msgf("creating remotesource")
-	rs, _, err := h.configstoreClient.CreateRemoteSource(ctx, rs)
+	rs, _, err := h.configstoreClient.CreateRemoteSource(ctx, creq)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create remotesource")
 	}
@@ -171,8 +172,22 @@ func (h *ActionHandler) UpdateRemoteSource(ctx context.Context, req *UpdateRemot
 		rs.LoginEnabled = req.LoginEnabled
 	}
 
+	creq := &csapitypes.CreateUpdateRemoteSourceRequest{
+		Name:                rs.Name,
+		Type:                rs.Type,
+		AuthType:            rs.AuthType,
+		APIURL:              rs.APIURL,
+		SkipVerify:          rs.SkipVerify,
+		Oauth2ClientID:      rs.Oauth2ClientID,
+		Oauth2ClientSecret:  rs.Oauth2ClientSecret,
+		SSHHostKey:          rs.SSHHostKey,
+		SkipSSHHostKeyCheck: rs.SkipSSHHostKeyCheck,
+		RegistrationEnabled: rs.RegistrationEnabled,
+		LoginEnabled:        rs.LoginEnabled,
+	}
+
 	h.log.Info().Msgf("updating remotesource")
-	rs, _, err = h.configstoreClient.UpdateRemoteSource(ctx, req.RemoteSourceRef, rs)
+	rs, _, err = h.configstoreClient.UpdateRemoteSource(ctx, req.RemoteSourceRef, creq)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to update remotesource")
 	}

--- a/internal/services/gateway/action/secret.go
+++ b/internal/services/gateway/action/secret.go
@@ -82,7 +82,7 @@ func (h *ActionHandler) CreateSecret(ctx context.Context, req *CreateSecretReque
 		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid secret name %q", req.Name))
 	}
 
-	s := &cstypes.Secret{
+	creq := &csapitypes.CreateUpdateSecretRequest{
 		Name: req.Name,
 		Type: req.Type,
 		Data: req.Data,
@@ -92,10 +92,10 @@ func (h *ActionHandler) CreateSecret(ctx context.Context, req *CreateSecretReque
 	switch req.ParentType {
 	case cstypes.ConfigTypeProjectGroup:
 		h.log.Info().Msgf("creating project group secret")
-		rs, _, err = h.configstoreClient.CreateProjectGroupSecret(ctx, req.ParentRef, s)
+		rs, _, err = h.configstoreClient.CreateProjectGroupSecret(ctx, req.ParentRef, creq)
 	case cstypes.ConfigTypeProject:
 		h.log.Info().Msgf("creating project secret")
-		rs, _, err = h.configstoreClient.CreateProjectSecret(ctx, req.ParentRef, s)
+		rs, _, err = h.configstoreClient.CreateProjectSecret(ctx, req.ParentRef, creq)
 	}
 	if err != nil {
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create secret"))
@@ -136,7 +136,7 @@ func (h *ActionHandler) UpdateSecret(ctx context.Context, req *UpdateSecretReque
 		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid secret name %q", req.Name))
 	}
 
-	s := &cstypes.Secret{
+	creq := &csapitypes.CreateUpdateSecretRequest{
 		Name: req.Name,
 		Type: req.Type,
 		Data: req.Data,
@@ -146,10 +146,10 @@ func (h *ActionHandler) UpdateSecret(ctx context.Context, req *UpdateSecretReque
 	switch req.ParentType {
 	case cstypes.ConfigTypeProjectGroup:
 		h.log.Info().Msgf("updating project group secret")
-		rs, _, err = h.configstoreClient.UpdateProjectGroupSecret(ctx, req.ParentRef, req.SecretName, s)
+		rs, _, err = h.configstoreClient.UpdateProjectGroupSecret(ctx, req.ParentRef, req.SecretName, creq)
 	case cstypes.ConfigTypeProject:
 		h.log.Info().Msgf("updating project secret")
-		rs, _, err = h.configstoreClient.UpdateProjectSecret(ctx, req.ParentRef, req.SecretName, s)
+		rs, _, err = h.configstoreClient.UpdateProjectSecret(ctx, req.ParentRef, req.SecretName, creq)
 	}
 	if err != nil {
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to update secret"))

--- a/internal/services/gateway/action/variable.go
+++ b/internal/services/gateway/action/variable.go
@@ -93,12 +93,8 @@ func (h *ActionHandler) CreateVariable(ctx context.Context, req *CreateVariableR
 		return nil, nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("empty variable values"))
 	}
 
-	v := &cstypes.Variable{
-		Name: req.Name,
-		Parent: cstypes.Parent{
-			Type: req.ParentType,
-			ID:   req.ParentRef,
-		},
+	creq := &csapitypes.CreateUpdateVariableRequest{
+		Name:   req.Name,
 		Values: req.Values,
 	}
 
@@ -114,7 +110,7 @@ func (h *ActionHandler) CreateVariable(ctx context.Context, req *CreateVariableR
 		}
 
 		h.log.Info().Msgf("creating project group variable")
-		rv, _, err = h.configstoreClient.CreateProjectGroupVariable(ctx, req.ParentRef, v)
+		rv, _, err = h.configstoreClient.CreateProjectGroupVariable(ctx, req.ParentRef, creq)
 		if err != nil {
 			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create variable"))
 		}
@@ -126,7 +122,7 @@ func (h *ActionHandler) CreateVariable(ctx context.Context, req *CreateVariableR
 		}
 
 		h.log.Info().Msgf("creating project variable")
-		rv, _, err = h.configstoreClient.CreateProjectVariable(ctx, req.ParentRef, v)
+		rv, _, err = h.configstoreClient.CreateProjectVariable(ctx, req.ParentRef, creq)
 		if err != nil {
 			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create variable"))
 		}
@@ -164,12 +160,8 @@ func (h *ActionHandler) UpdateVariable(ctx context.Context, req *UpdateVariableR
 		return nil, nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("empty variable values"))
 	}
 
-	v := &cstypes.Variable{
-		Name: req.Name,
-		Parent: cstypes.Parent{
-			Type: req.ParentType,
-			ID:   req.ParentRef,
-		},
+	creq := &csapitypes.CreateUpdateVariableRequest{
+		Name:   req.Name,
 		Values: req.Values,
 	}
 
@@ -185,7 +177,7 @@ func (h *ActionHandler) UpdateVariable(ctx context.Context, req *UpdateVariableR
 		}
 
 		h.log.Info().Msgf("creating project group variable")
-		rv, _, err = h.configstoreClient.UpdateProjectGroupVariable(ctx, req.ParentRef, req.VariableName, v)
+		rv, _, err = h.configstoreClient.UpdateProjectGroupVariable(ctx, req.ParentRef, req.VariableName, creq)
 		if err != nil {
 			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create variable"))
 		}
@@ -197,7 +189,7 @@ func (h *ActionHandler) UpdateVariable(ctx context.Context, req *UpdateVariableR
 		}
 
 		h.log.Info().Msgf("creating project variable")
-		rv, _, err = h.configstoreClient.UpdateProjectVariable(ctx, req.ParentRef, req.VariableName, v)
+		rv, _, err = h.configstoreClient.UpdateProjectVariable(ctx, req.ParentRef, req.VariableName, creq)
 		if err != nil {
 			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create variable"))
 		}

--- a/services/configstore/api/types/org.go
+++ b/services/configstore/api/types/org.go
@@ -18,6 +18,12 @@ import (
 	cstypes "agola.io/agola/services/configstore/types"
 )
 
+type CreateOrgRequest struct {
+	Name          string
+	Visibility    cstypes.Visibility
+	CreatorUserID string
+}
+
 type AddOrgMemberRequest struct {
 	Role cstypes.MemberRole
 }

--- a/services/configstore/api/types/project.go
+++ b/services/configstore/api/types/project.go
@@ -18,6 +18,20 @@ import (
 	cstypes "agola.io/agola/services/configstore/types"
 )
 
+type CreateUpdateProjectRequest struct {
+	Name                       string
+	Parent                     cstypes.Parent
+	Visibility                 cstypes.Visibility
+	RemoteRepositoryConfigType cstypes.RemoteRepositoryConfigType
+	RemoteSourceID             string
+	LinkedAccountID            string
+	RepositoryID               string
+	RepositoryPath             string
+	SSHPrivateKey              string
+	SkipSSHHostKeyCheck        bool
+	PassVarsToForkedPR         bool
+}
+
 // Project augments cstypes.Project with dynamic data
 type Project struct {
 	*cstypes.Project

--- a/services/configstore/api/types/remotesource.go
+++ b/services/configstore/api/types/remotesource.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Sorint.lab
+// Copyright 2022 Sorint.lab
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,20 +18,16 @@ import (
 	cstypes "agola.io/agola/services/configstore/types"
 )
 
-type CreateUpdateProjectGroupRequest struct {
-	Name       string
-	Parent     cstypes.Parent
-	Visibility cstypes.Visibility
-}
-
-// ProjectGroup augments cstypes.ProjectGroup with dynamic data
-type ProjectGroup struct {
-	*cstypes.ProjectGroup
-
-	// dynamic data
-	OwnerType        cstypes.ConfigType
-	OwnerID          string
-	Path             string
-	ParentPath       string
-	GlobalVisibility cstypes.Visibility
+type CreateUpdateRemoteSourceRequest struct {
+	Name                string
+	APIURL              string
+	SkipVerify          bool
+	Type                cstypes.RemoteSourceType
+	AuthType            cstypes.RemoteSourceAuthType
+	Oauth2ClientID      string
+	Oauth2ClientSecret  string
+	SSHHostKey          string
+	SkipSSHHostKeyCheck bool
+	RegistrationEnabled *bool
+	LoginEnabled        *bool
 }

--- a/services/configstore/api/types/secret.go
+++ b/services/configstore/api/types/secret.go
@@ -18,6 +18,14 @@ import (
 	cstypes "agola.io/agola/services/configstore/types"
 )
 
+type CreateUpdateSecretRequest struct {
+	Name             string
+	Type             cstypes.SecretType
+	Data             map[string]string
+	SecretProviderID string
+	Path             string
+}
+
 // Secret augments cstypes.Secret with dynamic data
 type Secret struct {
 	*cstypes.Secret

--- a/services/configstore/api/types/variable.go
+++ b/services/configstore/api/types/variable.go
@@ -18,6 +18,11 @@ import (
 	cstypes "agola.io/agola/services/configstore/types"
 )
 
+type CreateUpdateVariableRequest struct {
+	Name   string
+	Values []cstypes.VariableValue
+}
+
 // Variable augments cstypes.Variable with dynamic data
 type Variable struct {
 	*cstypes.Variable

--- a/services/configstore/client/client.go
+++ b/services/configstore/client/client.go
@@ -115,25 +115,25 @@ func (c *Client) GetProjectGroupProjects(ctx context.Context, projectGroupRef st
 	return projects, resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateProjectGroup(ctx context.Context, projectGroup *cstypes.ProjectGroup) (*csapitypes.ProjectGroup, *http.Response, error) {
-	pj, err := json.Marshal(projectGroup)
+func (c *Client) CreateProjectGroup(ctx context.Context, req *csapitypes.CreateUpdateProjectGroupRequest) (*csapitypes.ProjectGroup, *http.Response, error) {
+	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
 
 	resProjectGroup := new(csapitypes.ProjectGroup)
-	resp, err := c.getParsedResponse(ctx, "POST", "/projectgroups", nil, jsonContent, bytes.NewReader(pj), resProjectGroup)
+	resp, err := c.getParsedResponse(ctx, "POST", "/projectgroups", nil, jsonContent, bytes.NewReader(reqj), resProjectGroup)
 	return resProjectGroup, resp, errors.WithStack(err)
 }
 
-func (c *Client) UpdateProjectGroup(ctx context.Context, projectGroupRef string, projectGroup *cstypes.ProjectGroup) (*csapitypes.ProjectGroup, *http.Response, error) {
-	pj, err := json.Marshal(projectGroup)
+func (c *Client) UpdateProjectGroup(ctx context.Context, projectGroupRef string, req *csapitypes.CreateUpdateProjectGroupRequest) (*csapitypes.ProjectGroup, *http.Response, error) {
+	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
 
 	resProjectGroup := new(csapitypes.ProjectGroup)
-	resp, err := c.getParsedResponse(ctx, "PUT", fmt.Sprintf("/projectgroups/%s", url.PathEscape(projectGroupRef)), nil, jsonContent, bytes.NewReader(pj), resProjectGroup)
+	resp, err := c.getParsedResponse(ctx, "PUT", fmt.Sprintf("/projectgroups/%s", url.PathEscape(projectGroupRef)), nil, jsonContent, bytes.NewReader(reqj), resProjectGroup)
 	return resProjectGroup, resp, errors.WithStack(err)
 }
 
@@ -147,25 +147,25 @@ func (c *Client) GetProject(ctx context.Context, projectRef string) (*csapitypes
 	return project, resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateProject(ctx context.Context, project *cstypes.Project) (*csapitypes.Project, *http.Response, error) {
-	pj, err := json.Marshal(project)
+func (c *Client) CreateProject(ctx context.Context, req *csapitypes.CreateUpdateProjectRequest) (*csapitypes.Project, *http.Response, error) {
+	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
 
 	resProject := new(csapitypes.Project)
-	resp, err := c.getParsedResponse(ctx, "POST", "/projects", nil, jsonContent, bytes.NewReader(pj), resProject)
+	resp, err := c.getParsedResponse(ctx, "POST", "/projects", nil, jsonContent, bytes.NewReader(reqj), resProject)
 	return resProject, resp, errors.WithStack(err)
 }
 
-func (c *Client) UpdateProject(ctx context.Context, projectRef string, project *cstypes.Project) (*csapitypes.Project, *http.Response, error) {
-	pj, err := json.Marshal(project)
+func (c *Client) UpdateProject(ctx context.Context, projectRef string, req *csapitypes.CreateUpdateProjectRequest) (*csapitypes.Project, *http.Response, error) {
+	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
 
 	resProject := new(csapitypes.Project)
-	resp, err := c.getParsedResponse(ctx, "PUT", fmt.Sprintf("/projects/%s", url.PathEscape(projectRef)), nil, jsonContent, bytes.NewReader(pj), resProject)
+	resp, err := c.getParsedResponse(ctx, "PUT", fmt.Sprintf("/projects/%s", url.PathEscape(projectRef)), nil, jsonContent, bytes.NewReader(reqj), resProject)
 	return resProject, resp, errors.WithStack(err)
 }
 
@@ -195,47 +195,47 @@ func (c *Client) GetProjectSecrets(ctx context.Context, projectRef string, tree 
 	return secrets, resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateProjectGroupSecret(ctx context.Context, projectGroupRef string, secret *cstypes.Secret) (*csapitypes.Secret, *http.Response, error) {
-	pj, err := json.Marshal(secret)
+func (c *Client) CreateProjectGroupSecret(ctx context.Context, projectGroupRef string, req *csapitypes.CreateUpdateSecretRequest) (*csapitypes.Secret, *http.Response, error) {
+	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
 
 	resSecret := new(csapitypes.Secret)
-	resp, err := c.getParsedResponse(ctx, "POST", fmt.Sprintf("/projectgroups/%s/secrets", url.PathEscape(projectGroupRef)), nil, jsonContent, bytes.NewReader(pj), resSecret)
+	resp, err := c.getParsedResponse(ctx, "POST", fmt.Sprintf("/projectgroups/%s/secrets", url.PathEscape(projectGroupRef)), nil, jsonContent, bytes.NewReader(reqj), resSecret)
 	return resSecret, resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateProjectSecret(ctx context.Context, projectRef string, secret *cstypes.Secret) (*csapitypes.Secret, *http.Response, error) {
-	pj, err := json.Marshal(secret)
+func (c *Client) CreateProjectSecret(ctx context.Context, projectRef string, req *csapitypes.CreateUpdateSecretRequest) (*csapitypes.Secret, *http.Response, error) {
+	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
 
 	resSecret := new(csapitypes.Secret)
-	resp, err := c.getParsedResponse(ctx, "POST", fmt.Sprintf("/projects/%s/secrets", url.PathEscape(projectRef)), nil, jsonContent, bytes.NewReader(pj), resSecret)
+	resp, err := c.getParsedResponse(ctx, "POST", fmt.Sprintf("/projects/%s/secrets", url.PathEscape(projectRef)), nil, jsonContent, bytes.NewReader(reqj), resSecret)
 	return resSecret, resp, errors.WithStack(err)
 }
 
-func (c *Client) UpdateProjectGroupSecret(ctx context.Context, projectGroupRef, secretName string, secret *cstypes.Secret) (*csapitypes.Secret, *http.Response, error) {
-	pj, err := json.Marshal(secret)
+func (c *Client) UpdateProjectGroupSecret(ctx context.Context, projectGroupRef, secretName string, req *csapitypes.CreateUpdateSecretRequest) (*csapitypes.Secret, *http.Response, error) {
+	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
 
 	resSecret := new(csapitypes.Secret)
-	resp, err := c.getParsedResponse(ctx, "PUT", fmt.Sprintf("/projectgroups/%s/secrets/%s", url.PathEscape(projectGroupRef), secretName), nil, jsonContent, bytes.NewReader(pj), resSecret)
+	resp, err := c.getParsedResponse(ctx, "PUT", fmt.Sprintf("/projectgroups/%s/secrets/%s", url.PathEscape(projectGroupRef), secretName), nil, jsonContent, bytes.NewReader(reqj), resSecret)
 	return resSecret, resp, errors.WithStack(err)
 }
 
-func (c *Client) UpdateProjectSecret(ctx context.Context, projectRef, secretName string, secret *cstypes.Secret) (*csapitypes.Secret, *http.Response, error) {
-	pj, err := json.Marshal(secret)
+func (c *Client) UpdateProjectSecret(ctx context.Context, projectRef, secretName string, req *csapitypes.CreateUpdateSecretRequest) (*csapitypes.Secret, *http.Response, error) {
+	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
 
 	resSecret := new(csapitypes.Secret)
-	resp, err := c.getParsedResponse(ctx, "PUT", fmt.Sprintf("/projects/%s/secrets/%s", url.PathEscape(projectRef), secretName), nil, jsonContent, bytes.NewReader(pj), resSecret)
+	resp, err := c.getParsedResponse(ctx, "PUT", fmt.Sprintf("/projects/%s/secrets/%s", url.PathEscape(projectRef), secretName), nil, jsonContent, bytes.NewReader(reqj), resSecret)
 	return resSecret, resp, errors.WithStack(err)
 }
 
@@ -269,47 +269,47 @@ func (c *Client) GetProjectVariables(ctx context.Context, projectRef string, tre
 	return variables, resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateProjectGroupVariable(ctx context.Context, projectGroupRef string, variable *cstypes.Variable) (*csapitypes.Variable, *http.Response, error) {
-	pj, err := json.Marshal(variable)
+func (c *Client) CreateProjectGroupVariable(ctx context.Context, projectGroupRef string, req *csapitypes.CreateUpdateVariableRequest) (*csapitypes.Variable, *http.Response, error) {
+	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
 
 	resVariable := new(csapitypes.Variable)
-	resp, err := c.getParsedResponse(ctx, "POST", fmt.Sprintf("/projectgroups/%s/variables", url.PathEscape(projectGroupRef)), nil, jsonContent, bytes.NewReader(pj), resVariable)
+	resp, err := c.getParsedResponse(ctx, "POST", fmt.Sprintf("/projectgroups/%s/variables", url.PathEscape(projectGroupRef)), nil, jsonContent, bytes.NewReader(reqj), resVariable)
 	return resVariable, resp, errors.WithStack(err)
 }
 
-func (c *Client) UpdateProjectGroupVariable(ctx context.Context, projectGroupRef, variableName string, variable *cstypes.Variable) (*csapitypes.Variable, *http.Response, error) {
-	pj, err := json.Marshal(variable)
+func (c *Client) UpdateProjectGroupVariable(ctx context.Context, projectGroupRef, variableName string, req *csapitypes.CreateUpdateVariableRequest) (*csapitypes.Variable, *http.Response, error) {
+	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
 
 	resVariable := new(csapitypes.Variable)
-	resp, err := c.getParsedResponse(ctx, "PUT", fmt.Sprintf("/projectgroups/%s/variables/%s", url.PathEscape(projectGroupRef), variableName), nil, jsonContent, bytes.NewReader(pj), resVariable)
+	resp, err := c.getParsedResponse(ctx, "PUT", fmt.Sprintf("/projectgroups/%s/variables/%s", url.PathEscape(projectGroupRef), variableName), nil, jsonContent, bytes.NewReader(reqj), resVariable)
 	return resVariable, resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateProjectVariable(ctx context.Context, projectRef string, variable *cstypes.Variable) (*csapitypes.Variable, *http.Response, error) {
-	pj, err := json.Marshal(variable)
+func (c *Client) CreateProjectVariable(ctx context.Context, projectRef string, req *csapitypes.CreateUpdateVariableRequest) (*csapitypes.Variable, *http.Response, error) {
+	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
 
 	resVariable := new(csapitypes.Variable)
-	resp, err := c.getParsedResponse(ctx, "POST", fmt.Sprintf("/projects/%s/variables", url.PathEscape(projectRef)), nil, jsonContent, bytes.NewReader(pj), resVariable)
+	resp, err := c.getParsedResponse(ctx, "POST", fmt.Sprintf("/projects/%s/variables", url.PathEscape(projectRef)), nil, jsonContent, bytes.NewReader(reqj), resVariable)
 	return resVariable, resp, errors.WithStack(err)
 }
 
-func (c *Client) UpdateProjectVariable(ctx context.Context, projectRef, variableName string, variable *cstypes.Variable) (*csapitypes.Variable, *http.Response, error) {
-	pj, err := json.Marshal(variable)
+func (c *Client) UpdateProjectVariable(ctx context.Context, projectRef, variableName string, req *csapitypes.CreateUpdateVariableRequest) (*csapitypes.Variable, *http.Response, error) {
+	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
 
 	resVariable := new(csapitypes.Variable)
-	resp, err := c.getParsedResponse(ctx, "PUT", fmt.Sprintf("/projects/%s/variables/%s", url.PathEscape(projectRef), variableName), nil, jsonContent, bytes.NewReader(pj), resVariable)
+	resp, err := c.getParsedResponse(ctx, "PUT", fmt.Sprintf("/projects/%s/variables/%s", url.PathEscape(projectRef), variableName), nil, jsonContent, bytes.NewReader(reqj), resVariable)
 	return resVariable, resp, errors.WithStack(err)
 }
 
@@ -480,25 +480,25 @@ func (c *Client) GetRemoteSources(ctx context.Context, start string, limit int, 
 	return rss, resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateRemoteSource(ctx context.Context, rs *cstypes.RemoteSource) (*cstypes.RemoteSource, *http.Response, error) {
-	rsj, err := json.Marshal(rs)
+func (c *Client) CreateRemoteSource(ctx context.Context, req *csapitypes.CreateUpdateRemoteSourceRequest) (*cstypes.RemoteSource, *http.Response, error) {
+	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
 
-	rs = new(cstypes.RemoteSource)
-	resp, err := c.getParsedResponse(ctx, "POST", "/remotesources", nil, jsonContent, bytes.NewReader(rsj), rs)
+	rs := new(cstypes.RemoteSource)
+	resp, err := c.getParsedResponse(ctx, "POST", "/remotesources", nil, jsonContent, bytes.NewReader(reqj), rs)
 	return rs, resp, errors.WithStack(err)
 }
 
-func (c *Client) UpdateRemoteSource(ctx context.Context, remoteSourceRef string, remoteSource *cstypes.RemoteSource) (*cstypes.RemoteSource, *http.Response, error) {
-	rsj, err := json.Marshal(remoteSource)
+func (c *Client) UpdateRemoteSource(ctx context.Context, remoteSourceRef string, req *csapitypes.CreateUpdateRemoteSourceRequest) (*cstypes.RemoteSource, *http.Response, error) {
+	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
 
 	resRemoteSource := new(cstypes.RemoteSource)
-	resp, err := c.getParsedResponse(ctx, "PUT", fmt.Sprintf("/remotesources/%s", url.PathEscape(remoteSourceRef)), nil, jsonContent, bytes.NewReader(rsj), resRemoteSource)
+	resp, err := c.getParsedResponse(ctx, "PUT", fmt.Sprintf("/remotesources/%s", url.PathEscape(remoteSourceRef)), nil, jsonContent, bytes.NewReader(reqj), resRemoteSource)
 	return resRemoteSource, resp, errors.WithStack(err)
 }
 
@@ -506,14 +506,14 @@ func (c *Client) DeleteRemoteSource(ctx context.Context, rsRef string) (*http.Re
 	return c.getResponse(ctx, "DELETE", fmt.Sprintf("/remotesources/%s", rsRef), nil, jsonContent, nil)
 }
 
-func (c *Client) CreateOrg(ctx context.Context, org *cstypes.Organization) (*cstypes.Organization, *http.Response, error) {
-	oj, err := json.Marshal(org)
+func (c *Client) CreateOrg(ctx context.Context, req *csapitypes.CreateOrgRequest) (*cstypes.Organization, *http.Response, error) {
+	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
 
-	org = new(cstypes.Organization)
-	resp, err := c.getParsedResponse(ctx, "POST", "/orgs", nil, jsonContent, bytes.NewReader(oj), org)
+	org := new(cstypes.Organization)
+	resp, err := c.getParsedResponse(ctx, "POST", "/orgs", nil, jsonContent, bytes.NewReader(reqj), org)
 	return org, resp, errors.WithStack(err)
 }
 


### PR DESCRIPTION
Don't directly use object types as request but dedicated request types.