### PR TITLE
configstore: fix action AddOrgMember

### DIFF
--- a/internal/services/configstore/action/org.go
+++ b/internal/services/configstore/action/org.go
@@ -218,7 +218,7 @@ func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string
 			orgmember.MemberRole = role
 		}
 
-		if err := h.d.InsertOrganizationMember(tx, orgmember); err != nil {
+		if err := h.d.InsertOrUpdateOrganizationMember(tx, orgmember); err != nil {
 			return errors.WithStack(err)
 		}
 


### PR DESCRIPTION
The configstore action AddOrgMember actually use the db method InsertOrganizationMember, that return error when update an existing user member.
The method InsertOrUpdateOrganizationMember works for new and existing user member.
