### PR TITLE
configstore: fixed UpdateUserLA actionHandler

### DIFF
--- a/internal/services/configstore/action/user.go
+++ b/internal/services/configstore/action/user.go
@@ -389,7 +389,7 @@ func (h *ActionHandler) UpdateUserLA(ctx context.Context, req *UpdateUserLAReque
 		la.Oauth2RefreshToken = req.Oauth2RefreshToken
 		la.Oauth2AccessTokenExpiresAt = req.Oauth2AccessTokenExpiresAt
 
-		if err := h.d.UpdateUser(tx, user); err != nil {
+		if err := h.d.UpdateLinkedAccount(tx, la); err != nil {
 			return errors.WithStack(err)
 		}
 


### PR DESCRIPTION
UpdateUserLA actionHandler not save the user linked account because it call updateUser.
So we just change it with the action UpdateLinkedAccount