### PR TITLE
notification service: add custom webhook and retry logic

### DIFF
--- a/internal/services/configstore/action/hook.go
+++ b/internal/services/configstore/action/hook.go
@@ -1,0 +1,223 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"context"
+	"net/url"
+
+	"agola.io/agola/internal/errors"
+	"agola.io/agola/internal/sql"
+
+	"agola.io/agola/internal/util"
+	"agola.io/agola/services/configstore/types"
+)
+
+func (h *ActionHandler) GetHook(ctx context.Context, hookID string) (*types.Hook, error) {
+	var hook *types.Hook
+	err := h.d.Do(ctx, func(tx *sql.Tx) error {
+		var err error
+
+		hook, err = h.d.GetHook(tx, hookID)
+		return errors.WithStack(err)
+	})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return hook, nil
+}
+
+func (h *ActionHandler) GetProjectHooks(ctx context.Context, projectRef string) ([]*types.Hook, error) {
+	var hooks []*types.Hook
+	err := h.d.Do(ctx, func(tx *sql.Tx) error {
+		var err error
+
+		p, err := h.d.GetProject(tx, projectRef)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if p == nil {
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with ref %q not exists", projectRef))
+		}
+
+		hooks, err = h.d.GetHooks(tx, p.ID)
+		return errors.WithStack(err)
+	})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return hooks, nil
+}
+
+func (h *ActionHandler) ValidateCreateHookReq(ctx context.Context, req *CreateHookRequest) error {
+	if req.ProjectRef == "" {
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project ref required"))
+	}
+	if req.DestinationURL == "" {
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("destination url required"))
+	}
+	if _, err := url.ParseRequestURI(req.DestinationURL); err != nil {
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid destination url %q", req.DestinationURL))
+	}
+	if req.ContentType == "" {
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("content type required"))
+	}
+	if !req.ErrorEvent && !req.FailedEvent && !req.SuccessEvent && !req.PendingEvent {
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("no events defined"))
+	}
+
+	return nil
+}
+
+type CreateHookRequest struct {
+	ProjectRef     string
+	DestinationURL string
+	ContentType    string
+	Secret         string
+	PendingEvent   bool
+	SuccessEvent   bool
+	ErrorEvent     bool
+	FailedEvent    bool
+}
+
+func (h *ActionHandler) CreateHook(ctx context.Context, req *CreateHookRequest) (*types.Hook, error) {
+	if err := h.ValidateCreateHookReq(ctx, req); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	var hook *types.Hook
+	err := h.d.Do(ctx, func(tx *sql.Tx) error {
+		// check project exists
+		p, err := h.d.GetProject(tx, req.ProjectRef)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if p == nil {
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with ref %q not exists", req.ProjectRef))
+		}
+
+		hook = types.NewHook()
+		hook.ContentType = req.ContentType
+		hook.DestinationURL = req.DestinationURL
+		hook.Secret = req.Secret
+		hook.ProjectID = p.ID
+		hook.SuccessEvent = &req.SuccessEvent
+		hook.ErrorEvent = &req.ErrorEvent
+		hook.PendingEvent = &req.PendingEvent
+		hook.FailedEvent = &req.FailedEvent
+
+		if err := h.d.InsertHook(tx, hook); err != nil {
+			return errors.WithStack(err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return hook, errors.WithStack(err)
+}
+
+func (h *ActionHandler) ValidateUpdateHookReq(ctx context.Context, req *UpdateHookRequest) error {
+	if req.DestinationURL == "" {
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("destination url required"))
+	}
+	if _, err := url.ParseRequestURI(req.DestinationURL); err != nil {
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid destination url %q", req.DestinationURL))
+	}
+	if req.ContentType == "" {
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("content type required"))
+	}
+	if !req.ErrorEvent && !req.FailedEvent && !req.SuccessEvent && !req.PendingEvent {
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("no events defined"))
+	}
+
+	return nil
+}
+
+type UpdateHookRequest struct {
+	DestinationURL string
+	ContentType    string
+	Secret         string
+	PendingEvent   bool
+	SuccessEvent   bool
+	ErrorEvent     bool
+	FailedEvent    bool
+}
+
+func (h *ActionHandler) UpdateHook(ctx context.Context, curHookID string, req *UpdateHookRequest) (*types.Hook, error) {
+	if err := h.ValidateUpdateHookReq(ctx, req); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	var hook *types.Hook
+	err := h.d.Do(ctx, func(tx *sql.Tx) error {
+		// check hook exists
+		hook, err := h.d.GetHook(tx, curHookID)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if hook == nil {
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("hook with id %q doesn't exists", curHookID))
+		}
+
+		// update current variable
+		hook.DestinationURL = req.DestinationURL
+		hook.ContentType = req.ContentType
+		hook.Secret = req.Secret
+		hook.SuccessEvent = &req.SuccessEvent
+		hook.PendingEvent = &req.PendingEvent
+		hook.ErrorEvent = &req.ErrorEvent
+		hook.FailedEvent = &req.FailedEvent
+
+		if err := h.d.UpdateHook(tx, hook); err != nil {
+			return errors.WithStack(err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return hook, errors.WithStack(err)
+}
+
+func (h *ActionHandler) DeleteHook(ctx context.Context, curHookID string) error {
+	err := h.d.Do(ctx, func(tx *sql.Tx) error {
+		// check hook exists
+		hook, err := h.d.GetHook(tx, curHookID)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if hook == nil {
+			return util.NewAPIError(util.ErrNotExist, errors.Errorf("hook with id %q doesn't exists", curHookID))
+		}
+
+		if err := h.d.DeleteHook(tx, hook.ID); err != nil {
+			return errors.WithStack(err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return errors.WithStack(err)
+}

--- a/internal/services/configstore/action/webhookmessage.go
+++ b/internal/services/configstore/action/webhookmessage.go
@@ -1,0 +1,162 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"context"
+	"net/url"
+
+	"agola.io/agola/internal/errors"
+	"agola.io/agola/internal/sql"
+
+	"agola.io/agola/internal/util"
+	"agola.io/agola/services/configstore/types"
+)
+
+func (h *ActionHandler) GetWebhookMessage(ctx context.Context, webhookMessageID string) (*types.WebhookMessage, error) {
+	var webhookMessage *types.WebhookMessage
+	err := h.d.Do(ctx, func(tx *sql.Tx) error {
+		var err error
+
+		webhookMessage, err = h.d.GetWebhookMessage(tx, webhookMessageID)
+		return errors.WithStack(err)
+	})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return webhookMessage, nil
+}
+
+func (h *ActionHandler) GetAllWebhookMessages(ctx context.Context) ([]*types.WebhookMessage, error) {
+	var webhookMessages []*types.WebhookMessage
+	err := h.d.Do(ctx, func(tx *sql.Tx) error {
+		var err error
+
+		webhookMessages, err = h.d.GetAllWebhookMessagess(tx)
+		return errors.WithStack(err)
+	})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return webhookMessages, nil
+}
+
+func (h *ActionHandler) ValidateCreateWebhookMessageReq(ctx context.Context, req *CreateWebhookMessageRequest) error {
+	if req.CommitSha == "" {
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("commit sha required"))
+	}
+	if req.CommitStatus == "" {
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("commit status required"))
+	}
+	if req.TargetURL == "" {
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("target url required"))
+	}
+	if _, err := url.ParseRequestURI(req.TargetURL); err != nil {
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("target url %q", req.TargetURL))
+	}
+	if req.RepositoryPath == "" {
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("repository path required"))
+	}
+	if req.StatusContext == "" {
+		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("status context required"))
+	}
+	if req.IsCustom {
+		if req.DestinationURL == "" {
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("destination url required"))
+		}
+		if req.ContentType == "" {
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("content type required"))
+		}
+	} else {
+		if req.ProjectID == "" {
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project id required"))
+		}
+	}
+
+	return nil
+}
+
+type CreateWebhookMessageRequest struct {
+	IsCustom       bool
+	ProjectID      string
+	DestinationURL string
+	ContentType    string
+	Secret         string
+	TargetURL      string
+	CommitStatus   string
+	Description    string
+	RepositoryPath string
+	CommitSha      string
+	StatusContext  string
+}
+
+func (h *ActionHandler) CreateWebhookMessage(ctx context.Context, req *CreateWebhookMessageRequest) (*types.WebhookMessage, error) {
+	if err := h.ValidateCreateWebhookMessageReq(ctx, req); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	var webhookMessage *types.WebhookMessage
+	err := h.d.Do(ctx, func(tx *sql.Tx) error {
+		webhookMessage = types.NewWebhookMessage()
+		webhookMessage.IsCustom = req.IsCustom
+		webhookMessage.CommitSha = req.CommitSha
+		webhookMessage.CommitStatus = req.CommitStatus
+		webhookMessage.ContentType = &req.ContentType
+		webhookMessage.Description = req.Description
+		webhookMessage.DestinationURL = &req.DestinationURL
+		webhookMessage.ProjectID = &req.ProjectID
+		webhookMessage.RepositoryPath = req.RepositoryPath
+		webhookMessage.Secret = &req.Secret
+		webhookMessage.TargetURL = req.TargetURL
+		webhookMessage.StatusContext = req.StatusContext
+
+		if err := h.d.InsertWebhookMessage(tx, webhookMessage); err != nil {
+			return errors.WithStack(err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return webhookMessage, errors.WithStack(err)
+}
+
+func (h *ActionHandler) DeleteWebhookMessage(ctx context.Context, curWebhookMessageID string) error {
+	err := h.d.Do(ctx, func(tx *sql.Tx) error {
+		// check webhookmessage exists
+		webhookmessage, err := h.d.GetWebhookMessage(tx, curWebhookMessageID)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if webhookmessage == nil {
+			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("webhookmessage with id %q doesn't exists", curWebhookMessageID))
+		}
+
+		if err := h.d.DeleteWebhookMessage(tx, webhookmessage.ID); err != nil {
+			return errors.WithStack(err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return errors.WithStack(err)
+}

--- a/internal/services/configstore/api/hook.go
+++ b/internal/services/configstore/api/hook.go
@@ -1,0 +1,189 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"agola.io/agola/internal/errors"
+	"agola.io/agola/internal/services/configstore/action"
+	"agola.io/agola/internal/util"
+	csapitypes "agola.io/agola/services/configstore/api/types"
+	"github.com/gorilla/mux"
+	"github.com/rs/zerolog"
+)
+
+type CreateHookHandler struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewCreateHookHandler(log zerolog.Logger, ah *action.ActionHandler) *CreateHookHandler {
+	return &CreateHookHandler{log: log, ah: ah}
+}
+
+func (h *CreateHookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var req *csapitypes.CreateHookRequest
+	d := json.NewDecoder(r.Body)
+	if err := d.Decode(&req); err != nil {
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		return
+	}
+
+	areq := &action.CreateHookRequest{
+		ProjectRef:     req.ProjectRef,
+		DestinationURL: req.DestinationURL,
+		ContentType:    req.ContentType,
+		Secret:         req.Secret,
+		PendingEvent:   *req.PendingEvent,
+		SuccessEvent:   *req.SuccessEvent,
+		ErrorEvent:     *req.ErrorEvent,
+		FailedEvent:    *req.FailedEvent,
+	}
+
+	hook, err := h.ah.CreateHook(ctx, areq)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+
+	if err := util.HTTPResponse(w, http.StatusOK, hook); err != nil {
+		h.log.Err(err).Send()
+	}
+}
+
+type DeleteHookHandler struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewDeleteHookHandler(log zerolog.Logger, ah *action.ActionHandler) *DeleteHookHandler {
+	return &DeleteHookHandler{log: log, ah: ah}
+}
+
+func (h *DeleteHookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	vars := mux.Vars(r)
+	hookID, err := url.PathUnescape(vars["hookid"])
+	if err != nil {
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		return
+	}
+
+	err = h.ah.DeleteHook(ctx, hookID)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
+		h.log.Err(err).Send()
+	}
+}
+
+type HookHandler struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewHookHandler(log zerolog.Logger, ah *action.ActionHandler) *HookHandler {
+	return &HookHandler{log: log, ah: ah}
+}
+
+func (h *HookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	vars := mux.Vars(r)
+	hookID, err := url.PathUnescape(vars["hookid"])
+	if err != nil {
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		return
+	}
+
+	hook, err := h.ah.GetHook(ctx, hookID)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+
+	if hook == nil {
+		util.HTTPError(w, util.NewAPIError(util.ErrNotExist, errors.Errorf("hook %q doesn't exist", hookID)))
+		return
+	}
+
+	if err := util.HTTPResponse(w, http.StatusOK, hook); err != nil {
+		h.log.Err(err).Send()
+	}
+}
+
+type UpdateHookHandler struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewUpdateHookHandler(log zerolog.Logger, ah *action.ActionHandler) *UpdateHookHandler {
+	return &UpdateHookHandler{log: log, ah: ah}
+}
+
+func (h *UpdateHookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	vars := mux.Vars(r)
+	hookID, err := url.PathUnescape(vars["hookid"])
+	if err != nil {
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		return
+	}
+
+	var req *csapitypes.UpdateHookRequest
+	d := json.NewDecoder(r.Body)
+	if err := d.Decode(&req); err != nil {
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		return
+	}
+
+	areq := &action.UpdateHookRequest{
+		DestinationURL: req.DestinationURL,
+		ContentType:    req.ContentType,
+		Secret:         req.Secret,
+		PendingEvent:   *req.PendingEvent,
+		SuccessEvent:   *req.SuccessEvent,
+		ErrorEvent:     *req.ErrorEvent,
+		FailedEvent:    *req.FailedEvent,
+	}
+	if req.PendingEvent != nil {
+		areq.PendingEvent = *req.PendingEvent
+	}
+	if req.SuccessEvent != nil {
+		areq.SuccessEvent = *req.SuccessEvent
+	}
+	if req.ErrorEvent != nil {
+		areq.ErrorEvent = *req.ErrorEvent
+	}
+	if req.FailedEvent != nil {
+		areq.FailedEvent = *req.FailedEvent
+	}
+
+	hook, err := h.ah.UpdateHook(ctx, hookID, areq)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+
+	if err := util.HTTPResponse(w, http.StatusCreated, hook); err != nil {
+		h.log.Err(err).Send()
+	}
+}

--- a/internal/services/configstore/api/webhookmessage.go
+++ b/internal/services/configstore/api/webhookmessage.go
@@ -1,0 +1,161 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"agola.io/agola/internal/errors"
+	"agola.io/agola/internal/services/configstore/action"
+	"agola.io/agola/internal/util"
+	csapitypes "agola.io/agola/services/configstore/api/types"
+	"github.com/gorilla/mux"
+	"github.com/rs/zerolog"
+)
+
+type CreateWebhookMessageHandler struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewCreateWebhookMessageHandler(log zerolog.Logger, ah *action.ActionHandler) *CreateWebhookMessageHandler {
+	return &CreateWebhookMessageHandler{log: log, ah: ah}
+}
+
+func (h *CreateWebhookMessageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var req *csapitypes.CreateWebhookMessageRequest
+	d := json.NewDecoder(r.Body)
+	if err := d.Decode(&req); err != nil {
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		return
+	}
+
+	areq := &action.CreateWebhookMessageRequest{
+		IsCustom:       req.IsCustom,
+		ContentType:    req.ContentType,
+		Secret:         req.Secret,
+		TargetURL:      req.TargetURL,
+		CommitStatus:   req.CommitStatus,
+		Description:    req.Description,
+		RepositoryPath: req.RepositoryPath,
+		CommitSha:      req.CommitSha,
+		StatusContext:  req.StatusContext,
+	}
+	if req.DestinationURL != nil {
+		areq.DestinationURL = *req.DestinationURL
+	}
+	if req.ProjectID != nil {
+		areq.ProjectID = *req.ProjectID
+	}
+
+	webhookMessage, err := h.ah.CreateWebhookMessage(ctx, areq)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+
+	if err := util.HTTPResponse(w, http.StatusOK, webhookMessage); err != nil {
+		h.log.Err(err).Send()
+	}
+}
+
+type DeleteWebhookMessageHandler struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewDeleteWebhookMessageHandler(log zerolog.Logger, ah *action.ActionHandler) *DeleteWebhookMessageHandler {
+	return &DeleteWebhookMessageHandler{log: log, ah: ah}
+}
+
+func (h *DeleteWebhookMessageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	vars := mux.Vars(r)
+	webhookmessageID, err := url.PathUnescape(vars["webhookmessageid"])
+	if err != nil {
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		return
+	}
+
+	err = h.ah.DeleteWebhookMessage(ctx, webhookmessageID)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
+		h.log.Err(err).Send()
+	}
+}
+
+type WebhookMessageHandler struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewWebhookMessageHandler(log zerolog.Logger, ah *action.ActionHandler) *WebhookMessageHandler {
+	return &WebhookMessageHandler{log: log, ah: ah}
+}
+
+func (h *WebhookMessageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	vars := mux.Vars(r)
+	webhookmessageID, err := url.PathUnescape(vars["webhookmessageid"])
+	if err != nil {
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		return
+	}
+
+	webhookmessage, err := h.ah.GetWebhookMessage(ctx, webhookmessageID)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+
+	if webhookmessage == nil {
+		util.HTTPError(w, util.NewAPIError(util.ErrNotExist, errors.Errorf("webhook message %q doesn't exist", webhookmessageID)))
+		return
+	}
+
+	if err := util.HTTPResponse(w, http.StatusCreated, webhookmessage); err != nil {
+		h.log.Err(err).Send()
+	}
+}
+
+type WebhookMessagesHandler struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewWebhookMessagesHandler(log zerolog.Logger, ah *action.ActionHandler) *WebhookMessagesHandler {
+	return &WebhookMessagesHandler{log: log, ah: ah}
+}
+
+func (h *WebhookMessagesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	webhookmessages, err := h.ah.GetAllWebhookMessages(ctx)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+
+	if err := util.HTTPResponse(w, http.StatusCreated, webhookmessages); err != nil {
+		h.log.Err(err).Send()
+	}
+}

--- a/internal/services/configstore/configstore.go
+++ b/internal/services/configstore/configstore.go
@@ -147,6 +147,7 @@ func (s *Configstore) setupDefaultRouter() http.Handler {
 	createProjectHandler := api.NewCreateProjectHandler(s.log, s.ah, s.d)
 	updateProjectHandler := api.NewUpdateProjectHandler(s.log, s.ah, s.d)
 	deleteProjectHandler := api.NewDeleteProjectHandler(s.log, s.ah)
+	projectHooksHandler := api.NewProjectHooksHandler(s.log, s.ah)
 
 	secretsHandler := api.NewSecretsHandler(s.log, s.ah, s.d)
 	createSecretHandler := api.NewCreateSecretHandler(s.log, s.ah)
@@ -190,6 +191,16 @@ func (s *Configstore) setupDefaultRouter() http.Handler {
 	updateRemoteSourceHandler := api.NewUpdateRemoteSourceHandler(s.log, s.ah)
 	deleteRemoteSourceHandler := api.NewDeleteRemoteSourceHandler(s.log, s.ah)
 
+	hookHandler := api.NewHookHandler(s.log, s.ah)
+	createHookHandler := api.NewCreateHookHandler(s.log, s.ah)
+	updateHookHandler := api.NewUpdateHookHandler(s.log, s.ah)
+	deleteHookHandler := api.NewDeleteHookHandler(s.log, s.ah)
+
+	webhookMessagesHandler := api.NewWebhookMessagesHandler(s.log, s.ah)
+	webhookMessageHandler := api.NewWebhookMessageHandler(s.log, s.ah)
+	createWebhookMessageHandler := api.NewCreateWebhookMessageHandler(s.log, s.ah)
+	deleteWebhookMessageHandler := api.NewDeleteWebhookMessageHandler(s.log, s.ah)
+
 	router := mux.NewRouter()
 	apirouter := router.PathPrefix("/api/v1alpha").Subrouter().UseEncodedPath()
 
@@ -204,6 +215,7 @@ func (s *Configstore) setupDefaultRouter() http.Handler {
 	apirouter.Handle("/projects", createProjectHandler).Methods("POST")
 	apirouter.Handle("/projects/{projectref}", updateProjectHandler).Methods("PUT")
 	apirouter.Handle("/projects/{projectref}", deleteProjectHandler).Methods("DELETE")
+	apirouter.Handle("/projects/{projectref}/hooks", projectHooksHandler).Methods("GET")
 
 	apirouter.Handle("/projectgroups/{projectgroupref}/secrets", secretsHandler).Methods("GET")
 	apirouter.Handle("/projects/{projectref}/secrets", secretsHandler).Methods("GET")
@@ -252,6 +264,16 @@ func (s *Configstore) setupDefaultRouter() http.Handler {
 	apirouter.Handle("/remotesources", createRemoteSourceHandler).Methods("POST")
 	apirouter.Handle("/remotesources/{remotesourceref}", updateRemoteSourceHandler).Methods("PUT")
 	apirouter.Handle("/remotesources/{remotesourceref}", deleteRemoteSourceHandler).Methods("DELETE")
+
+	apirouter.Handle("/hooks/{hookid}", hookHandler).Methods("GET")
+	apirouter.Handle("/hooks", createHookHandler).Methods("POST")
+	apirouter.Handle("/hooks/{hookid}", updateHookHandler).Methods("PUT")
+	apirouter.Handle("/hooks/{hookid}", deleteHookHandler).Methods("DELETE")
+
+	apirouter.Handle("/webhookmessages", webhookMessagesHandler).Methods("GET")
+	apirouter.Handle("/webhookmessages/{webhookmessageid}", webhookMessageHandler).Methods("GET")
+	apirouter.Handle("/webhookmessages", createWebhookMessageHandler).Methods("POST")
+	apirouter.Handle("/webhookmessages/{webhookmessageid}", deleteWebhookMessageHandler).Methods("DELETE")
 
 	apirouter.Handle("/maintenance", maintenanceModeHandler).Methods("PUT", "DELETE")
 

--- a/internal/services/configstore/db/fetch.go
+++ b/internal/services/configstore/db/fetch.go
@@ -671,3 +671,135 @@ func (d *DB) scanVariables(rows *stdsql.Rows) ([]*types.Variable, []string, erro
 	}
 	return vs, ids, nil
 }
+
+func (d *DB) fetchHooks(tx *sql.Tx, q sq.Sqlizer) ([]*types.Hook, []string, error) {
+	rows, err := d.query(tx, q)
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+	defer rows.Close()
+
+	return d.scanHooks(rows)
+}
+
+func (d *DB) scanHook(rows *stdsql.Rows, additionalFields []interface{}) (*types.Hook, string, error) {
+	var id string
+	var revision uint64
+	var data []byte
+	fields := append([]interface{}{&id, &revision, &data}, additionalFields...)
+	if err := rows.Scan(fields...); err != nil {
+		return nil, "", errors.Wrap(err, "failed to scan rows")
+	}
+	v := types.Hook{}
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &v); err != nil {
+			return nil, "", errors.Wrap(err, "failed to unmarshal Hook")
+		}
+	}
+
+	v.Revision = revision
+
+	return &v, id, nil
+}
+
+func (d *DB) scanHooks(rows *stdsql.Rows) ([]*types.Hook, []string, error) {
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+	fieldsNumber := len(cols)
+	if fieldsNumber < 3 {
+		return nil, nil, errors.Errorf("not enough columns (%d < 3)", len(cols))
+	}
+	var additionalFieldsPtr []interface{}
+	if fieldsNumber > 3 {
+		additionalFieldsNumber := fieldsNumber - 3
+		additionalFields := make([]interface{}, additionalFieldsNumber)
+		additionalFieldsPtr = make([]interface{}, additionalFieldsNumber)
+		for i := 0; i < additionalFieldsNumber; i++ {
+			additionalFieldsPtr[i] = &additionalFields[i]
+		}
+	}
+
+	vs := []*types.Hook{}
+	ids := []string{}
+	for rows.Next() {
+		v, id, err := d.scanHook(rows, additionalFieldsPtr)
+		if err != nil {
+			rows.Close()
+			return nil, nil, errors.WithStack(err)
+		}
+		vs = append(vs, v)
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+	return vs, ids, nil
+}
+
+func (d *DB) fetchWebhookMessages(tx *sql.Tx, q sq.Sqlizer) ([]*types.WebhookMessage, []string, error) {
+	rows, err := d.query(tx, q)
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+	defer rows.Close()
+
+	return d.scanWebhookMessages(rows)
+}
+
+func (d *DB) scanWebhookMessage(rows *stdsql.Rows, additionalFields []interface{}) (*types.WebhookMessage, string, error) {
+	var id string
+	var revision uint64
+	var data []byte
+	fields := append([]interface{}{&id, &revision, &data}, additionalFields...)
+	if err := rows.Scan(fields...); err != nil {
+		return nil, "", errors.Wrap(err, "failed to scan rows")
+	}
+	v := types.WebhookMessage{}
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &v); err != nil {
+			return nil, "", errors.Wrap(err, "failed to unmarshal WebhookMessage")
+		}
+	}
+
+	v.Revision = revision
+
+	return &v, id, nil
+}
+
+func (d *DB) scanWebhookMessages(rows *stdsql.Rows) ([]*types.WebhookMessage, []string, error) {
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+	fieldsNumber := len(cols)
+	if fieldsNumber < 3 {
+		return nil, nil, errors.Errorf("not enough columns (%d < 3)", len(cols))
+	}
+	var additionalFieldsPtr []interface{}
+	if fieldsNumber > 3 {
+		additionalFieldsNumber := fieldsNumber - 3
+		additionalFields := make([]interface{}, additionalFieldsNumber)
+		additionalFieldsPtr = make([]interface{}, additionalFieldsNumber)
+		for i := 0; i < additionalFieldsNumber; i++ {
+			additionalFieldsPtr[i] = &additionalFields[i]
+		}
+	}
+
+	vs := []*types.WebhookMessage{}
+	ids := []string{}
+	for rows.Next() {
+		v, id, err := d.scanWebhookMessage(rows, additionalFieldsPtr)
+		if err != nil {
+			rows.Close()
+			return nil, nil, errors.WithStack(err)
+		}
+		vs = append(vs, v)
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+	return vs, ids, nil
+}

--- a/internal/services/configstore/db/objects/objects.go
+++ b/internal/services/configstore/db/objects/objects.go
@@ -15,4 +15,6 @@ var ObjectsInfo = []idb.ObjectInfo{
 	{Name: "Project", Table: "project"},
 	{Name: "Secret", Table: "secret"},
 	{Name: "Variable", Table: "variable"},
+	{Name: "Hook", Table: "hook"},
+	{Name: "WebhookMessage", Table: "webhookmessage"},
 }

--- a/internal/services/gateway/action/hook.go
+++ b/internal/services/gateway/action/hook.go
@@ -1,0 +1,165 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"context"
+
+	"agola.io/agola/internal/errors"
+	"agola.io/agola/internal/util"
+	csatypes "agola.io/agola/services/configstore/api/types"
+	"agola.io/agola/services/configstore/types"
+)
+
+func (h *ActionHandler) GetProjectHooks(ctx context.Context, projectRef string) ([]*types.Hook, error) {
+	hooksResp, _, err := h.configstoreClient.GetProjectHooks(ctx, projectRef)
+	if err != nil {
+		return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
+	}
+
+	return hooksResp, nil
+}
+
+type CreateHookRequest struct {
+	ProjectRef     string
+	DestinationURL string
+	ContentType    string
+	Secret         string
+	PendingEvent   bool
+	SuccessEvent   bool
+	ErrorEvent     bool
+	FailedEvent    bool
+}
+
+func (h *ActionHandler) CreateHook(ctx context.Context, req *CreateHookRequest) (*types.Hook, error) {
+	isProjectOwner, err := h.isUserProjectOwner(ctx, req.ProjectRef)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if !isProjectOwner {
+		return nil, util.NewAPIError(util.ErrUnauthorized, errors.Errorf("user not owner of project %q", req.ProjectRef))
+	}
+
+	creq := csatypes.CreateHookRequest{
+		ProjectRef:     req.ProjectRef,
+		DestinationURL: req.DestinationURL,
+		ContentType:    req.ContentType,
+		Secret:         req.Secret,
+		PendingEvent:   &req.PendingEvent,
+		SuccessEvent:   &req.SuccessEvent,
+		ErrorEvent:     &req.ErrorEvent,
+		FailedEvent:    &req.FailedEvent,
+	}
+
+	hook, _, err := h.configstoreClient.CreateHook(ctx, &creq)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return hook, errors.WithStack(err)
+}
+
+func (h *ActionHandler) DeleteHook(ctx context.Context, curHookID string) error {
+	hook, err := h.GetHook(ctx, curHookID)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if hook == nil {
+		return util.NewAPIError(util.ErrNotExist, errors.Errorf("failed to get hook %q", curHookID))
+	}
+
+	isProjectOwner, err := h.isUserProjectOwner(ctx, hook.ProjectID)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if !isProjectOwner {
+		return util.NewAPIError(util.ErrUnauthorized, errors.Errorf("user not owner of project %q", hook.ID))
+	}
+
+	if _, err = h.configstoreClient.DeleteHook(ctx, curHookID); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return errors.WithStack(err)
+}
+
+func (h *ActionHandler) GetHook(ctx context.Context, hookID string) (*types.Hook, error) {
+	hook, _, err := h.configstoreClient.GetHook(ctx, hookID)
+	if err != nil {
+		return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
+	}
+	return hook, nil
+}
+
+type UpdateHookRequest struct {
+	DestinationURL string
+	ContentType    string
+	Secret         string
+	PendingEvent   bool
+	SuccessEvent   bool
+	ErrorEvent     bool
+	FailedEvent    bool
+}
+
+func (h *ActionHandler) UpdateHook(ctx context.Context, curHookID string, req *UpdateHookRequest) (*types.Hook, error) {
+	creq := csatypes.UpdateHookRequest{
+		DestinationURL: req.DestinationURL,
+		ContentType:    req.ContentType,
+		Secret:         req.Secret,
+		PendingEvent:   &req.PendingEvent,
+		SuccessEvent:   &req.SuccessEvent,
+		ErrorEvent:     &req.ErrorEvent,
+		FailedEvent:    &req.FailedEvent,
+	}
+
+	hook, err := h.GetHook(ctx, curHookID)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if hook == nil {
+		return nil, util.NewAPIError(util.ErrNotExist, errors.Errorf("failed to get hook %q", curHookID))
+	}
+
+	isProjectOwner, err := h.isUserProjectOwner(ctx, hook.ProjectID)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if !isProjectOwner {
+		return nil, util.NewAPIError(util.ErrUnauthorized, errors.Errorf("user not owner of project %q", hook.ProjectID))
+	}
+
+	hook, _, err = h.configstoreClient.UpdateHook(ctx, curHookID, &creq)
+	if err != nil {
+		return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
+	}
+	return hook, nil
+}
+
+func (h *ActionHandler) isUserProjectOwner(ctx context.Context, projectRef string) (bool, error) {
+	project, err := h.GetProject(ctx, projectRef)
+	if err != nil {
+		return false, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project %q", projectRef))
+	}
+	pg, _, err := h.configstoreClient.GetProjectGroup(ctx, project.Parent.ID)
+	if err != nil {
+		return false, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project group %q", project.Parent.ID))
+	}
+	isProjectOwner, err := h.IsProjectOwner(ctx, pg.OwnerType, project.OwnerID)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to determine ownership")
+	}
+
+	return isProjectOwner, nil
+}

--- a/internal/services/gateway/api/hook.go
+++ b/internal/services/gateway/api/hook.go
@@ -1,0 +1,206 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"agola.io/agola/internal/services/gateway/action"
+	util "agola.io/agola/internal/util"
+	cstypes "agola.io/agola/services/configstore/types"
+	gwapitypes "agola.io/agola/services/gateway/api/types"
+	"github.com/gorilla/mux"
+	"github.com/rs/zerolog"
+)
+
+type CreateHookHandler struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewCreateHookHandler(log zerolog.Logger, ah *action.ActionHandler) *CreateHookHandler {
+	return &CreateHookHandler{log: log, ah: ah}
+}
+
+func (h *CreateHookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var req *gwapitypes.CreateHookRequest
+	d := json.NewDecoder(r.Body)
+	if err := d.Decode(&req); err != nil {
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		return
+	}
+
+	areq := &action.CreateHookRequest{
+		ProjectRef:     req.ProjectRef,
+		DestinationURL: req.DestinationURL,
+		ContentType:    req.ContentType,
+		Secret:         req.Secret,
+	}
+	if req.PendingEvent != nil {
+		areq.PendingEvent = *req.PendingEvent
+	}
+	if req.SuccessEvent != nil {
+		areq.SuccessEvent = *req.SuccessEvent
+	}
+	if req.ErrorEvent != nil {
+		areq.ErrorEvent = *req.ErrorEvent
+	}
+	if req.FailedEvent != nil {
+		areq.FailedEvent = *req.FailedEvent
+	}
+
+	hook, err := h.ah.CreateHook(ctx, areq)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+
+	res := createHookResponse(hook)
+	if err := util.HTTPResponse(w, http.StatusCreated, res); err != nil {
+		h.log.Err(err).Send()
+	}
+}
+
+type DeleteHookHandler struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewDeleteHookHandler(log zerolog.Logger, ah *action.ActionHandler) *DeleteHookHandler {
+	return &DeleteHookHandler{log: log, ah: ah}
+}
+
+func (h *DeleteHookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	vars := mux.Vars(r)
+	hookID, err := url.PathUnescape(vars["hookid"])
+	if err != nil {
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		return
+	}
+
+	err = h.ah.DeleteHook(ctx, hookID)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+	if err := util.HTTPResponse(w, http.StatusNoContent, nil); err != nil {
+		h.log.Err(err).Send()
+	}
+}
+
+type HookHandler struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewHookHandler(log zerolog.Logger, ah *action.ActionHandler) *HookHandler {
+	return &HookHandler{log: log, ah: ah}
+}
+
+func (h *HookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	vars := mux.Vars(r)
+	hookID, err := url.PathUnescape(vars["hookid"])
+	if err != nil {
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		return
+	}
+
+	hook, err := h.ah.GetHook(ctx, hookID)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+
+	res := createHookResponse(hook)
+	if err := util.HTTPResponse(w, http.StatusCreated, res); err != nil {
+		h.log.Err(err).Send()
+	}
+}
+
+type UpdateHookHandler struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewUpdateHookHandler(log zerolog.Logger, ah *action.ActionHandler) *UpdateHookHandler {
+	return &UpdateHookHandler{log: log, ah: ah}
+}
+
+func (h *UpdateHookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	vars := mux.Vars(r)
+	hookID, err := url.PathUnescape(vars["hookid"])
+	if err != nil {
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		return
+	}
+
+	var req *gwapitypes.UpdateHookRequest
+	d := json.NewDecoder(r.Body)
+	if err := d.Decode(&req); err != nil {
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		return
+	}
+
+	areq := &action.UpdateHookRequest{
+		DestinationURL: req.DestinationURL,
+		ContentType:    req.ContentType,
+		Secret:         req.Secret,
+	}
+	if req.PendingEvent != nil {
+		areq.PendingEvent = *req.PendingEvent
+	}
+	if req.SuccessEvent != nil {
+		areq.SuccessEvent = *req.SuccessEvent
+	}
+	if req.ErrorEvent != nil {
+		areq.ErrorEvent = *req.ErrorEvent
+	}
+	if req.FailedEvent != nil {
+		areq.FailedEvent = *req.FailedEvent
+	}
+
+	hook, err := h.ah.UpdateHook(ctx, hookID, areq)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+
+	res := createHookResponse(hook)
+	if err := util.HTTPResponse(w, http.StatusCreated, res); err != nil {
+		h.log.Err(err).Send()
+	}
+}
+
+func createHookResponse(o *cstypes.Hook) *gwapitypes.HookResponse {
+	org := &gwapitypes.HookResponse{
+		ID:             o.ID,
+		ProjectRef:     o.ProjectID,
+		DestinationURL: o.DestinationURL,
+		ContentType:    o.ContentType,
+		Secret:         o.Secret,
+		PendingEvent:   o.PendingEvent,
+		SuccessEvent:   o.SuccessEvent,
+		ErrorEvent:     o.ErrorEvent,
+		FailedEvent:    o.FailedEvent,
+	}
+	return org
+}

--- a/internal/services/gateway/api/project.go
+++ b/internal/services/gateway/api/project.go
@@ -284,3 +284,37 @@ func (h *ProjectCreateRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		h.log.Err(err).Send()
 	}
 }
