### PR TITLE
feat(k8s-driver): use custom ServiceAccount for task pods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 bin/
 tools/
 webbundle/bindata.go
+.idea/

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,6 +131,7 @@ type Task struct {
 	When                 *When                          `json:"when"`
 	DockerRegistriesAuth map[string]*DockerRegistryAuth `json:"docker_registries_auth"`
 	TaskTimeoutInterval  *types.Duration                `json:"task_timeout_interval"`
+	ServiceAccountName   string                         `json:"service_account_name,omitempty"`
 }
 
 type DependCondition string

--- a/internal/runconfig/runconfig.go
+++ b/internal/runconfig/runconfig.go
@@ -229,6 +229,7 @@ func GenRunConfigTasks(uuid util.UUIDGenerator, c *config.Config, runName string
 			Skip:                 !include,
 			NeedsApproval:        ct.Approval,
 			DockerRegistriesAuth: make(map[string]rstypes.DockerRegistryAuth),
+			ServiceAccountName:   ct.ServiceAccountName,
 		}
 
 		if t.Shell == "" {

--- a/internal/services/executor/driver/driver.go
+++ b/internal/services/executor/driver/driver.go
@@ -82,6 +82,10 @@ type PodConfig struct {
 	TaskID     string
 	Containers []*ContainerConfig
 	Arch       types.Arch
+
+	// Service account to use for the build pod
+	ServiceAccountName string
+
 	// The container dir where the init volume will be mounted
 	InitVolumeDir string
 	DockerConfig  *registry.DockerConfig

--- a/internal/services/executor/driver/k8s.go
+++ b/internal/services/executor/driver/k8s.go
@@ -357,6 +357,8 @@ func (d *K8sDriver) NewPod(ctx context.Context, podConfig *PodConfig, out io.Wri
 		return nil, errors.WithStack(err)
 	}
 
+	d.log.Debug().Str("ServiceAccount", podConfig.ServiceAccountName)
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: d.namespace,
@@ -365,9 +367,9 @@ func (d *K8sDriver) NewPod(ctx context.Context, podConfig *PodConfig, out io.Wri
 		},
 		Spec: corev1.PodSpec{
 			ImagePullSecrets: []corev1.LocalObjectReference{{Name: name}},
-			// don't mount service account secrets or pods will be able to talk with k8s
-			// api
-			AutomountServiceAccountToken: util.BoolP(false),
+			// only mount service account secrets if there's an explicit service account configured
+			AutomountServiceAccountToken: util.BoolP(podConfig.ServiceAccountName != ""),
+			ServiceAccountName:           podConfig.ServiceAccountName,
 			InitContainers: []corev1.Container{
 				{
 					Name:  "initcontainer",

--- a/internal/services/executor/executor.go
+++ b/internal/services/executor/executor.go
@@ -856,12 +856,13 @@ func (e *Executor) setupTask(ctx context.Context, rt *runningTask) error {
 	podConfig := &driver.PodConfig{
 		// generate a random pod id (don't use task id for future ability to restart
 		// tasks failed to start and don't clash with existing pods)
-		ID:            uuid.Must(uuid.NewV4()).String(),
-		TaskID:        et.ID,
-		Arch:          et.Spec.Arch,
-		InitVolumeDir: toolboxContainerDir,
-		DockerConfig:  dockerConfig,
-		Containers:    make([]*driver.ContainerConfig, len(et.Spec.Containers)),
+		ID:                 uuid.Must(uuid.NewV4()).String(),
+		TaskID:             et.ID,
+		Arch:               et.Spec.Arch,
+		InitVolumeDir:      toolboxContainerDir,
+		DockerConfig:       dockerConfig,
+		ServiceAccountName: et.Spec.ServiceAccountName,
+		Containers:         make([]*driver.ContainerConfig, len(et.Spec.Containers)),
 	}
 	for i, c := range et.Spec.Containers {
 		var cmd []string

--- a/internal/services/runservice/common/common.go
+++ b/internal/services/runservice/common/common.go
@@ -145,6 +145,7 @@ func GenExecutorTaskSpecData(r *types.Run, rt *types.RunTask, rc *types.RunConfi
 		CachePrefix:          cachePrefix,
 		DockerRegistriesAuth: rct.DockerRegistriesAuth,
 		TaskTimeoutInterval:  rct.TaskTimeoutInterval,
+		ServiceAccountName:   rct.ServiceAccountName,
 	}
 
 	// calculate workspace operations

--- a/services/runservice/types/executortask.go
+++ b/services/runservice/types/executortask.go
@@ -81,6 +81,8 @@ type ExecutorTaskSpecData struct {
 	Steps Steps `json:"steps,omitempty"`
 
 	TaskTimeoutInterval time.Duration `json:"task_timeout_interval"`
+
+	ServiceAccountName string `json:"service_account_name,omitempty"`
 }
 
 type ExecutorTaskStatus struct {

--- a/services/runservice/types/runconfig.go
+++ b/services/runservice/types/runconfig.go
@@ -82,6 +82,7 @@ type RunConfigTask struct {
 	Skip                 bool                            `json:"skip,omitempty"`
 	DockerRegistriesAuth map[string]DockerRegistryAuth   `json:"docker_registries_auth"`
 	TaskTimeoutInterval  time.Duration                   `json:"task_timeout_interval"`
+	ServiceAccountName   string                          `json:"service_account_name,omitempty"`
 }
 
 func (rct *RunConfigTask) DeepCopy() *RunConfigTask {


### PR DESCRIPTION
As mentioned in #36 being able to use a custom ServiceAccount would be great e.g. when deploying applications from a pipeline to the local cluster.

I kept the default behavior that if there's no `ServiceAccountName` is configured, the driver won't mount the `ServiceAccount` but it's now possible to use a custom `ServiceAccount` for a task