### PR TITLE
gateway: average run duration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 bin/
 tools/
 webbundle/bindata.go
+.vscode/

--- a/internal/migration/runservice/types/types.go
+++ b/internal/migration/runservice/types/types.go
@@ -125,6 +125,7 @@ type Run struct {
 	EnqueueTime *time.Time          `json:"enqueue_time,omitempty"`
 	StartTime   *time.Time          `json:"start_time,omitempty"`
 	EndTime     *time.Time          `json:"end_time,omitempty"`
+	AvgRunTime  *time.Duration      `json:"avg_run_duration"`
 
 	Archived bool `json:"archived,omitempty"`
 

--- a/internal/services/gateway/api/run.go
+++ b/internal/services/gateway/api/run.go
@@ -48,6 +48,7 @@ func createRunResponse(r *rstypes.Run, rc *rstypes.RunConfig) *gwapitypes.RunRes
 		EnqueueTime: r.EnqueueTime,
 		StartTime:   r.StartTime,
 		EndTime:     r.EndTime,
+		AvgRunTime:  r.AvgRunTime,
 	}
 
 	run.CanRestartFromScratch, _ = r.CanRestartFromScratch()
@@ -282,6 +283,7 @@ func createRunsResponse(r *rstypes.Run) *gwapitypes.RunsResponse {
 		EnqueueTime: r.EnqueueTime,
 		StartTime:   r.StartTime,
 		EndTime:     r.EndTime,
+		AvgRunTime:  r.AvgRunTime,
 	}
 
 	return run

--- a/services/gateway/api/types/run.go
+++ b/services/gateway/api/types/run.go
@@ -35,9 +35,10 @@ type RunsResponse struct {
 
 	TasksWaitingApproval []string `json:"tasks_waiting_approval"`
 
-	EnqueueTime *time.Time `json:"enqueue_time"`
-	StartTime   *time.Time `json:"start_time"`
-	EndTime     *time.Time `json:"end_time"`
+	EnqueueTime *time.Time     `json:"enqueue_time"`
+	StartTime   *time.Time     `json:"start_time"`
+	EndTime     *time.Time     `json:"end_time"`
+	AvgRunTime  *time.Duration `json:"avg_run_duration"`
 }
 
 type RunResponse struct {
@@ -52,9 +53,10 @@ type RunResponse struct {
 	Tasks                map[string]*RunResponseTask `json:"tasks"`
 	TasksWaitingApproval []string                    `json:"tasks_waiting_approval"`
 
-	EnqueueTime *time.Time `json:"enqueue_time"`
-	StartTime   *time.Time `json:"start_time"`
-	EndTime     *time.Time `json:"end_time"`
+	EnqueueTime *time.Time     `json:"enqueue_time"`
+	StartTime   *time.Time     `json:"start_time"`
+	EndTime     *time.Time     `json:"end_time"`
+	AvgRunTime  *time.Duration `json:"avg_run_duration"`
 
 	CanRestartFromScratch     bool `json:"can_restart_from_scratch"`
 	CanRestartFromFailedTasks bool `json:"can_restart_from_failed_tasks"`

--- a/services/runservice/types/run.go
+++ b/services/runservice/types/run.go
@@ -100,6 +100,7 @@ type Run struct {
 	EnqueueTime *time.Time          `json:"enqueue_time,omitempty"`
 	StartTime   *time.Time          `json:"start_time,omitempty"`
 	EndTime     *time.Time          `json:"end_time,omitempty"`
+	AvgRunTime  *time.Duration      `json:"avg_run_duration"`
 
 	Archived bool `json:"archived,omitempty"`
 }


### PR DESCRIPTION
Hi,
In this PR I've added the code to have the average duration from a run. 
The average is calculated getting the last 10 runs that have  run result equals success and run phase equals finished.

Added also some unit tests.

Kindly can you review this pull request ?
thank you !