+
+type ProjectHooksHandler struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewProjectHooksHandler(log zerolog.Logger, ah *action.ActionHandler) *ProjectHooksHandler {
+	return &ProjectHooksHandler{log: log, ah: ah}
+}
+
+func (h *ProjectHooksHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	vars := mux.Vars(r)
+	projectRef, err := url.PathUnescape(vars["projectref"])
+	if err != nil {
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		return
+	}
+
+	hooks, err := h.ah.GetProjectHooks(ctx, projectRef)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+
+	res := make([]*gwapitypes.HookResponse, len(hooks))
+	for i, userOrg := range hooks {
+		res[i] = createHookResponse(userOrg)
+	}
+
+	if err := util.HTTPResponse(w, http.StatusOK, res); err != nil {
+		h.log.Err(err).Send()
+	}
+}

--- a/internal/services/gateway/gateway.go
+++ b/internal/services/gateway/gateway.go
@@ -163,6 +163,7 @@ func (g *Gateway) Run(ctx context.Context) error {
 	projectReconfigHandler := api.NewProjectReconfigHandler(g.log, g.ah)
 	projectUpdateRepoLinkedAccountHandler := api.NewProjectUpdateRepoLinkedAccountHandler(g.log, g.ah)
 	projectCreateRunHandler := api.NewProjectCreateRunHandler(g.log, g.ah)
+	projectHooksHandler := api.NewProjectHooksHandler(g.log, g.ah)
 
 	secretHandler := api.NewSecretHandler(g.log, g.ah)
 	createSecretHandler := api.NewCreateSecretHandler(g.log, g.ah)
@@ -218,6 +219,11 @@ func (g *Gateway) Run(ctx context.Context) error {
 	userRunLogsHandler := api.NewLogsHandler(g.log, g.ah, common.GroupTypeUser)
 	userRunLogsDeleteHandler := api.NewLogsDeleteHandler(g.log, g.ah, common.GroupTypeUser)
 
+	hookHandler := api.NewHookHandler(g.log, g.ah)
+	createHookHandler := api.NewCreateHookHandler(g.log, g.ah)
+	updateHookHandler := api.NewUpdateHookHandler(g.log, g.ah)
+	deleteHookHandler := api.NewDeleteHookHandler(g.log, g.ah)
+
 	userRemoteReposHandler := api.NewUserRemoteReposHandler(g.log, g.ah, g.configstoreClient)
 
 	badgeHandler := api.NewBadgeHandler(g.log, g.ah)
@@ -263,6 +269,7 @@ func (g *Gateway) Run(ctx context.Context) error {
 	apirouter.Handle("/projects/{projectref}/runs/{runnumber}/tasks/{taskid}/actions", authForcedHandler(projectRunTaskActionsHandler)).Methods("PUT")
 	apirouter.Handle("/projects/{projectref}/runs/{runnumber}/tasks/{taskid}/logs", authOptionalHandler(projectRunLogsHandler)).Methods("GET")
 	apirouter.Handle("/projects/{projectref}/runs/{runnumber}/tasks/{taskid}/logs", authForcedHandler(projectRunLogsDeleteHandler)).Methods("DELETE")
+	apirouter.Handle("/projects/{projectref}/hooks", authForcedHandler(projectHooksHandler)).Methods("GET")
 
 	apirouter.Handle("/projectgroups/{projectgroupref}/secrets", authForcedHandler(secretHandler)).Methods("GET")
 	apirouter.Handle("/projects/{projectref}/secrets", authForcedHandler(secretHandler)).Methods("GET")
@@ -316,6 +323,11 @@ func (g *Gateway) Run(ctx context.Context) error {
 	apirouter.Handle("/orgs/{orgref}/members", authForcedHandler(orgMembersHandler)).Methods("GET")
 	apirouter.Handle("/orgs/{orgref}/members/{userref}", authForcedHandler(addOrgMemberHandler)).Methods("PUT")
 	apirouter.Handle("/orgs/{orgref}/members/{userref}", authForcedHandler(removeOrgMemberHandler)).Methods("DELETE")
+
+	apirouter.Handle("/hooks/{hookid}", authForcedHandler(hookHandler)).Methods("GET")
+	apirouter.Handle("/hooks", authForcedHandler(createHookHandler)).Methods("POST")
+	apirouter.Handle("/hooks/{hookid}", authForcedHandler(updateHookHandler)).Methods("PUT")
+	apirouter.Handle("/hooks/{hookid}", authForcedHandler(deleteHookHandler)).Methods("DELETE")
 
 	apirouter.Handle("/user/remoterepos/{remotesourceref}", authForcedHandler(userRemoteReposHandler)).Methods("GET")
 

--- a/internal/services/notification/notification.go
+++ b/internal/services/notification/notification.go
@@ -78,6 +78,7 @@ func NewNotificationService(ctx context.Context, log zerolog.Logger, gc *config.
 
 func (n *NotificationService) Run(ctx context.Context) error {
 	go n.runEventsHandlerLoop(ctx)
+	go n.webhooksSenderHandlerLoop(ctx)
 
 	<-ctx.Done()
 	n.log.Info().Msgf("notification service exiting")

--- a/internal/services/notification/runevents.go
+++ b/internal/services/notification/runevents.go
@@ -96,10 +96,6 @@ func (n *NotificationService) runEventsHandler(ctx context.Context) error {
 				return errors.WithStack(err)
 			}
 
-			// TODO(sgotti)
-			// this is just a basic handling. Improve it to store received events and
-			// their status in the db so we can also do more logic like retrying and handle
-			// multiple kind of notifications (email etc...)
 			if err := n.updateCommitStatus(ctx, ev); err != nil {
 				n.log.Info().Msgf("failed to update commit status: %v", err)
 			}

--- a/internal/services/notification/webhookmessagesender.go
+++ b/internal/services/notification/webhookmessagesender.go
@@ -1,0 +1,158 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notification
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"agola.io/agola/internal/errors"
+	gitsource "agola.io/agola/internal/gitsources"
+	"agola.io/agola/internal/lock"
+	"agola.io/agola/internal/services/common"
+	cstypes "agola.io/agola/services/configstore/types"
+)
+
+const (
+	RunWebhookMessagesLockKey = "webhookmessages"
+)
+
+func (n *NotificationService) webhooksSenderHandlerLoop(ctx context.Context) {
+	for {
+		if err := n.webhooksSenderHandler(ctx); err != nil {
+			n.log.Err(err).Send()
+		}
+
+		sleepCh := time.NewTimer(1 * time.Second).C
+		select {
+		case <-ctx.Done():
+			return
+		case <-sleepCh:
+		}
+	}
+}
+
+func (n *NotificationService) webhooksSenderHandler(ctx context.Context) error {
+	l := n.lf.NewLock(RunWebhookMessagesLockKey)
+	if err := l.TryLock(ctx); err != nil {
+		if errors.Is(err, lock.ErrLocked) {
+			return nil
+		}
+		return errors.WithStack(err)
+	}
+	defer func() { _ = l.Unlock() }()
+
+	webhookMessages, _, err := n.configstoreClient.GetWebhookMessages(ctx)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	for _, webhookMessage := range webhookMessages {
+		if err = n.sendWebhookMessage(ctx, webhookMessage); err != nil {
+			return errors.WithStack(err)
+		} else {
+			if _, err = n.configstoreClient.DeleteWebookMessage(ctx, webhookMessage.ID); err != nil {
+				return errors.WithStack(err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (n *NotificationService) sendWebhookMessage(ctx context.Context, webhookMessage *cstypes.WebhookMessage) error {
+	if webhookMessage.IsCustom {
+		return n.sendCustomWebhookMessage(ctx, webhookMessage)
+	} else {
+		return n.sendGitsourceWebhookMessage(ctx, webhookMessage)
+	}
+}
+
+func (n *NotificationService) sendGitsourceWebhookMessage(ctx context.Context, webhookMessage *cstypes.WebhookMessage) error {
+	project, _, err := n.configstoreClient.GetProject(ctx, *webhookMessage.ProjectID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get project %s", *webhookMessage.ProjectID)
+	}
+
+	user, _, err := n.configstoreClient.GetUserByLinkedAccount(ctx, project.LinkedAccountID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get user by linked account %q", project.LinkedAccountID)
+	}
+
+	linkedAccounts, _, err := n.configstoreClient.GetUserLinkedAccounts(ctx, user.ID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get user %q linked accounts", user.Name)
+	}
+
+	var la *cstypes.LinkedAccount
+	for _, v := range linkedAccounts {
+		if v.ID == project.LinkedAccountID {
+			la = v
+			break
+		}
+	}
+	if la == nil {
+		return errors.Errorf("linked account %q for user %q doesn't exist", project.LinkedAccountID, user.Name)
+	}
+
+	rs, _, err := n.configstoreClient.GetRemoteSource(ctx, la.RemoteSourceID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get remote source %q", la.RemoteSourceID)
+	}
+
+	// TODO(sgotti) handle refreshing oauth2 tokens
+	gitSource, err := common.GetGitSource(rs, la)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create gitea client")
+	}
+
+	if err := gitSource.CreateCommitStatus(project.RepositoryPath, webhookMessage.CommitSha, gitsource.CommitStatus(webhookMessage.CommitStatus), webhookMessage.TargetURL, webhookMessage.Description, webhookMessage.StatusContext); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+type WemhookMessage struct {
+	TargetURL string `json:"target_url,omitempty"`
+
+	CommitStatus string `json:"commit_status,omitempty"`
+
+	Description string `json:"description,omitempty"`
+
+	RepositoryPath string `json:"repository_path,omitempty"`
+
+	CommitSha string `json:"commit_sha,omitempty"`
+
+	Secret string `json:"secret,omitempty"`
+
+	StatusContext string `json:"status_context,omitempty"`
+}
+
+func (n *NotificationService) sendCustomWebhookMessage(ctx context.Context, webhookMessage *cstypes.WebhookMessage) error {
+	message := WemhookMessage{TargetURL: webhookMessage.TargetURL, CommitStatus: webhookMessage.CommitStatus, CommitSha: webhookMessage.CommitSha, Description: webhookMessage.Description, RepositoryPath: webhookMessage.RepositoryPath, StatusContext: webhookMessage.StatusContext, Secret: *webhookMessage.Secret}
+
+	c := &http.Client{}
+
+	body, err := json.Marshal(&message)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.Post(*webhookMessage.DestinationURL, *webhookMessage.ContentType, bytes.NewReader(body))
+	return errors.WithStack(err)
+}

--- a/services/configstore/api/types/hook.go
+++ b/services/configstore/api/types/hook.go
@@ -1,0 +1,49 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+type CreateHookRequest struct {
+	ProjectRef string `json:"project_ref,omitempty"`
+
+	DestinationURL string `json:"destination_url,omitempty"`
+
+	ContentType string `json:"content_type,omitempty"`
+
+	Secret string `json:"secret,omitempty"`
+
+	PendingEvent *bool `json:"pending_event,omitempty"`
+
+	SuccessEvent *bool `json:"success_event,omitempty"`
+
+	ErrorEvent *bool `json:"error_event,omitempty"`
+
+	FailedEvent *bool `json:"failed_event,omitempty"`
+}
+
+type UpdateHookRequest struct {
+	DestinationURL string `json:"destination_url,omitempty"`
+
+	ContentType string `json:"content_type,omitempty"`
+
+	Secret string `json:"secret,omitempty"`
+
+	PendingEvent *bool `json:"pending_event,omitempty"`
+
+	SuccessEvent *bool `json:"success_event,omitempty"`
+
+	ErrorEvent *bool `json:"error_event,omitempty"`
+
+	FailedEvent *bool `json:"failed_event,omitempty"`
+}

--- a/services/configstore/api/types/webhookmessage.go
+++ b/services/configstore/api/types/webhookmessage.go
@@ -1,0 +1,39 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+type CreateWebhookMessageRequest struct {
+	IsCustom bool `json:"is_custom,omitempty"`
+
+	ProjectID *string `json:"project_id,omitempty"`
+
+	DestinationURL *string `json:"destination_url,omitempty"`
+
+	ContentType string `json:"content_type,omitempty"`
+
+	Secret string `json:"secret,omitempty"`
+
+	TargetURL string `json:"target_url,omitempty"`
+
+	CommitStatus string `json:"commit_status,omitempty"`
+
+	Description string `json:"description,omitempty"`
+
+	RepositoryPath string `json:"repository_path,omitempty"`
+
+	CommitSha string `json:"commit_sha,omitempty"`
+
+	StatusContext string `json:"status_context,omitempty"`
+}

--- a/services/configstore/client/client.go
+++ b/services/configstore/client/client.go
@@ -579,3 +579,68 @@ func (c *Client) GetOrgMembers(ctx context.Context, orgRef string) ([]*csapitype
 	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/orgs/%s/members", orgRef), nil, jsonContent, nil, &orgMembers)
 	return orgMembers, resp, errors.WithStack(err)
 }
+
+func (c *Client) GetHook(ctx context.Context, hookID string) (*cstypes.Hook, *http.Response, error) {
+	hook := new(cstypes.Hook)
+	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/hooks/%s", hookID), nil, jsonContent, nil, hook)
+	return hook, resp, errors.WithStack(err)
+}
+
+func (c *Client) CreateHook(ctx context.Context, req *csapitypes.CreateHookRequest) (*cstypes.Hook, *http.Response, error) {
+	reqj, err := json.Marshal(req)
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+
+	hook := new(cstypes.Hook)
+	resp, err := c.getParsedResponse(ctx, "POST", "/hooks", nil, jsonContent, bytes.NewReader(reqj), hook)
+	return hook, resp, errors.WithStack(err)
+}
+
+func (c *Client) UpdateHook(ctx context.Context, hookID string, req *csapitypes.UpdateHookRequest) (*cstypes.Hook, *http.Response, error) {
+	reqj, err := json.Marshal(req)
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+
+	hook := new(cstypes.Hook)
+	resp, err := c.getParsedResponse(ctx, "PUT", fmt.Sprintf("/hooks/%s", hookID), nil, jsonContent, bytes.NewReader(reqj), hook)
+	return hook, resp, errors.WithStack(err)
+}
+
+func (c *Client) DeleteHook(ctx context.Context, hookID string) (*http.Response, error) {
+	return c.getResponse(ctx, "DELETE", fmt.Sprintf("/hooks/%s", hookID), nil, jsonContent, nil)
+}
+
+func (c *Client) GetProjectHooks(ctx context.Context, projectRef string) ([]*cstypes.Hook, *http.Response, error) {
+	hooks := []*cstypes.Hook{}
+	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/projects/%s/hooks", projectRef), nil, jsonContent, nil, &hooks)
+	return hooks, resp, errors.WithStack(err)
+}
+
+func (c *Client) GetWebhookMessage(ctx context.Context, webhookMessageID string) (*cstypes.WebhookMessage, *http.Response, error) {
+	webhookMessage := new(cstypes.WebhookMessage)
+	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/webhookmessages/%s", webhookMessageID), nil, jsonContent, nil, webhookMessage)
+	return webhookMessage, resp, errors.WithStack(err)
+}
+
+func (c *Client) CreateWebookMessage(ctx context.Context, req *csapitypes.CreateWebhookMessageRequest) (*cstypes.WebhookMessage, *http.Response, error) {
+	reqj, err := json.Marshal(req)
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+
+	webhookMessage := new(cstypes.WebhookMessage)
+	resp, err := c.getParsedResponse(ctx, "POST", "/webhookmessages", nil, jsonContent, bytes.NewReader(reqj), webhookMessage)
+	return webhookMessage, resp, errors.WithStack(err)
+}
+
+func (c *Client) DeleteWebookMessage(ctx context.Context, webhookMessageID string) (*http.Response, error) {
+	return c.getResponse(ctx, "DELETE", fmt.Sprintf("/webhookmessages/%s", webhookMessageID), nil, jsonContent, nil)
+}
+
+func (c *Client) GetWebhookMessages(ctx context.Context) ([]*cstypes.WebhookMessage, *http.Response, error) {
+	webhookMessages := []*cstypes.WebhookMessage{}
+	resp, err := c.getParsedResponse(ctx, "GET", "/webhookmessages", nil, jsonContent, nil, &webhookMessages)
+	return webhookMessages, resp, errors.WithStack(err)
+}

--- a/services/configstore/types/hook.go
+++ b/services/configstore/types/hook.go
@@ -1,0 +1,59 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	stypes "agola.io/agola/services/types"
+
+	"github.com/gofrs/uuid"
+)
+
+const (
+	HookKind    = "hook"
+	HookVersion = "v0.1.0"
+)
+
+type Hook struct {
+	stypes.TypeMeta
+	stypes.ObjectMeta
+
+	ProjectID string `json:"project_id,omitempty"`
+
+	DestinationURL string `json:"destination_url,omitempty"`
+
+	ContentType string `json:"content_type,omitempty"`
+
+	Secret string `json:"secret,omitempty"`
+
+	PendingEvent *bool `json:"pending_event,omitempty"`
+
+	SuccessEvent *bool `json:"success_event,omitempty"`
+
+	ErrorEvent *bool `json:"error_event,omitempty"`
+
+	FailedEvent *bool `json:"failed_event,omitempty"`
+}
+
+func NewHook() *Hook {
+	return &Hook{
+		TypeMeta: stypes.TypeMeta{
+			Kind:    HookKind,
+			Version: HookVersion,
+		},
+		ObjectMeta: stypes.ObjectMeta{
+			ID: uuid.Must(uuid.NewV4()).String(),
+		},
+	}
+}

--- a/services/configstore/types/types.go
+++ b/services/configstore/types/types.go
@@ -17,14 +17,16 @@ package types
 type ObjectKind string
 
 const (
-	ObjectKindUser         ObjectKind = "user"
-	ObjectKindOrg          ObjectKind = "org"
-	ObjectKindOrgMember    ObjectKind = "orgmember"
-	ObjectKindProjectGroup ObjectKind = "projectgroup"
-	ObjectKindProject      ObjectKind = "project"
-	ObjectKindRemoteSource ObjectKind = "remotesource"
-	ObjectKindSecret       ObjectKind = "secret"
-	ObjectKindVariable     ObjectKind = "variable"
+	ObjectKindUser           ObjectKind = "user"
+	ObjectKindOrg            ObjectKind = "org"
+	ObjectKindOrgMember      ObjectKind = "orgmember"
+	ObjectKindProjectGroup   ObjectKind = "projectgroup"
+	ObjectKindProject        ObjectKind = "project"
+	ObjectKindRemoteSource   ObjectKind = "remotesource"
+	ObjectKindSecret         ObjectKind = "secret"
+	ObjectKindVariable       ObjectKind = "variable"
+	ObjectKindHook           ObjectKind = "hook"
+	ObjectKindWebhookMessage ObjectKind = "webhookmessage"
 )
 
 type Visibility string

--- a/services/configstore/types/webhookmessage.go
+++ b/services/configstore/types/webhookmessage.go
@@ -1,0 +1,65 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	stypes "agola.io/agola/services/types"
+
+	"github.com/gofrs/uuid"
+)
+
+const (
+	WebhookMessageKind    = "webhookmessage"
+	WebhookMessageVersion = "v0.1.0"
+)
+
+type WebhookMessage struct {
+	stypes.TypeMeta
+	stypes.ObjectMeta
+
+	IsCustom bool `json:"is_custom,omitempty"`
+
+	ProjectID *string `json:"project_id,omitempty"`
+
+	DestinationURL *string `json:"destination_url,omitempty"`
+
+	ContentType *string `json:"content_type,omitempty"`
+
+	Secret *string `json:"secret,omitempty"`
+
+	TargetURL string `json:"target_url,omitempty"`
+
+	CommitStatus string `json:"commit_status,omitempty"`
+
+	Description string `json:"description,omitempty"`
+
+	RepositoryPath string `json:"repository_path,omitempty"`
+
+	CommitSha string `json:"commit_sha,omitempty"`
+
+	StatusContext string `json:"status_context,omitempty"`
+}
+
+func NewWebhookMessage() *WebhookMessage {
+	return &WebhookMessage{
+		TypeMeta: stypes.TypeMeta{
+			Kind:    WebhookMessageKind,
+			Version: WebhookMessageVersion,
+		},
+		ObjectMeta: stypes.ObjectMeta{
+			ID: uuid.Must(uuid.NewV4()).String(),
+		},
+	}
+}

--- a/services/gateway/api/types/hook.go
+++ b/services/gateway/api/types/hook.go
@@ -1,0 +1,61 @@
+// Copyright 2022 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+type CreateHookRequest struct {
+	ProjectRef string `json:"project_ref,omitempty"`
+
+	DestinationURL string `json:"destination_url,omitempty"`
+
+	ContentType string `json:"content_type,omitempty"`
+
+	Secret string `json:"secret,omitempty"`
+
+	PendingEvent *bool `json:"pending_event,omitempty"`
+
+	SuccessEvent *bool `json:"success_event,omitempty"`
+
+	ErrorEvent *bool `json:"error_event,omitempty"`
+
+	FailedEvent *bool `json:"failed_event,omitempty"`
+}
+
+type UpdateHookRequest struct {
+	DestinationURL string `json:"destination_url,omitempty"`
+
+	ContentType string `json:"content_type,omitempty"`
+
+	Secret string `json:"secret,omitempty"`
+
+	PendingEvent *bool `json:"pending_event,omitempty"`
+
+	SuccessEvent *bool `json:"success_event,omitempty"`
+
+	ErrorEvent *bool `json:"error_event,omitempty"`
+
+	FailedEvent *bool `json:"failed_event,omitempty"`
+}
+
+type HookResponse struct {
+	ID             string `json:"id,omitempty"`
+	ProjectRef     string `json:"project_ref,omitempty"`
+	DestinationURL string `json:"destination_url,omitempty"`
+	ContentType    string `json:"content_type,omitempty"`
+	Secret         string `json:"secret,omitempty"`
+	PendingEvent   *bool  `json:"pending_event,omitempty"`
+	SuccessEvent   *bool  `json:"success_event,omitempty"`
+	ErrorEvent     *bool  `json:"error_event,omitempty"`
+	FailedEvent    *bool  `json:"failed_event,omitempty"`
+}

--- a/services/gateway/client/client.go
+++ b/services/gateway/client/client.go
@@ -28,6 +28,7 @@ import (
 
 	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/util"
+	"agola.io/agola/services/gateway/api/types"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 )
 
@@ -636,4 +637,42 @@ func (c *Client) GetUserOrgs(ctx context.Context) ([]*gwapitypes.UserOrgsRespons
 	userOrgs := []*gwapitypes.UserOrgsResponse{}
 	resp, err := c.getParsedResponse(ctx, "GET", "/user/orgs", nil, jsonContent, nil, &userOrgs)
 	return userOrgs, resp, errors.WithStack(err)
+}
+
+func (c *Client) GetHook(ctx context.Context, hookID string) (*types.HookResponse, *http.Response, error) {
+	hook := new(types.HookResponse)
+	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/hooks/%s", hookID), nil, jsonContent, nil, hook)
+	return hook, resp, errors.WithStack(err)
+}
+
+func (c *Client) CreateHook(ctx context.Context, req *gwapitypes.CreateHookRequest) (*types.HookResponse, *http.Response, error) {
+	reqj, err := json.Marshal(req)
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+
+	hook := new(types.HookResponse)
+	resp, err := c.getParsedResponse(ctx, "POST", "/hooks", nil, jsonContent, bytes.NewReader(reqj), hook)
+	return hook, resp, errors.WithStack(err)
+}
+
+func (c *Client) UpdateHook(ctx context.Context, hookID string, req *gwapitypes.UpdateHookRequest) (*types.HookResponse, *http.Response, error) {
+	reqj, err := json.Marshal(req)
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+
+	hook := new(types.HookResponse)
+	resp, err := c.getParsedResponse(ctx, "PUT", fmt.Sprintf("/hooks/%s", hookID), nil, jsonContent, bytes.NewReader(reqj), hook)
+	return hook, resp, errors.WithStack(err)
+}
+
+func (c *Client) DeleteHook(ctx context.Context, hookID string) (*http.Response, error) {
+	return c.getResponse(ctx, "DELETE", fmt.Sprintf("/hooks/%s", hookID), nil, jsonContent, nil)
+}
+
+func (c *Client) GetProjectHooks(ctx context.Context, projectRef string) ([]*types.HookResponse, *http.Response, error) {
+	hooks := []*types.HookResponse{}
+	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/projects/%s/hooks", projectRef), nil, jsonContent, nil, &hooks)
+	return hooks, resp, errors.WithStack(err)
 }


### PR DESCRIPTION
fix  #339 

Add 2 table hook and webhookmessage.

When notification service receive a run event, runEventsHandler checks if there are some hook for that project and save the webhook message for a retry logic.
WebhooksSenderHandler give the webhook messages from the db and send they to the external services.