### PR TITLE
add cmd import, export, maintenance for runservice and configstore

### DIFF
--- a/cmd/agola/cmd/export.go
+++ b/cmd/agola/cmd/export.go
@@ -1,0 +1,82 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os"
+
+	"agola.io/agola/internal/errors"
+	gatewayclient "agola.io/agola/services/gateway/client"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+var cmdExport = &cobra.Command{
+	Use: "export",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := export(cmd, args); err != nil {
+			log.Fatal().Err(err).Send()
+		}
+	},
+	Short: "export",
+}
+
+type exportOptions struct {
+	outFilePath string
+	servicename string
+}
+
+var exportOpts exportOptions
+
+func init() {
+	flags := cmdExport.Flags()
+
+	flags.StringVar(&exportOpts.servicename, "service", "", "service name")
+	flags.StringVar(&exportOpts.outFilePath, "out", "-", "output file path")
+
+	cmdAgola.AddCommand(cmdExport)
+}
+
+func export(cmd *cobra.Command, args []string) error {
+	gatewayclient := gatewayclient.NewClient(gatewayURL, token)
+
+	resp, err := gatewayclient.Export(context.TODO(), exportOpts.servicename)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	var w *os.File
+	if exportOpts.outFilePath == "-" {
+		w = os.Stdout
+	} else {
+		var err error
+		w, err = os.Create(exportOpts.outFilePath)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	r := bufio.NewReader(resp.Body)
+	_, err = io.Copy(w, r)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return errors.WithStack(err)
+}

--- a/cmd/agola/cmd/import.go
+++ b/cmd/agola/cmd/import.go
@@ -1,0 +1,74 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"os"
+
+	"agola.io/agola/internal/errors"
+	gatewayclient "agola.io/agola/services/gateway/client"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+var cmdImport = &cobra.Command{
+	Use: "import",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := imp(cmd, args); err != nil {
+			log.Fatal().Err(err).Send()
+		}
+	},
+	Short: "import",
+}
+
+type importOptions struct {
+	inFilePath  string
+	servicename string
+}
+
+var importOpts importOptions
+
+func init() {
+	flags := cmdImport.Flags()
+
+	flags.StringVar(&importOpts.servicename, "service", "", "service name")
+	flags.StringVar(&importOpts.inFilePath, "in", "-", "input file path")
+
+	cmdAgola.AddCommand(cmdImport)
+}
+
+func imp(cmd *cobra.Command, args []string) error {
+	gatewayclient := gatewayclient.NewClient(gatewayURL, token)
+
+	var r *os.File
+	if importOpts.inFilePath == "-" {
+		r = os.Stdin
+	} else {
+		var err error
+		r, err = os.Open(importOpts.inFilePath)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	_, err := gatewayclient.Import(context.TODO(), importOpts.servicename, r)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}

--- a/cmd/agola/cmd/maintenance.go
+++ b/cmd/agola/cmd/maintenance.go
@@ -1,0 +1,44 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+var cmdMaintenance = &cobra.Command{
+	Use: "maintenance",
+	Run: func(c *cobra.Command, args []string) {
+		if err := c.Help(); err != nil {
+			log.Fatal().Err(err).Send()
+		}
+	},
+	Short: "maintenance",
+}
+
+type maintenanceOptions struct {
+	servicename string
+}
+
+var maintenanceOpts maintenanceOptions
+
+func init() {
+	flags := cmdMaintenance.PersistentFlags()
+
+	flags.StringVar(&maintenanceOpts.servicename, "service", "", "service name")
+
+	cmdAgola.AddCommand(cmdMaintenance)
+}

--- a/cmd/agola/cmd/maintenancedisable.go
+++ b/cmd/agola/cmd/maintenancedisable.go
@@ -1,0 +1,46 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+
+	"agola.io/agola/internal/errors"
+	gatewayclient "agola.io/agola/services/gateway/client"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+var cmdMaintenanceDisable = &cobra.Command{
+	Use: "disable",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := disable(cmd, args); err != nil {
+			log.Fatal().Err(err).Send()
+		}
+	},
+	Short: "disable",
+}
+
+func init() {
+	cmdMaintenance.AddCommand(cmdMaintenanceDisable)
+}
+
+func disable(cmd *cobra.Command, args []string) error {
+	gatewayclient := gatewayclient.NewClient(gatewayURL, token)
+
+	_, err := gatewayclient.DisableMaintenance(context.TODO(), maintenanceOpts.servicename)
+
+	return errors.WithStack(err)
+}

