### PR TITLE
runservice: add tasks timeout

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	Runs []*Run `json:"runs"`
 
 	DockerRegistriesAuth map[string]*DockerRegistryAuth `json:"docker_registries_auth"`
+	TaskTimeoutInterval  *types.Duration                `json:"task_timeout_interval"`
 }
 
 type RuntimeType string
@@ -113,6 +114,7 @@ type Run struct {
 	Tasks                []*Task                        `json:"tasks"`
 	When                 *When                          `json:"when"`
 	DockerRegistriesAuth map[string]*DockerRegistryAuth `json:"docker_registries_auth"`
+	TaskTimeoutInterval  *types.Duration                `json:"task_timeout_interval"`
 }
 
 type Task struct {
@@ -128,6 +130,7 @@ type Task struct {
 	Approval             bool                           `json:"approval"`
 	When                 *When                          `json:"when"`
 	DockerRegistriesAuth map[string]*DockerRegistryAuth `json:"docker_registries_auth"`
+	TaskTimeoutInterval  *types.Duration                `json:"task_timeout_interval"`
 }
 
 type DependCondition string

--- a/internal/runconfig/runconfig.go
+++ b/internal/runconfig/runconfig.go
@@ -270,6 +270,20 @@ func GenRunConfigTasks(uuid util.UUIDGenerator, c *config.Config, runName string
 			}
 		}
 
+		if c.TaskTimeoutInterval != nil {
+			t.TaskTimeoutInterval = c.TaskTimeoutInterval.Duration
+		}
+
+		// override with per run task timeout
+		if cr.TaskTimeoutInterval != nil {
+			t.TaskTimeoutInterval = cr.TaskTimeoutInterval.Duration
+		}
+
+		// override with per task timeout
+		if ct.TaskTimeoutInterval != nil {
+			t.TaskTimeoutInterval = ct.TaskTimeoutInterval.Duration
+		}
+
 		rcts[t.ID] = t
 	}
 

--- a/internal/runconfig/runconfig_test.go
+++ b/internal/runconfig/runconfig_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"agola.io/agola/internal/config"
 	"agola.io/agola/internal/errors"
@@ -1355,6 +1356,162 @@ func TestGenRunConfig(t *testing.T) {
 					Environment: map[string]string{},
 					Steps:       rstypes.Steps{},
 					Skip:        false,
+				},
+			},
+		},
+		{
+			name: "test runconfig generation task timeout global",
+			in: &config.Config{
+				Runs: []*config.Run{
+					&config.Run{
+						Name: "run01",
+						Tasks: []*config.Task{
+							&config.Task{
+								Name: "task01",
+								Runtime: &config.Runtime{
+									Type: "pod",
+									Arch: "",
+									Containers: []*config.Container{
+										&config.Container{
+											Image: "image01",
+										},
+									},
+								},
+
+								Depends:    []*config.Depend{},
+								WorkingDir: "",
+								Shell:      "",
+								User:       "",
+							},
+						},
+					},
+				},
+				TaskTimeoutInterval: &types.Duration{Duration: 10 * time.Second},
+			},
+			out: map[string]*rstypes.RunConfigTask{
+				uuid.New("task01").String(): &rstypes.RunConfigTask{
+					ID:   uuid.New("task01").String(),
+					Name: "task01", Depends: map[string]*rstypes.RunConfigTaskDepend{},
+					DockerRegistriesAuth: map[string]rstypes.DockerRegistryAuth{},
+					TaskTimeoutInterval:  10 * time.Second,
+					Runtime: &rstypes.Runtime{Type: rstypes.RuntimeType("pod"),
+						Containers: []*rstypes.Container{
+							{
+								Image:       "image01",
+								Volumes:     []rstypes.Volume{},
+								Environment: map[string]string{},
+							},
+						},
+					},
+					Environment: map[string]string{},
+					Skip:        false,
+					Steps:       rstypes.Steps{},
+					Shell:       "/bin/sh -e",
+				},
+			},
+		},
+		{
+			name: "test global task timeout override by run",
+			in: &config.Config{
+				Runs: []*config.Run{
+					&config.Run{
+						Name: "run01",
+						Tasks: []*config.Task{
+							&config.Task{
+								Name: "task01",
+								Runtime: &config.Runtime{
+									Type: "pod",
+									Arch: "",
+									Containers: []*config.Container{
+										&config.Container{
+											Image: "image01",
+										},
+									},
+								},
+
+								Depends:    []*config.Depend{},
+								WorkingDir: "",
+								Shell:      "",
+								User:       "",
+							},
+						},
+						TaskTimeoutInterval: &types.Duration{Duration: 15 * time.Second},
+					},
+				},
+				TaskTimeoutInterval: &types.Duration{Duration: 10 * time.Second},
+			},
+			out: map[string]*rstypes.RunConfigTask{
+				uuid.New("task01").String(): &rstypes.RunConfigTask{
+					ID:   uuid.New("task01").String(),
+					Name: "task01", Depends: map[string]*rstypes.RunConfigTaskDepend{},
+					DockerRegistriesAuth: map[string]rstypes.DockerRegistryAuth{},
+					TaskTimeoutInterval:  15 * time.Second,
+					Runtime: &rstypes.Runtime{Type: rstypes.RuntimeType("pod"),
+						Containers: []*rstypes.Container{
+							{
+								Image:       "image01",
+								Volumes:     []rstypes.Volume{},
+								Environment: map[string]string{},
+							},
+						},
+					},
+					Environment: map[string]string{},
+					Skip:        false,
+					Steps:       rstypes.Steps{},
+					Shell:       "/bin/sh -e",
+				},
+			},
+		},
+		{
+			name: "test global task timeout override by task",
+			in: &config.Config{
+				Runs: []*config.Run{
+					&config.Run{
+						Name: "run01",
+						Tasks: []*config.Task{
+							&config.Task{
+								Name:                "task01",
+								TaskTimeoutInterval: &types.Duration{Duration: 20 * time.Second},
+								Runtime: &config.Runtime{
+									Type: "pod",
+									Arch: "",
+									Containers: []*config.Container{
+										&config.Container{
+											Image: "image01",
+										},
+									},
+								},
+
+								Depends:    []*config.Depend{},
+								WorkingDir: "",
+								Shell:      "",
+								User:       "",
+							},
+						},
+						TaskTimeoutInterval: &types.Duration{Duration: 15 * time.Second},
+					},
+				},
+				TaskTimeoutInterval: &types.Duration{Duration: 10 * time.Second},
+			},
+			out: map[string]*rstypes.RunConfigTask{
+				uuid.New("task01").String(): &rstypes.RunConfigTask{
+					ID:   uuid.New("task01").String(),
+					Name: "task01", Depends: map[string]*rstypes.RunConfigTaskDepend{},
+					DockerRegistriesAuth: map[string]rstypes.DockerRegistryAuth{},
+					TaskTimeoutInterval:  20 * time.Second,
+					Runtime: &rstypes.Runtime{Type: rstypes.RuntimeType("pod"),
+						Containers: []*rstypes.Container{
+							{
+								Image:       "image01",
+								Volumes:     []rstypes.Volume{},
+								Environment: map[string]string{},
+							},
+						},
+					},
+					Environment: map[string]string{},
+					Skip:        false,
+					Steps:       rstypes.Steps{},
+					Shell:       "/bin/sh -e",
 				},
 			},
 		},

