### PR TITLE
configstore: use GetOrg method in DeleteOrg

### DIFF
--- a/internal/services/configstore/action/org.go
+++ b/internal/services/configstore/action/org.go
@@ -187,7 +187,7 @@ func (h *ActionHandler) DeleteOrg(ctx context.Context, orgRef string) error {
 	err := h.d.Do(ctx, func(tx *sql.Tx) error {
 		var err error
 		// check org existance
-		org, err = h.d.GetOrgByName(tx, orgRef)
+		org, err = h.d.GetOrg(tx, orgRef)
 		if err != nil {
 			return errors.WithStack(err)
 		}


### PR DESCRIPTION
Use GetOrg method in DeleteOrg action to correctly get the org by both id and ref.