### PR TITLE
*: fix updating of user linked account

### DIFF
--- a/internal/services/configstore/action/user.go
+++ b/internal/services/configstore/action/user.go
@@ -389,7 +389,7 @@ func (h *ActionHandler) UpdateUserLA(ctx context.Context, req *UpdateUserLAReque
 		la.Oauth2RefreshToken = req.Oauth2RefreshToken
 		la.Oauth2AccessTokenExpiresAt = req.Oauth2AccessTokenExpiresAt
 
-		if err := h.d.UpdateUser(tx, user); err != nil {
+		if err := h.d.UpdateLinkedAccount(tx, la); err != nil {
 			return errors.WithStack(err)
 		}
 

--- a/internal/services/gateway/action/user.go
+++ b/internal/services/gateway/action/user.go
@@ -472,10 +472,10 @@ func (h *ActionHandler) LoginUser(ctx context.Context, req *LoginUserRequest) (*
 		creq := &csapitypes.UpdateUserLARequest{
 			RemoteUserID:               la.RemoteUserID,
 			RemoteUserName:             la.RemoteUserName,
-			UserAccessToken:            la.UserAccessToken,
-			Oauth2AccessToken:          la.Oauth2AccessToken,
-			Oauth2RefreshToken:         la.Oauth2RefreshToken,
-			Oauth2AccessTokenExpiresAt: la.Oauth2AccessTokenExpiresAt,
+			UserAccessToken:            req.UserAccessToken,
+			Oauth2AccessToken:          req.Oauth2AccessToken,
+			Oauth2RefreshToken:         req.Oauth2RefreshToken,
+			Oauth2AccessTokenExpiresAt: req.Oauth2AccessTokenExpiresAt,
 		}
 
 		h.log.Info().Msgf("updating user %q linked account", user.Name)


### PR DESCRIPTION
gateway: use the request new access token data
configstore: call UpdateLinkedAccount and not UpdateUser