--- a/internal/services/gateway/api/run.go
+++ b/internal/services/gateway/api/run.go
@@ -63,9 +63,10 @@ func createRunResponse(r *rstypes.Run, rc *rstypes.RunConfig) *gwapitypes.RunRes
 
 func createRunResponseTask(r *rstypes.Run, rt *rstypes.RunTask, rct *rstypes.RunConfigTask) *gwapitypes.RunResponseTask {
 	t := &gwapitypes.RunResponseTask{
-		ID:     rt.ID,
-		Name:   rct.Name,
-		Status: rt.Status,
+		ID:       rt.ID,
+		Name:     rct.Name,
+		Status:   rt.Status,
+		Timedout: rt.Timedout,
 
 		StartTime: rt.StartTime,
 		EndTime:   rt.EndTime,
@@ -76,6 +77,8 @@ func createRunResponseTask(r *rstypes.Run, rt *rstypes.RunTask, rct *rstypes.Run
 
 		Level:   rct.Level,
 		Depends: rct.Depends,
+
+		TaskTimeoutInterval: rct.TaskTimeoutInterval,
 	}
 
 	return t
@@ -86,6 +89,7 @@ func createRunTaskResponse(rt *rstypes.RunTask, rct *rstypes.RunConfigTask) *gwa
 		ID:         rt.ID,
 		Name:       rct.Name,
 		Status:     rt.Status,
+		Timedout:   rt.Timedout,
 		Containers: []gwapitypes.RunTaskResponseContainer{},
 
 		WaitingApproval:     rt.WaitingApproval,
@@ -96,6 +100,8 @@ func createRunTaskResponse(rt *rstypes.RunTask, rct *rstypes.RunConfigTask) *gwa
 
 		StartTime: rt.StartTime,
 		EndTime:   rt.EndTime,
+
+		TaskTimeoutInterval: rct.TaskTimeoutInterval,
 	}
 
 	t.SetupStep = &gwapitypes.RunTaskResponseSetupStep{

--- a/internal/services/runservice/common/common.go
+++ b/internal/services/runservice/common/common.go
@@ -144,6 +144,7 @@ func GenExecutorTaskSpecData(r *types.Run, rt *types.RunTask, rc *types.RunConfi
 		Steps:                rct.Steps,
 		CachePrefix:          cachePrefix,
 		DockerRegistriesAuth: rct.DockerRegistriesAuth,
+		TaskTimeoutInterval:  rct.TaskTimeoutInterval,
 	}
 
 	// calculate workspace operations

--- a/internal/services/runservice/scheduler.go
+++ b/internal/services/runservice/scheduler.go
@@ -796,6 +796,7 @@ func (s *Runservice) updateRunTaskStatus(et *types.ExecutorTask, r *types.Run) e
 		rt.Status = types.RunTaskStatusFailed
 	}
 
+	rt.Timedout = et.Status.Timedout
 	rt.SetupStep.Phase = et.Status.SetupStep.Phase
 	rt.SetupStep.StartTime = et.Status.SetupStep.StartTime
 	rt.SetupStep.EndTime = et.Status.SetupStep.EndTime

--- a/services/gateway/api/types/run.go
+++ b/services/gateway/api/types/run.go
@@ -61,11 +61,12 @@ type RunResponse struct {
 }
 
 type RunResponseTask struct {
-	ID      string                                  `json:"id"`
-	Name    string                                  `json:"name"`
-	Status  rstypes.RunTaskStatus                   `json:"status"`
-	Level   int                                     `json:"level"`
-	Depends map[string]*rstypes.RunConfigTaskDepend `json:"depends"`
+	ID       string                                  `json:"id"`
+	Name     string                                  `json:"name"`
+	Status   rstypes.RunTaskStatus                   `json:"status"`
+	Timedout bool                                    `json:"timedout"`
+	Level    int                                     `json:"level"`
+	Depends  map[string]*rstypes.RunConfigTaskDepend `json:"depends"`
 
 	WaitingApproval     bool              `json:"waiting_approval"`
 	Approved            bool              `json:"approved"`
@@ -73,12 +74,15 @@ type RunResponseTask struct {
 
 	StartTime *time.Time `json:"start_time"`
 	EndTime   *time.Time `json:"end_time"`
+
+	TaskTimeoutInterval time.Duration `json:"task_timeout_interval"`
 }
 
 type RunTaskResponse struct {
 	ID         string                     `json:"id"`
 	Name       string                     `json:"name"`
 	Status     rstypes.RunTaskStatus      `json:"status"`
+	Timedout   bool                       `json:"timedout"`
 	Containers []RunTaskResponseContainer `json:"containers"`
 
 	WaitingApproval     bool              `json:"waiting_approval"`
@@ -90,6 +94,8 @@ type RunTaskResponse struct {
 
 	StartTime *time.Time `json:"start_time"`
 	EndTime   *time.Time `json:"end_time"`
+
+	TaskTimeoutInterval time.Duration `json:"task_timeout_interval"`
 }
 
 type RunTaskResponseContainer struct {

--- a/services/runservice/types/executortask.go
+++ b/services/runservice/types/executortask.go
@@ -79,12 +79,15 @@ type ExecutorTaskSpecData struct {
 	CachePrefix string `json:"cache_prefix,omitempty"`
 
 	Steps Steps `json:"steps,omitempty"`
+
+	TaskTimeoutInterval time.Duration `json:"task_timeout_interval"`
 }
 
 type ExecutorTaskStatus struct {
 	ID string `json:"id,omitempty"`
 
-	Phase ExecutorTaskPhase `json:"phase,omitempty"`
+	Phase    ExecutorTaskPhase `json:"phase,omitempty"`
+	Timedout bool              `json:"timedout,omitempty"`
 
 	FailError string `json:"fail_error,omitempty"`
 

--- a/services/runservice/types/run.go
+++ b/services/runservice/types/run.go
@@ -201,6 +201,9 @@ type RunTask struct {
 	// there're no executor tasks scheduled
 	Status RunTaskStatus `json:"status,omitempty"`
 
+	// Timedout represent if the task has timed out
+	Timedout bool `json:"timedout,omitempty"`
+
 	// Annotations contain custom task annotations
 	// these are opaque to the runservice and used for multiple pourposes. For
 	// example to stores task approval metadata.
@@ -220,6 +223,8 @@ type RunTask struct {
 
 	StartTime *time.Time `json:"start_time,omitempty"`
 	EndTime   *time.Time `json:"end_time,omitempty"`
+
+	TaskTimeoutInterval *time.Duration `json:"task_timeout_interval"`
 }
 
 func (rt *RunTask) LogsFetchFinished() bool {

--- a/services/runservice/types/runconfig.go
+++ b/services/runservice/types/runconfig.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"time"
 
 	"agola.io/agola/internal/errors"
 	stypes "agola.io/agola/services/types"
@@ -80,6 +81,7 @@ type RunConfigTask struct {
 	NeedsApproval        bool                            `json:"needs_approval,omitempty"`
 	Skip                 bool                            `json:"skip,omitempty"`
 	DockerRegistriesAuth map[string]DockerRegistryAuth   `json:"docker_registries_auth"`
+	TaskTimeoutInterval  time.Duration                   `json:"task_timeout_interval"`
 }
 
 func (rct *RunConfigTask) DeepCopy() *RunConfigTask {


### PR DESCRIPTION
fix #6 

runConfig: added TaskTimeout in global, run and task configuration
executor: added tasksTimeoutCleaner for managing task timeout
scheduler: updated executorTaskCleaner for managing task timeout and report it to the executor with a timeout signal in ExecutorTaskSpec