### PR TITLE
runconfig: temporary enable ssh client ssh-rsa sha1 signature algorithm

### DIFF
--- a/internal/runconfig/runconfig.go
+++ b/internal/runconfig/runconfig.go
@@ -109,6 +109,10 @@ Host $AGOLA_GIT_HOST
 	Port $AGOLA_GIT_PORT
 	StrictHostKeyChecking ${STRICT_HOST_KEY_CHECKING}
 	PasswordAuthentication no
+
+	IgnoreUnknown PubkeyAcceptedKeyTypes,PubkeyAcceptedAlgorithms
+	PubkeyAcceptedKeyTypes +ssh-rsa
+	PubkeyAcceptedAlgorithms +ssh-rsa
 EOF
 )
 


### PR DESCRIPTION
Newer versions of openssh client disables ssh-rsa sha1 public key
signature algorithm.

Unfortunately gitea ssh server requires this signature algorithm instead
of using the stronger rsa-sha2-256/rsa-sha2-512 (see
https://github.com/go-gitea/gitea/issues/17798)

So, as a temporary workaround, force enable on the ssh client the
ssh-rsa sha1 signature algorithm.


That's the reason why tests on run.agola.io are failing.
The new alpine/git image has a new openssh version disabling such algo.