### PR TITLE
executor: avoid locking during setupTask

### DIFF
--- a/internal/services/executor/executor.go
+++ b/internal/services/executor/executor.go
@@ -758,7 +758,9 @@ func (e *Executor) executeTask(rt *runningTask) {
 		e.log.Err(err).Send()
 	}
 
+	rt.Unlock()
 	if err := e.setupTask(ctx, rt); err != nil {
+		rt.Lock()
 		e.log.Err(err).Send()
 		et.Status.Phase = types.ExecutorTaskPhaseFailed
 		et.Status.EndTime = util.TimeP(time.Now())
@@ -771,6 +773,7 @@ func (e *Executor) executeTask(rt *runningTask) {
 		return
 	}
 
+	rt.Lock()
 	et.Status.SetupStep.Phase = types.ExecutorTaskPhaseSuccess
 	et.Status.SetupStep.EndTime = util.TimeP(time.Now())
 	if err := e.sendExecutorTaskStatus(ctx, et); err != nil {


### PR DESCRIPTION
Unlock runningTask before calling setupTask
This is needed because setupTask can take much time and lock other routines