--- a/cmd/agola/cmd/maintenanceenable.go
+++ b/cmd/agola/cmd/maintenanceenable.go
@@ -1,0 +1,46 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+
+	"agola.io/agola/internal/errors"
+	gatewayclient "agola.io/agola/services/gateway/client"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+var cmdMaintenanceEnable = &cobra.Command{
+	Use: "enable",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := enable(cmd, args); err != nil {
+			log.Fatal().Err(err).Send()
+		}
+	},
+	Short: "enable",
+}
+
+func init() {
+	cmdMaintenance.AddCommand(cmdMaintenanceEnable)
+}
+
+func enable(cmd *cobra.Command, args []string) error {
+	gatewayclient := gatewayclient.NewClient(gatewayURL, token)
+
+	_, err := gatewayclient.EnableMaintenance(context.TODO(), maintenanceOpts.servicename)
+
+	return errors.WithStack(err)
+}

--- a/internal/services/configstore/configstore.go
+++ b/internal/services/configstore/configstore.go
@@ -132,6 +132,7 @@ func NewConfigstore(ctx context.Context, log zerolog.Logger, c *config.Configsto
 }
 
 func (s *Configstore) setupDefaultRouter() http.Handler {
+	maintenanceStatusHandler := api.NewMaintenanceStatusHandler(s.log, s.ah, false)
 	maintenanceModeHandler := api.NewMaintenanceModeHandler(s.log, s.ah)
 	exportHandler := api.NewExportHandler(s.log, s.ah)
 	importHandler := api.NewImportHandler(s.log, s.ah)
@@ -268,6 +269,7 @@ func (s *Configstore) setupDefaultRouter() http.Handler {
 	apirouter.Handle("/remotesources/{remotesourceref}", updateRemoteSourceHandler).Methods("PUT")
 	apirouter.Handle("/remotesources/{remotesourceref}", deleteRemoteSourceHandler).Methods("DELETE")
 
+	apirouter.Handle("/maintenance", maintenanceStatusHandler).Methods("GET")
 	apirouter.Handle("/maintenance", maintenanceModeHandler).Methods("PUT", "DELETE")
 
 	apirouter.Handle("/export", exportHandler).Methods("GET")
@@ -280,6 +282,7 @@ func (s *Configstore) setupDefaultRouter() http.Handler {
 }
 
 func (s *Configstore) setupMaintenanceRouter() http.Handler {
+	maintenanceStatusHandler := api.NewMaintenanceStatusHandler(s.log, s.ah, true)
 	maintenanceModeHandler := api.NewMaintenanceModeHandler(s.log, s.ah)
 	exportHandler := api.NewExportHandler(s.log, s.ah)
 	importHandler := api.NewImportHandler(s.log, s.ah)
@@ -287,6 +290,7 @@ func (s *Configstore) setupMaintenanceRouter() http.Handler {
 	router := mux.NewRouter()
 	apirouter := router.PathPrefix("/api/v1alpha").Subrouter().UseEncodedPath()
 
+	apirouter.Handle("/maintenance", maintenanceStatusHandler).Methods("GET")
 	apirouter.Handle("/maintenance", maintenanceModeHandler).Methods("PUT", "DELETE")
 
 	apirouter.Handle("/export", exportHandler).Methods("GET")

--- a/internal/services/gateway/action/maintenance.go
+++ b/internal/services/gateway/action/maintenance.go
@@ -1,0 +1,132 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	"agola.io/agola/internal/errors"
+	"agola.io/agola/internal/services/gateway/common"
+	"agola.io/agola/internal/util"
+)
+
+const (
+	ConfigstoreService = "configstore"
+	RunserviceService  = "runservice"
+)
+
+type MaintenanceStatusResponse struct {
+	RequestedStatus bool
+	CurrentStatus   bool
+}
+
+func (h *ActionHandler) IsMaintenanceEnabled(ctx context.Context, serviceName string) (*MaintenanceStatusResponse, error) {
+	if !common.IsUserAdmin(ctx) {
+		return nil, util.NewAPIError(util.ErrUnauthorized, errors.Errorf("user not admin"))
+	}
+
+	switch serviceName {
+	case ConfigstoreService:
+		csresp, _, err := h.configstoreClient.GetMaintenanceStatus(ctx)
+		if err != nil {
+			return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
+		}
+
+		return &MaintenanceStatusResponse{RequestedStatus: csresp.RequestedStatus, CurrentStatus: csresp.CurrentStatus}, nil
+	case RunserviceService:
+		rsresp, _, err := h.runserviceClient.GetMaintenanceStatus(ctx)
+		if err != nil {
+			return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
+		}
+
+		return &MaintenanceStatusResponse{RequestedStatus: rsresp.RequestedStatus, CurrentStatus: rsresp.CurrentStatus}, nil
+	default:
+		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid service name %q", serviceName))
+	}
+}
+
+func (h *ActionHandler) MaintenanceMode(ctx context.Context, serviceName string, enable bool) error {
+	if !common.IsUserAdmin(ctx) {
+		return util.NewAPIError(util.ErrUnauthorized, errors.Errorf("user not admin"))
+	}
+
+	var err error
+	switch serviceName {
+	case ConfigstoreService:
+		if enable {
+			_, err = h.configstoreClient.EnableMaintenance(ctx)
+		} else {
+			_, err = h.configstoreClient.DisableMaintenance(ctx)
+		}
+	case RunserviceService:
+		if enable {
+			_, err = h.runserviceClient.EnableMaintenance(ctx)
+		} else {
+			_, err = h.runserviceClient.DisableMaintenance(ctx)
+		}
+	default:
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid service name %q", serviceName))
+	}
+
+	if err != nil {
+		return util.NewAPIError(util.KindFromRemoteError(err), err)
+	}
+	return nil
+}
+
+func (h *ActionHandler) Export(ctx context.Context, serviceName string) (*http.Response, error) {
+	if !common.IsUserAdmin(ctx) {
+		return nil, util.NewAPIError(util.ErrUnauthorized, errors.Errorf("user not admin"))
+	}
+
+	var err error
+	var resp *http.Response
+	switch serviceName {
+	case ConfigstoreService:
+		resp, err = h.configstoreClient.Export(ctx)
+	case RunserviceService:
+		resp, err = h.runserviceClient.Export(ctx)
+	default:
+		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid service name %q", serviceName))
+	}
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return resp, nil
+}
+
+func (h *ActionHandler) Import(ctx context.Context, r io.Reader, serviceName string) error {
+	if !common.IsUserAdmin(ctx) {
+		return util.NewAPIError(util.ErrUnauthorized, errors.Errorf("user not admin"))
+	}
+
+	var err error
+	switch serviceName {
+	case ConfigstoreService:
+		_, err = h.configstoreClient.Import(ctx, r)
+	case RunserviceService:
+		_, err = h.runserviceClient.Import(ctx, r)
+	default:
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid service name %q", serviceName))
+	}
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}

--- a/internal/services/gateway/gateway.go
+++ b/internal/services/gateway/gateway.go
@@ -239,6 +239,11 @@ func (g *Gateway) Run(ctx context.Context) error {
 	registerHandler := api.NewRegisterUserHandler(g.log, g.ah)
 	oauth2callbackHandler := api.NewOAuth2CallbackHandler(g.log, g.ah)
 
+	maintenanceStatusHandler := api.NewMaintenanceStatusHandler(g.log, g.ah)
+	maintenanceModeHandler := api.NewMaintenanceModeHandler(g.log, g.ah)
+	exportHandler := api.NewExportHandler(g.log, g.ah)
+	importHandler := api.NewImportHandler(g.log, g.ah)
+
 	router := mux.NewRouter()
 	reposRouter := mux.NewRouter()
 
@@ -343,6 +348,11 @@ func (g *Gateway) Run(ctx context.Context) error {
 	apirouter.Handle("/auth/authorize", authorizeHandler).Methods("POST")
 	apirouter.Handle("/auth/register", registerHandler).Methods("POST")
 	apirouter.Handle("/auth/oauth2/callback", oauth2callbackHandler).Methods("GET")
+
+	apirouter.Handle("/maintenance/{servicename}", maintenanceStatusHandler).Methods("GET")
+	apirouter.Handle("/maintenance/{servicename}", authForcedHandler(maintenanceModeHandler)).Methods("PUT", "DELETE")
+	apirouter.Handle("/export/{servicename}", authForcedHandler(exportHandler)).Methods("GET")
+	apirouter.Handle("/import/{servicename}", authForcedHandler(importHandler)).Methods("POST")
 
 	// TODO(sgotti) add auth to these requests
 	reposRouter.Handle("/repos/{rest:.*}", reposHandler).Methods("GET", "POST")

--- a/internal/services/runservice/runservice.go
+++ b/internal/services/runservice/runservice.go
@@ -131,6 +131,7 @@ func NewRunservice(ctx context.Context, log zerolog.Logger, c *config.Runservice
 }
 
 func (s *Runservice) setupDefaultRouter(etCh chan string) http.Handler {
+	maintenanceStatusHandler := api.NewMaintenanceStatusHandler(s.log, s.ah, false)
 	maintenanceModeHandler := api.NewMaintenanceModeHandler(s.log, s.ah)
 	exportHandler := api.NewExportHandler(s.log, s.ah)
 	importHandler := api.NewImportHandler(s.log, s.ah)
@@ -193,6 +194,7 @@ func (s *Runservice) setupDefaultRouter(etCh chan string) http.Handler {
 
 	apirouter.Handle("/changegroups", changeGroupsUpdateTokensHandler).Methods("GET")
 
+	apirouter.Handle("/maintenance", maintenanceStatusHandler).Methods("GET")
 	apirouter.Handle("/maintenance", maintenanceModeHandler).Methods("PUT", "DELETE")
 
 	apirouter.Handle("/export", exportHandler).Methods("GET")
@@ -208,6 +210,7 @@ func (s *Runservice) setupDefaultRouter(etCh chan string) http.Handler {
 }
 
 func (s *Runservice) setupMaintenanceRouter() http.Handler {
+	maintenanceStatusHandler := api.NewMaintenanceStatusHandler(s.log, s.ah, true)
 	maintenanceModeHandler := api.NewMaintenanceModeHandler(s.log, s.ah)
 	exportHandler := api.NewExportHandler(s.log, s.ah)
 	importHandler := api.NewImportHandler(s.log, s.ah)
@@ -215,6 +218,7 @@ func (s *Runservice) setupMaintenanceRouter() http.Handler {
 	router := mux.NewRouter()
 	apirouter := router.PathPrefix("/api/v1alpha").Subrouter().UseEncodedPath()
 
+	apirouter.Handle("/maintenance", maintenanceStatusHandler).Methods("GET")
 	apirouter.Handle("/maintenance", maintenanceModeHandler).Methods("PUT", "DELETE")
 
 	apirouter.Handle("/export", exportHandler).Methods("GET")

--- a/services/configstore/api/types/maintenance.go
+++ b/services/configstore/api/types/maintenance.go
@@ -1,0 +1,20 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+type MaintenanceStatusResponse struct {
+	RequestedStatus bool
+	CurrentStatus   bool
+}

--- a/services/configstore/client/client.go
+++ b/services/configstore/client/client.go
@@ -644,3 +644,25 @@ func (c *Client) UserOrgInvitationAction(ctx context.Context, userRef string, or
 	resp, err := c.getResponse(ctx, "PUT", fmt.Sprintf("/orgs/%s/invitations/%s/actions", orgRef, userRef), nil, jsonContent, bytes.NewReader(reqj))
 	return resp, errors.WithStack(err)
 }
+
+func (c *Client) GetMaintenanceStatus(ctx context.Context) (*csapitypes.MaintenanceStatusResponse, *http.Response, error) {
+	maintenanceStatus := new(csapitypes.MaintenanceStatusResponse)
+	resp, err := c.getParsedResponse(ctx, "GET", "/maintenance", nil, jsonContent, nil, maintenanceStatus)
+	return maintenanceStatus, resp, errors.WithStack(err)
+}
+
+func (c *Client) EnableMaintenance(ctx context.Context) (*http.Response, error) {
+	return c.getResponse(ctx, "PUT", "/maintenance", nil, jsonContent, nil)
+}
+
+func (c *Client) DisableMaintenance(ctx context.Context) (*http.Response, error) {
+	return c.getResponse(ctx, "DELETE", "/maintenance", nil, jsonContent, nil)
+}
+
+func (c *Client) Export(ctx context.Context) (*http.Response, error) {
+	return c.getResponse(ctx, "GET", "/export", nil, jsonContent, nil)
+}
+
+func (c *Client) Import(ctx context.Context, r io.Reader) (*http.Response, error) {
+	return c.getResponse(ctx, "POST", "/import", nil, jsonContent, r)
+}

--- a/services/gateway/api/types/maintenance.go
+++ b/services/gateway/api/types/maintenance.go
@@ -1,0 +1,20 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+type MaintenanceStatusResponse struct {
+	RequestedStatus bool
+	CurrentStatus   bool
+}

--- a/services/gateway/client/client.go
+++ b/services/gateway/client/client.go
@@ -735,3 +735,25 @@ func (c *Client) UserOrgInvitationAction(ctx context.Context, orgRef string, req
 	resp, err := c.getResponse(ctx, "PUT", fmt.Sprintf("/user/org_invitations/%s/actions", orgRef), nil, jsonContent, bytes.NewReader(reqj))
 	return resp, errors.WithStack(err)
 }
+
+func (c *Client) GetMaintenanceStatus(ctx context.Context, serviceName string) (*gwapitypes.MaintenanceStatusResponse, *http.Response, error) {
+	maintenanceStatus := new(gwapitypes.MaintenanceStatusResponse)
+	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/maintenance/%s", serviceName), nil, jsonContent, nil, maintenanceStatus)
+	return maintenanceStatus, resp, errors.WithStack(err)
+}
+
+func (c *Client) EnableMaintenance(ctx context.Context, serviceName string) (*http.Response, error) {
+	return c.getResponse(ctx, "PUT", fmt.Sprintf("/maintenance/%s", serviceName), nil, jsonContent, nil)
+}
+
+func (c *Client) DisableMaintenance(ctx context.Context, serviceName string) (*http.Response, error) {
+	return c.getResponse(ctx, "DELETE", fmt.Sprintf("/maintenance/%s", serviceName), nil, jsonContent, nil)
+}
+
+func (c *Client) Export(ctx context.Context, serviceName string) (*http.Response, error) {
+	return c.getResponse(ctx, "GET", fmt.Sprintf("/export/%s", serviceName), nil, jsonContent, nil)
+}
+
+func (c *Client) Import(ctx context.Context, serviceName string, r io.Reader) (*http.Response, error) {
+	return c.getResponse(ctx, "POST", fmt.Sprintf("/import/%s", serviceName), nil, jsonContent, r)
+}

--- a/services/runservice/api/types/maintenance.go
+++ b/services/runservice/api/types/maintenance.go
@@ -1,0 +1,20 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+type MaintenanceStatusResponse struct {
+	RequestedStatus bool
+	CurrentStatus   bool
+}

--- a/services/runservice/client/client.go
+++ b/services/runservice/client/client.go
@@ -353,3 +353,25 @@ func (c *Client) GetRunEvents(ctx context.Context, startRunEventID string) (*htt
 
 	return c.getResponse(ctx, "GET", "/runs/events", q, -1, nil, nil)
 }
+
+func (c *Client) GetMaintenanceStatus(ctx context.Context) (*rsapitypes.MaintenanceStatusResponse, *http.Response, error) {
+	maintenanceStatus := new(rsapitypes.MaintenanceStatusResponse)
+	resp, err := c.getParsedResponse(ctx, "GET", "/maintenance", nil, jsonContent, nil, maintenanceStatus)
+	return maintenanceStatus, resp, errors.WithStack(err)
+}
+
+func (c *Client) EnableMaintenance(ctx context.Context) (*http.Response, error) {
+	return c.getResponse(ctx, "PUT", "/maintenance", nil, -1, nil, nil)
+}
+
+func (c *Client) DisableMaintenance(ctx context.Context) (*http.Response, error) {
+	return c.getResponse(ctx, "DELETE", "/maintenance", nil, -1, nil, nil)
+}
+
+func (c *Client) Export(ctx context.Context) (*http.Response, error) {
+	return c.getResponse(ctx, "GET", "/export", nil, -1, nil, nil)
+}
+
+func (c *Client) Import(ctx context.Context, r io.Reader) (*http.Response, error) {
+	return c.getResponse(ctx, "POST", "/import", nil, -1, nil, r)
+}


### PR DESCRIPTION
fix #318
Agola commands added:

agola export  --service {configstore/runservice} --file-path {export-file-path}
agola import --service {configstore/runservice} --file-path {import-file-path}
agola maintenance --service {configstore/runservice}