### PR TITLE
db: improve transactions handling

### DIFF
--- a/internal/generators/gen_fetch.go
+++ b/internal/generators/gen_fetch.go
@@ -62,7 +62,7 @@ func (d *DB) fetch{{ $oi.Name }}s(tx *sql.Tx, q sq.Sqlizer) ([]*types.{{ $oi.Nam
 	}
 	defer rows.Close()
 
-	return d.scan{{ $oi.Name }}s(rows)
+	return d.scan{{ $oi.Name }}s(rows, tx.ID())
 }
 
 func (d *DB) scan{{ $oi.Name }}(rows *stdsql.Rows, additionalFields []interface{}) (*types.{{ $oi.Name }}, string, error) {
@@ -85,7 +85,7 @@ func (d *DB) scan{{ $oi.Name }}(rows *stdsql.Rows, additionalFields []interface{
 	return &v, id, nil
 }
 
-func (d *DB) scan{{ $oi.Name }}s(rows *stdsql.Rows) ([]*types.{{ $oi.Name }}, []string, error) {
+func (d *DB) scan{{ $oi.Name }}s(rows *stdsql.Rows, txID string) ([]*types.{{ $oi.Name }}, []string, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -112,6 +112,7 @@ func (d *DB) scan{{ $oi.Name }}s(rows *stdsql.Rows) ([]*types.{{ $oi.Name }}, []
 			rows.Close()
 			return nil, nil, errors.WithStack(err)
 		}
+		v.TxID = txID
 		vs = append(vs, v)
 		ids = append(ids, id)
 	}

--- a/internal/generators/gen_insert_delete.go
+++ b/internal/generators/gen_insert_delete.go
@@ -72,6 +72,10 @@ func (d *DB) Insert{{ $oi.Name }}(tx *sql.Tx, v *types.{{ $oi.Name }}) error {
 		return errors.Errorf("expected revision 0 got %d", v.Revision)
 	}
 
+	if v.TxID != tx.ID() {
+		return errors.Errorf("object was not created by this transaction")
+	}
+
 	data, err := d.insert{{ $oi.Name }}Data(tx, v)
 	if err != nil {
 		return errors.WithStack(err)
@@ -134,6 +138,10 @@ func (d *DB) Update{{ $oi.Name }}(tx *sql.Tx, v *types.{{ $oi.Name }}) error {
 func (d *DB) update{{ $oi.Name }}Data(tx *sql.Tx, v *types.{{ $oi.Name }}) ([]byte, error) {
 	if v.Revision < 1 {
 		return nil, errors.Errorf("expected revision > 0 got %d", v.Revision)
+	}
+
+	if v.TxID != tx.ID() {
+		return nil, errors.Errorf("object was not fetched by this transaction")
 	}
 
 	curRevision := v.Revision

--- a/internal/migration/configstore.go
+++ b/internal/migration/configstore.go
@@ -77,7 +77,7 @@ func MigrateConfigStore(ctx context.Context, r io.Reader, w io.Writer) error {
 			oldUserj, _ := json.Marshal(oldUser)
 			log.Debug().Msgf("oldUser: %s", oldUserj)
 
-			user := types.NewUser()
+			user := types.NewUser(newTx)
 			user.ID = oldUser.ID
 			user.Name = oldUser.Name
 			user.Secret = oldUser.Secret
@@ -90,7 +90,7 @@ func MigrateConfigStore(ctx context.Context, r io.Reader, w io.Writer) error {
 			}
 
 			for _, oldLA := range oldUser.LinkedAccounts {
-				la := types.NewLinkedAccount()
+				la := types.NewLinkedAccount(newTx)
 				// reuse old linked account id since it's referenced by project
 				la.ID = oldLA.ID
 				la.UserID = user.ID
@@ -110,7 +110,7 @@ func MigrateConfigStore(ctx context.Context, r io.Reader, w io.Writer) error {
 			}
 
 			for oldTokenName, oldTokenValue := range oldUser.Tokens {
-				userToken := types.NewUserToken()
+				userToken := types.NewUserToken(newTx)
 				// reuse old linked account id since it's referenced by project
 				userToken.UserID = user.ID
 				userToken.Name = oldTokenName
@@ -131,7 +131,7 @@ func MigrateConfigStore(ctx context.Context, r io.Reader, w io.Writer) error {
 			oldOrgj, _ := json.Marshal(oldOrg)
 			log.Debug().Msgf("oldOrg: %s", oldOrgj)
 
-			org := types.NewOrganization()
+			org := types.NewOrganization(newTx)
 			org.ID = oldOrg.ID
 			org.Name = oldOrg.Name
 			org.Visibility = types.Visibility(oldOrg.Visibility)
@@ -152,7 +152,7 @@ func MigrateConfigStore(ctx context.Context, r io.Reader, w io.Writer) error {
 			oldOrgMemberj, _ := json.Marshal(oldOrgMember)
 			log.Debug().Msgf("oldOrgMember: %s", oldOrgMemberj)
 
-			orgMember := types.NewOrganizationMember()
+			orgMember := types.NewOrganizationMember(newTx)
 			orgMember.ID = oldOrgMember.ID
 			orgMember.OrganizationID = oldOrgMember.OrganizationID
 			orgMember.UserID = oldOrgMember.UserID
@@ -172,7 +172,7 @@ func MigrateConfigStore(ctx context.Context, r io.Reader, w io.Writer) error {
 			oldProjectGroupj, _ := json.Marshal(oldProjectGroup)
 			log.Debug().Msgf("oldProjectGroup: %s", oldProjectGroupj)
 
-			projectGroup := types.NewProjectGroup()
+			projectGroup := types.NewProjectGroup(newTx)
 			projectGroup.ID = oldProjectGroup.ID
 			projectGroup.Name = oldProjectGroup.Name
 			projectGroup.Parent = types.Parent{
@@ -195,7 +195,7 @@ func MigrateConfigStore(ctx context.Context, r io.Reader, w io.Writer) error {
 			oldProjectj, _ := json.Marshal(oldProject)
 			log.Debug().Msgf("oldProject: %s", oldProjectj)
 
-			project := types.NewProject()
+			project := types.NewProject(newTx)
 			project.ID = oldProject.ID
 			project.Name = oldProject.Name
 			project.Parent = types.Parent{
@@ -229,7 +229,7 @@ func MigrateConfigStore(ctx context.Context, r io.Reader, w io.Writer) error {
 			oldRemoteSourcej, _ := json.Marshal(oldRemoteSource)
 			log.Debug().Msgf("oldRemoteSource: %s", oldRemoteSourcej)
 
-			remoteSource := types.NewRemoteSource()
+			remoteSource := types.NewRemoteSource(newTx)
 			remoteSource.ID = oldRemoteSource.ID
 			remoteSource.Name = oldRemoteSource.Name
 			remoteSource.APIURL = oldRemoteSource.APIURL
@@ -257,7 +257,7 @@ func MigrateConfigStore(ctx context.Context, r io.Reader, w io.Writer) error {
 			oldSecretj, _ := json.Marshal(oldSecret)
 			log.Debug().Msgf("oldSecret: %s", oldSecretj)
 
-			secret := types.NewSecret()
+			secret := types.NewSecret(newTx)
 			secret.ID = oldSecret.ID
 			secret.Name = oldSecret.Name
 			secret.Parent = types.Parent{
@@ -283,7 +283,7 @@ func MigrateConfigStore(ctx context.Context, r io.Reader, w io.Writer) error {
 			oldVariablej, _ := json.Marshal(oldVariable)
 			log.Debug().Msgf("oldVariable: %s", oldVariablej)
 
-			variable := types.NewVariable()
+			variable := types.NewVariable(newTx)
 			variable.ID = oldVariable.ID
 			variable.Name = oldVariable.Name
 			variable.Parent = types.Parent{

--- a/internal/migration/runservice.go
+++ b/internal/migration/runservice.go
@@ -89,7 +89,7 @@ func MigrateRunService(ctx context.Context, r io.Reader, w io.Writer) error {
 
 			curNewRunSequence++
 
-			run := types.NewRun()
+			run := types.NewRun(newTx)
 			run.Sequence = curNewRunSequence
 			run.Name = oldRun.Name
 			run.Counter = oldRun.Counter
@@ -133,7 +133,7 @@ func MigrateRunService(ctx context.Context, r io.Reader, w io.Writer) error {
 			oldRunConfigj, _ := json.Marshal(oldRunConfig)
 			log.Debug().Msgf("oldRunConfig: %s", oldRunConfigj)
 
-			runConfig := types.NewRunConfig()
+			runConfig := types.NewRunConfig(newTx)
 			runConfig.Name = oldRunConfig.Name
 			runConfig.Group = oldRunConfig.Group
 			runConfig.SetupErrors = oldRunConfig.SetupErrors
@@ -175,7 +175,7 @@ func MigrateRunService(ctx context.Context, r io.Reader, w io.Writer) error {
 
 			log.Debug().Msgf("oldRunCounter: %d", oldRunCounter)
 
-			runCounter := types.NewRunCounter(de.ID)
+			runCounter := types.NewRunCounter(newTx, de.ID)
 			runCounter.Value = oldRunCounter
 
 			if err := newd.InsertRunCounter(newTx, runCounter); err != nil {
@@ -188,7 +188,7 @@ func MigrateRunService(ctx context.Context, r io.Reader, w io.Writer) error {
 	}
 
 	// Generate run sequence
-	runSequence := types.NewSequence(types.SequenceTypeRun)
+	runSequence := types.NewSequence(newTx, types.SequenceTypeRun)
 	runSequence.Value = curNewRunSequence
 	if err := newd.InsertSequence(newTx, runSequence); err != nil {
 		return errors.WithStack(err)

--- a/internal/services/configstore/action/org.go
+++ b/internal/services/configstore/action/org.go
@@ -103,7 +103,7 @@ func (h *ActionHandler) CreateOrg(ctx context.Context, req *CreateOrgRequest) (*
 			}
 		}
 
-		org = types.NewOrganization()
+		org = types.NewOrganization(tx)
 		org.Name = req.Name
 		org.Visibility = req.Visibility
 		org.CreatorUserID = req.CreatorUserID
@@ -114,7 +114,7 @@ func (h *ActionHandler) CreateOrg(ctx context.Context, req *CreateOrgRequest) (*
 
 		if org.CreatorUserID != "" {
 			// add the creator as org member with role owner
-			orgmember := types.NewOrganizationMember()
+			orgmember := types.NewOrganizationMember(tx)
 			orgmember.OrganizationID = org.ID
 			orgmember.UserID = org.CreatorUserID
 			orgmember.MemberRole = types.MemberRoleOwner
@@ -125,7 +125,7 @@ func (h *ActionHandler) CreateOrg(ctx context.Context, req *CreateOrgRequest) (*
 		}
 
 		// create root org project group
-		pg := types.NewProjectGroup()
+		pg := types.NewProjectGroup(tx)
 		// use same org visibility
 		pg.Visibility = org.Visibility
 		pg.Parent = types.Parent{
@@ -283,7 +283,7 @@ func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string
 			}
 			orgmember.MemberRole = role
 		} else {
-			orgmember = types.NewOrganizationMember()
+			orgmember = types.NewOrganizationMember(tx)
 			orgmember.OrganizationID = org.ID
 			orgmember.UserID = user.ID
 			orgmember.MemberRole = role
@@ -461,7 +461,7 @@ func (h *ActionHandler) CreateOrgInvitation(ctx context.Context, req *CreateOrgI
 			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invitation already exists"))
 		}
 
-		orgInvitation = types.NewOrgInvitation()
+		orgInvitation = types.NewOrgInvitation(tx)
 		orgInvitation.UserID = user.ID
 		orgInvitation.OrganizationID = org.ID
 		orgInvitation.Role = req.Role
@@ -557,7 +557,7 @@ func (h *ActionHandler) OrgInvitationAction(ctx context.Context, req *OrgInvitat
 		}
 
 		if req.Action == csapitypes.Accept {
-			orgMember := types.NewOrganizationMember()
+			orgMember := types.NewOrganizationMember(tx)
 			orgMember.OrganizationID = orgInvitation.OrganizationID
 			orgMember.UserID = orgInvitation.UserID
 			orgMember.MemberRole = orgInvitation.Role

--- a/internal/services/configstore/action/project.go
+++ b/internal/services/configstore/action/project.go
@@ -151,7 +151,7 @@ func (h *ActionHandler) CreateProject(ctx context.Context, req *CreateUpdateProj
 			}
 		}
 
-		project = types.NewProject()
+		project = types.NewProject(tx)
 		project.Name = req.Name
 		project.Parent = req.Parent
 		project.Visibility = req.Visibility

--- a/internal/services/configstore/action/projectgroup.go
+++ b/internal/services/configstore/action/projectgroup.go
@@ -165,7 +165,7 @@ func (h *ActionHandler) CreateProjectGroup(ctx context.Context, req *CreateUpdat
 			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project group with name %q, path %q already exists", req.Name, pp))
 		}
 
-		projectGroup = types.NewProjectGroup()
+		projectGroup = types.NewProjectGroup(tx)
 		projectGroup.Name = req.Name
 		projectGroup.Parent = req.Parent
 		projectGroup.Visibility = req.Visibility

--- a/internal/services/configstore/action/remotesource.go
+++ b/internal/services/configstore/action/remotesource.go
@@ -91,7 +91,7 @@ func (h *ActionHandler) CreateRemoteSource(ctx context.Context, req *CreateUpdat
 			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource %q already exists", req.Name))
 		}
 
-		remoteSource = types.NewRemoteSource()
+		remoteSource = types.NewRemoteSource(tx)
 		remoteSource.Name = req.Name
 		remoteSource.APIURL = req.APIURL
 		remoteSource.SkipVerify = req.SkipVerify

--- a/internal/services/configstore/action/secret.go
+++ b/internal/services/configstore/action/secret.go
@@ -123,7 +123,7 @@ func (h *ActionHandler) CreateSecret(ctx context.Context, req *CreateUpdateSecre
 			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("secret with name %q for %s with id %q already exists", req.Name, req.Parent.Kind, req.Parent.ID))
 		}
 
-		secret = types.NewSecret()
+		secret = types.NewSecret(tx)
 		secret.Name = req.Name
 		secret.Parent = req.Parent
 		secret.Type = req.Type

--- a/internal/services/configstore/action/user.go
+++ b/internal/services/configstore/action/user.go
@@ -72,13 +72,12 @@ func (h *ActionHandler) CreateUser(ctx context.Context, req *CreateUserRequest) 
 			}
 		}
 
-		user = types.NewUser()
+		user = types.NewUser(tx)
 		user.Name = req.UserName
 		user.Secret = util.EncodeSha1Hex(uuid.Must(uuid.NewV4()).String())
 
 		if req.CreateUserLARequest != nil {
-
-			la := types.NewLinkedAccount()
+			la := types.NewLinkedAccount(tx)
 			la.UserID = user.ID
 			la.RemoteSourceID = rs.ID
 			la.RemoteUserID = req.CreateUserLARequest.RemoteUserID
@@ -94,7 +93,7 @@ func (h *ActionHandler) CreateUser(ctx context.Context, req *CreateUserRequest) 
 		}
 
 		// create root user project group
-		pg := types.NewProjectGroup()
+		pg := types.NewProjectGroup(tx)
 		// use public visibility
 		pg.Visibility = types.VisibilityPublic
 		pg.Parent = types.Parent{
@@ -276,7 +275,7 @@ func (h *ActionHandler) CreateUserLA(ctx context.Context, req *CreateUserLAReque
 			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("linked account for remote user id %q for remote source %q already exists", req.RemoteUserID, req.RemoteSourceName))
 		}
 
-		la = types.NewLinkedAccount()
+		la = types.NewLinkedAccount(tx)
 		la.UserID = user.ID
 		la.RemoteSourceID = rs.ID
 		la.RemoteUserID = req.RemoteUserID
@@ -469,7 +468,7 @@ func (h *ActionHandler) CreateUserToken(ctx context.Context, userRef, tokenName 
 			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("token %q for user %q already exists", tokenName, userRef))
 		}
 
-		token = types.NewUserToken()
+		token = types.NewUserToken(tx)
 		token.UserID = user.ID
 		token.Name = tokenName
 		token.Value = util.EncodeSha1Hex(uuid.Must(uuid.NewV4()).String())

--- a/internal/services/configstore/action/variable.go
+++ b/internal/services/configstore/action/variable.go
@@ -96,7 +96,7 @@ func (h *ActionHandler) CreateVariable(ctx context.Context, req *CreateUpdateVar
 			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("variable with name %q for %s with id %q already exists", req.Name, req.Parent.Kind, req.Parent.ID))
 		}
 
-		variable = types.NewVariable()
+		variable = types.NewVariable(tx)
 		variable.Name = req.Name
 		variable.Parent = req.Parent
 		variable.Values = req.Values

--- a/internal/services/configstore/db/fetch.go
+++ b/internal/services/configstore/db/fetch.go
@@ -19,7 +19,7 @@ func (d *DB) fetchRemoteSources(tx *sql.Tx, q sq.Sqlizer) ([]*types.RemoteSource
 	}
 	defer rows.Close()
 
-	return d.scanRemoteSources(rows)
+	return d.scanRemoteSources(rows, tx.ID())
 }
 
 func (d *DB) scanRemoteSource(rows *stdsql.Rows, additionalFields []interface{}) (*types.RemoteSource, string, error) {
@@ -42,7 +42,7 @@ func (d *DB) scanRemoteSource(rows *stdsql.Rows, additionalFields []interface{})
 	return &v, id, nil
 }
 
-func (d *DB) scanRemoteSources(rows *stdsql.Rows) ([]*types.RemoteSource, []string, error) {
+func (d *DB) scanRemoteSources(rows *stdsql.Rows, txID string) ([]*types.RemoteSource, []string, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -69,6 +69,7 @@ func (d *DB) scanRemoteSources(rows *stdsql.Rows) ([]*types.RemoteSource, []stri
 			rows.Close()
 			return nil, nil, errors.WithStack(err)
 		}
+		v.TxID = txID
 		vs = append(vs, v)
 		ids = append(ids, id)
 	}
@@ -85,7 +86,7 @@ func (d *DB) fetchUsers(tx *sql.Tx, q sq.Sqlizer) ([]*types.User, []string, erro
 	}
 	defer rows.Close()
 
-	return d.scanUsers(rows)
+	return d.scanUsers(rows, tx.ID())
 }
 
 func (d *DB) scanUser(rows *stdsql.Rows, additionalFields []interface{}) (*types.User, string, error) {
@@ -108,7 +109,7 @@ func (d *DB) scanUser(rows *stdsql.Rows, additionalFields []interface{}) (*types
 	return &v, id, nil
 }
 
-func (d *DB) scanUsers(rows *stdsql.Rows) ([]*types.User, []string, error) {
+func (d *DB) scanUsers(rows *stdsql.Rows, txID string) ([]*types.User, []string, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -135,6 +136,7 @@ func (d *DB) scanUsers(rows *stdsql.Rows) ([]*types.User, []string, error) {
 			rows.Close()
 			return nil, nil, errors.WithStack(err)
 		}
+		v.TxID = txID
 		vs = append(vs, v)
 		ids = append(ids, id)
 	}
@@ -151,7 +153,7 @@ func (d *DB) fetchUserTokens(tx *sql.Tx, q sq.Sqlizer) ([]*types.UserToken, []st
 	}
 	defer rows.Close()
 
-	return d.scanUserTokens(rows)
+	return d.scanUserTokens(rows, tx.ID())
 }
 
 func (d *DB) scanUserToken(rows *stdsql.Rows, additionalFields []interface{}) (*types.UserToken, string, error) {
@@ -174,7 +176,7 @@ func (d *DB) scanUserToken(rows *stdsql.Rows, additionalFields []interface{}) (*
 	return &v, id, nil
 }
 
-func (d *DB) scanUserTokens(rows *stdsql.Rows) ([]*types.UserToken, []string, error) {
+func (d *DB) scanUserTokens(rows *stdsql.Rows, txID string) ([]*types.UserToken, []string, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -201,6 +203,7 @@ func (d *DB) scanUserTokens(rows *stdsql.Rows) ([]*types.UserToken, []string, er
 			rows.Close()
 			return nil, nil, errors.WithStack(err)
 		}
+		v.TxID = txID
 		vs = append(vs, v)
 		ids = append(ids, id)
 	}
@@ -217,7 +220,7 @@ func (d *DB) fetchLinkedAccounts(tx *sql.Tx, q sq.Sqlizer) ([]*types.LinkedAccou
 	}
 	defer rows.Close()
 
-	return d.scanLinkedAccounts(rows)
+	return d.scanLinkedAccounts(rows, tx.ID())
 }
 
 func (d *DB) scanLinkedAccount(rows *stdsql.Rows, additionalFields []interface{}) (*types.LinkedAccount, string, error) {
@@ -240,7 +243,7 @@ func (d *DB) scanLinkedAccount(rows *stdsql.Rows, additionalFields []interface{}
 	return &v, id, nil
 }
 
-func (d *DB) scanLinkedAccounts(rows *stdsql.Rows) ([]*types.LinkedAccount, []string, error) {
+func (d *DB) scanLinkedAccounts(rows *stdsql.Rows, txID string) ([]*types.LinkedAccount, []string, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -267,6 +270,7 @@ func (d *DB) scanLinkedAccounts(rows *stdsql.Rows) ([]*types.LinkedAccount, []st
 			rows.Close()
 			return nil, nil, errors.WithStack(err)
 		}
+		v.TxID = txID
 		vs = append(vs, v)
 		ids = append(ids, id)
 	}
@@ -283,7 +287,7 @@ func (d *DB) fetchOrganizations(tx *sql.Tx, q sq.Sqlizer) ([]*types.Organization
 	}
 	defer rows.Close()
 
-	return d.scanOrganizations(rows)
+	return d.scanOrganizations(rows, tx.ID())
 }
 
 func (d *DB) scanOrganization(rows *stdsql.Rows, additionalFields []interface{}) (*types.Organization, string, error) {
@@ -306,7 +310,7 @@ func (d *DB) scanOrganization(rows *stdsql.Rows, additionalFields []interface{})
 	return &v, id, nil
 }
 
-func (d *DB) scanOrganizations(rows *stdsql.Rows) ([]*types.Organization, []string, error) {
+func (d *DB) scanOrganizations(rows *stdsql.Rows, txID string) ([]*types.Organization, []string, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -333,6 +337,7 @@ func (d *DB) scanOrganizations(rows *stdsql.Rows) ([]*types.Organization, []stri
 			rows.Close()
 			return nil, nil, errors.WithStack(err)
 		}
+		v.TxID = txID
 		vs = append(vs, v)
 		ids = append(ids, id)
 	}
@@ -349,7 +354,7 @@ func (d *DB) fetchOrganizationMembers(tx *sql.Tx, q sq.Sqlizer) ([]*types.Organi
 	}
 	defer rows.Close()
 
-	return d.scanOrganizationMembers(rows)
+	return d.scanOrganizationMembers(rows, tx.ID())
 }
 
 func (d *DB) scanOrganizationMember(rows *stdsql.Rows, additionalFields []interface{}) (*types.OrganizationMember, string, error) {
@@ -372,7 +377,7 @@ func (d *DB) scanOrganizationMember(rows *stdsql.Rows, additionalFields []interf
 	return &v, id, nil
 }
 
-func (d *DB) scanOrganizationMembers(rows *stdsql.Rows) ([]*types.OrganizationMember, []string, error) {
+func (d *DB) scanOrganizationMembers(rows *stdsql.Rows, txID string) ([]*types.OrganizationMember, []string, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -399,6 +404,7 @@ func (d *DB) scanOrganizationMembers(rows *stdsql.Rows) ([]*types.OrganizationMe
 			rows.Close()
 			return nil, nil, errors.WithStack(err)
 		}
+		v.TxID = txID
 		vs = append(vs, v)
 		ids = append(ids, id)
 	}
@@ -415,7 +421,7 @@ func (d *DB) fetchProjectGroups(tx *sql.Tx, q sq.Sqlizer) ([]*types.ProjectGroup
 	}
 	defer rows.Close()
 
-	return d.scanProjectGroups(rows)
+	return d.scanProjectGroups(rows, tx.ID())
 }
 
 func (d *DB) scanProjectGroup(rows *stdsql.Rows, additionalFields []interface{}) (*types.ProjectGroup, string, error) {
@@ -438,7 +444,7 @@ func (d *DB) scanProjectGroup(rows *stdsql.Rows, additionalFields []interface{})
 	return &v, id, nil
 }
 
-func (d *DB) scanProjectGroups(rows *stdsql.Rows) ([]*types.ProjectGroup, []string, error) {
+func (d *DB) scanProjectGroups(rows *stdsql.Rows, txID string) ([]*types.ProjectGroup, []string, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -465,6 +471,7 @@ func (d *DB) scanProjectGroups(rows *stdsql.Rows) ([]*types.ProjectGroup, []stri
 			rows.Close()
 			return nil, nil, errors.WithStack(err)
 		}
+		v.TxID = txID
 		vs = append(vs, v)
 		ids = append(ids, id)
 	}
@@ -481,7 +488,7 @@ func (d *DB) fetchProjects(tx *sql.Tx, q sq.Sqlizer) ([]*types.Project, []string
 	}
 	defer rows.Close()
 
-	return d.scanProjects(rows)
+	return d.scanProjects(rows, tx.ID())
 }
 
 func (d *DB) scanProject(rows *stdsql.Rows, additionalFields []interface{}) (*types.Project, string, error) {
@@ -504,7 +511,7 @@ func (d *DB) scanProject(rows *stdsql.Rows, additionalFields []interface{}) (*ty
 	return &v, id, nil
 }
 
-func (d *DB) scanProjects(rows *stdsql.Rows) ([]*types.Project, []string, error) {
+func (d *DB) scanProjects(rows *stdsql.Rows, txID string) ([]*types.Project, []string, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -531,6 +538,7 @@ func (d *DB) scanProjects(rows *stdsql.Rows) ([]*types.Project, []string, error)
 			rows.Close()
 			return nil, nil, errors.WithStack(err)
 		}
+		v.TxID = txID
 		vs = append(vs, v)
 		ids = append(ids, id)
 	}
@@ -547,7 +555,7 @@ func (d *DB) fetchSecrets(tx *sql.Tx, q sq.Sqlizer) ([]*types.Secret, []string, 
 	}
 	defer rows.Close()
 
-	return d.scanSecrets(rows)
+	return d.scanSecrets(rows, tx.ID())
 }
 
 func (d *DB) scanSecret(rows *stdsql.Rows, additionalFields []interface{}) (*types.Secret, string, error) {
@@ -570,7 +578,7 @@ func (d *DB) scanSecret(rows *stdsql.Rows, additionalFields []interface{}) (*typ
 	return &v, id, nil
 }
 
-func (d *DB) scanSecrets(rows *stdsql.Rows) ([]*types.Secret, []string, error) {
+func (d *DB) scanSecrets(rows *stdsql.Rows, txID string) ([]*types.Secret, []string, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -597,6 +605,7 @@ func (d *DB) scanSecrets(rows *stdsql.Rows) ([]*types.Secret, []string, error) {
 			rows.Close()
 			return nil, nil, errors.WithStack(err)
 		}
+		v.TxID = txID
 		vs = append(vs, v)
 		ids = append(ids, id)
 	}
@@ -613,7 +622,7 @@ func (d *DB) fetchVariables(tx *sql.Tx, q sq.Sqlizer) ([]*types.Variable, []stri
 	}
 	defer rows.Close()
 
-	return d.scanVariables(rows)
+	return d.scanVariables(rows, tx.ID())
 }
 
 func (d *DB) scanVariable(rows *stdsql.Rows, additionalFields []interface{}) (*types.Variable, string, error) {
@@ -636,7 +645,7 @@ func (d *DB) scanVariable(rows *stdsql.Rows, additionalFields []interface{}) (*t
 	return &v, id, nil
 }
 
-func (d *DB) scanVariables(rows *stdsql.Rows) ([]*types.Variable, []string, error) {
+func (d *DB) scanVariables(rows *stdsql.Rows, txID string) ([]*types.Variable, []string, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -663,6 +672,7 @@ func (d *DB) scanVariables(rows *stdsql.Rows) ([]*types.Variable, []string, erro
 			rows.Close()
 			return nil, nil, errors.WithStack(err)
 		}
+		v.TxID = txID
 		vs = append(vs, v)
 		ids = append(ids, id)
 	}
@@ -679,7 +689,7 @@ func (d *DB) fetchOrgInvitations(tx *sql.Tx, q sq.Sqlizer) ([]*types.OrgInvitati
 	}
 	defer rows.Close()
 
-	return d.scanOrgInvitations(rows)
+	return d.scanOrgInvitations(rows, tx.ID())
 }
 
 func (d *DB) scanOrgInvitation(rows *stdsql.Rows, additionalFields []interface{}) (*types.OrgInvitation, string, error) {
@@ -702,7 +712,7 @@ func (d *DB) scanOrgInvitation(rows *stdsql.Rows, additionalFields []interface{}
 	return &v, id, nil
 }
 
-func (d *DB) scanOrgInvitations(rows *stdsql.Rows) ([]*types.OrgInvitation, []string, error) {
+func (d *DB) scanOrgInvitations(rows *stdsql.Rows, txID string) ([]*types.OrgInvitation, []string, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -729,6 +739,7 @@ func (d *DB) scanOrgInvitations(rows *stdsql.Rows) ([]*types.OrgInvitation, []st
 			rows.Close()
 			return nil, nil, errors.WithStack(err)
 		}
+		v.TxID = txID
 		vs = append(vs, v)
 		ids = append(ids, id)
 	}

--- a/internal/services/configstore/db/insert_delete.go
+++ b/internal/services/configstore/db/insert_delete.go
@@ -29,6 +29,10 @@ func (d *DB) InsertRemoteSource(tx *sql.Tx, v *types.RemoteSource) error {
 		return errors.Errorf("expected revision 0 got %d", v.Revision)
 	}
 
+	if v.TxID != tx.ID() {
+		return errors.Errorf("object was not created by this transaction")
+	}
+
 	data, err := d.insertRemoteSourceData(tx, v)
 	if err != nil {
 		return errors.WithStack(err)
@@ -93,6 +97,10 @@ func (d *DB) updateRemoteSourceData(tx *sql.Tx, v *types.RemoteSource) ([]byte, 
 		return nil, errors.Errorf("expected revision > 0 got %d", v.Revision)
 	}
 
+	if v.TxID != tx.ID() {
+		return nil, errors.Errorf("object was not fetched by this transaction")
+	}
+
 	curRevision := v.Revision
 	v.Revision++
 
@@ -154,6 +162,10 @@ func (d *DB) InsertOrUpdateUser(tx *sql.Tx, v *types.User) error {
 func (d *DB) InsertUser(tx *sql.Tx, v *types.User) error {
 	if v.Revision != 0 {
 		return errors.Errorf("expected revision 0 got %d", v.Revision)
+	}
+
+	if v.TxID != tx.ID() {
+		return errors.Errorf("object was not created by this transaction")
 	}
 
 	data, err := d.insertUserData(tx, v)
@@ -220,6 +232,10 @@ func (d *DB) updateUserData(tx *sql.Tx, v *types.User) ([]byte, error) {
 		return nil, errors.Errorf("expected revision > 0 got %d", v.Revision)
 	}
 
+	if v.TxID != tx.ID() {
+		return nil, errors.Errorf("object was not fetched by this transaction")
+	}
+
 	curRevision := v.Revision
 	v.Revision++
 
@@ -281,6 +297,10 @@ func (d *DB) InsertOrUpdateUserToken(tx *sql.Tx, v *types.UserToken) error {
 func (d *DB) InsertUserToken(tx *sql.Tx, v *types.UserToken) error {
 	if v.Revision != 0 {
 		return errors.Errorf("expected revision 0 got %d", v.Revision)
+	}
+
+	if v.TxID != tx.ID() {
+		return errors.Errorf("object was not created by this transaction")
 	}
 
 	data, err := d.insertUserTokenData(tx, v)
@@ -347,6 +367,10 @@ func (d *DB) updateUserTokenData(tx *sql.Tx, v *types.UserToken) ([]byte, error)
 		return nil, errors.Errorf("expected revision > 0 got %d", v.Revision)
 	}
 
+	if v.TxID != tx.ID() {
+		return nil, errors.Errorf("object was not fetched by this transaction")
+	}
+
 	curRevision := v.Revision
 	v.Revision++
 
@@ -408,6 +432,10 @@ func (d *DB) InsertOrUpdateLinkedAccount(tx *sql.Tx, v *types.LinkedAccount) err
 func (d *DB) InsertLinkedAccount(tx *sql.Tx, v *types.LinkedAccount) error {
 	if v.Revision != 0 {
 		return errors.Errorf("expected revision 0 got %d", v.Revision)
+	}
+
+	if v.TxID != tx.ID() {
+		return errors.Errorf("object was not created by this transaction")
 	}
 
 	data, err := d.insertLinkedAccountData(tx, v)
@@ -474,6 +502,10 @@ func (d *DB) updateLinkedAccountData(tx *sql.Tx, v *types.LinkedAccount) ([]byte
 		return nil, errors.Errorf("expected revision > 0 got %d", v.Revision)
 	}
 
+	if v.TxID != tx.ID() {
+		return nil, errors.Errorf("object was not fetched by this transaction")
+	}
+
 	curRevision := v.Revision
 	v.Revision++
 
@@ -535,6 +567,10 @@ func (d *DB) InsertOrUpdateOrganization(tx *sql.Tx, v *types.Organization) error
 func (d *DB) InsertOrganization(tx *sql.Tx, v *types.Organization) error {
 	if v.Revision != 0 {
 		return errors.Errorf("expected revision 0 got %d", v.Revision)
+	}
+
+	if v.TxID != tx.ID() {
+		return errors.Errorf("object was not created by this transaction")
 	}
 
 	data, err := d.insertOrganizationData(tx, v)
@@ -601,6 +637,10 @@ func (d *DB) updateOrganizationData(tx *sql.Tx, v *types.Organization) ([]byte, 
 		return nil, errors.Errorf("expected revision > 0 got %d", v.Revision)
 	}
 
+	if v.TxID != tx.ID() {
+		return nil, errors.Errorf("object was not fetched by this transaction")
+	}
+
 	curRevision := v.Revision
 	v.Revision++
 
@@ -662,6 +702,10 @@ func (d *DB) InsertOrUpdateOrganizationMember(tx *sql.Tx, v *types.OrganizationM
 func (d *DB) InsertOrganizationMember(tx *sql.Tx, v *types.OrganizationMember) error {
 	if v.Revision != 0 {
 		return errors.Errorf("expected revision 0 got %d", v.Revision)
+	}
+
+	if v.TxID != tx.ID() {
+		return errors.Errorf("object was not created by this transaction")
 	}
 
 	data, err := d.insertOrganizationMemberData(tx, v)
@@ -728,6 +772,10 @@ func (d *DB) updateOrganizationMemberData(tx *sql.Tx, v *types.OrganizationMembe
 		return nil, errors.Errorf("expected revision > 0 got %d", v.Revision)
 	}
 
+	if v.TxID != tx.ID() {
+		return nil, errors.Errorf("object was not fetched by this transaction")
+	}
+
 	curRevision := v.Revision
 	v.Revision++
 
@@ -789,6 +837,10 @@ func (d *DB) InsertOrUpdateProjectGroup(tx *sql.Tx, v *types.ProjectGroup) error
 func (d *DB) InsertProjectGroup(tx *sql.Tx, v *types.ProjectGroup) error {
 	if v.Revision != 0 {
 		return errors.Errorf("expected revision 0 got %d", v.Revision)
+	}
+
+	if v.TxID != tx.ID() {
+		return errors.Errorf("object was not created by this transaction")
 	}
 
 	data, err := d.insertProjectGroupData(tx, v)
@@ -855,6 +907,10 @@ func (d *DB) updateProjectGroupData(tx *sql.Tx, v *types.ProjectGroup) ([]byte, 
 		return nil, errors.Errorf("expected revision > 0 got %d", v.Revision)
 	}
 
+	if v.TxID != tx.ID() {
+		return nil, errors.Errorf("object was not fetched by this transaction")
+	}
+
 	curRevision := v.Revision
 	v.Revision++
 
@@ -916,6 +972,10 @@ func (d *DB) InsertOrUpdateProject(tx *sql.Tx, v *types.Project) error {
 func (d *DB) InsertProject(tx *sql.Tx, v *types.Project) error {
 	if v.Revision != 0 {
 		return errors.Errorf("expected revision 0 got %d", v.Revision)
+	}
+
+	if v.TxID != tx.ID() {
+		return errors.Errorf("object was not created by this transaction")
 	}
 
 	data, err := d.insertProjectData(tx, v)
@@ -982,6 +1042,10 @@ func (d *DB) updateProjectData(tx *sql.Tx, v *types.Project) ([]byte, error) {
 		return nil, errors.Errorf("expected revision > 0 got %d", v.Revision)
 	}
 
+	if v.TxID != tx.ID() {
+		return nil, errors.Errorf("object was not fetched by this transaction")
+	}
+
 	curRevision := v.Revision
 	v.Revision++
 
@@ -1043,6 +1107,10 @@ func (d *DB) InsertOrUpdateSecret(tx *sql.Tx, v *types.Secret) error {
 func (d *DB) InsertSecret(tx *sql.Tx, v *types.Secret) error {
 	if v.Revision != 0 {
 		return errors.Errorf("expected revision 0 got %d", v.Revision)
+	}
+
+	if v.TxID != tx.ID() {
+		return errors.Errorf("object was not created by this transaction")
 	}
 
 	data, err := d.insertSecretData(tx, v)
@@ -1109,6 +1177,10 @@ func (d *DB) updateSecretData(tx *sql.Tx, v *types.Secret) ([]byte, error) {
 		return nil, errors.Errorf("expected revision > 0 got %d", v.Revision)
 	}
 
+	if v.TxID != tx.ID() {
+		return nil, errors.Errorf("object was not fetched by this transaction")
+	}
+
 	curRevision := v.Revision
 	v.Revision++
 
@@ -1170,6 +1242,10 @@ func (d *DB) InsertOrUpdateVariable(tx *sql.Tx, v *types.Variable) error {
 func (d *DB) InsertVariable(tx *sql.Tx, v *types.Variable) error {
 	if v.Revision != 0 {
 		return errors.Errorf("expected revision 0 got %d", v.Revision)
+	}
+
+	if v.TxID != tx.ID() {
+		return errors.Errorf("object was not created by this transaction")
 	}
 
 	data, err := d.insertVariableData(tx, v)
@@ -1236,6 +1312,10 @@ func (d *DB) updateVariableData(tx *sql.Tx, v *types.Variable) ([]byte, error) {
 		return nil, errors.Errorf("expected revision > 0 got %d", v.Revision)
 	}
 
+	if v.TxID != tx.ID() {
+		return nil, errors.Errorf("object was not fetched by this transaction")
+	}
+
 	curRevision := v.Revision
 	v.Revision++
 
@@ -1297,6 +1377,10 @@ func (d *DB) InsertOrUpdateOrgInvitation(tx *sql.Tx, v *types.OrgInvitation) err
 func (d *DB) InsertOrgInvitation(tx *sql.Tx, v *types.OrgInvitation) error {
 	if v.Revision != 0 {
 		return errors.Errorf("expected revision 0 got %d", v.Revision)
+	}
+
+	if v.TxID != tx.ID() {
+		return errors.Errorf("object was not created by this transaction")
 	}
 
 	data, err := d.insertOrgInvitationData(tx, v)
@@ -1361,6 +1445,10 @@ func (d *DB) UpdateOrgInvitation(tx *sql.Tx, v *types.OrgInvitation) error {
 func (d *DB) updateOrgInvitationData(tx *sql.Tx, v *types.OrgInvitation) ([]byte, error) {
 	if v.Revision < 1 {
 		return nil, errors.Errorf("expected revision > 0 got %d", v.Revision)
+	}
+
+	if v.TxID != tx.ID() {
+		return nil, errors.Errorf("object was not fetched by this transaction")
 	}
 
 	curRevision := v.Revision

--- a/internal/services/executor/registry/registry.go
+++ b/internal/services/executor/registry/registry.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"agola.io/agola/internal/errors"
-	"agola.io/agola/services/runservice/types"
 
 	"github.com/google/go-containerregistry/pkg/name"
 )
@@ -46,6 +45,20 @@ import (
 //		return "", errors.Errorf("unsupported registry auth type %q", auth.Type)
 //	}
 //}
+
+type DockerRegistryAuthType string
+
+const (
+	DockerRegistryAuthTypeBasic       DockerRegistryAuthType = "basic"
+	DockerRegistryAuthTypeEncodedAuth DockerRegistryAuthType = "encodedauth"
+)
+
+type DockerRegistryAuth struct {
+	Type     DockerRegistryAuthType
+	Username string
+	Password string
+	Auth     string
+}
 
 // Docker config represents the docker config.json format. We only consider the "auths" part
 type DockerConfig struct {
@@ -94,12 +107,12 @@ func GetRegistry(image string) (string, error) {
 }
 
 // ResolveAuth resolves the auth username and password for the provided registry name
-func ResolveAuth(auths map[string]types.DockerRegistryAuth, regname string) (string, string, error) {
+func ResolveAuth(auths map[string]DockerRegistryAuth, regname string) (string, string, error) {
 	if auths != nil {
 		for _, form := range domainForms {
 			if auth, ok := auths[fmt.Sprintf(form, regname)]; ok {
 				switch auth.Type {
-				case types.DockerRegistryAuthTypeEncodedAuth:
+				case DockerRegistryAuthTypeEncodedAuth:
 					decoded, err := base64.StdEncoding.DecodeString(auth.Auth)
 					if err != nil {
 						return "", "", errors.Wrapf(err, "failed to decode docker auth")
@@ -109,7 +122,7 @@ func ResolveAuth(auths map[string]types.DockerRegistryAuth, regname string) (str
 						return "", "", errors.Wrapf(err, "wrong docker auth")
 					}
 					return parts[0], parts[1], nil
-				case types.DockerRegistryAuthTypeBasic:
+				case DockerRegistryAuthTypeBasic:
 					return auth.Username, auth.Password, nil
 				default:
 					return "", "", errors.Errorf("unsupported auth type %q", auth.Type)
@@ -121,7 +134,7 @@ func ResolveAuth(auths map[string]types.DockerRegistryAuth, regname string) (str
 	return "", "", nil
 }
 
-func GenDockerConfig(auths map[string]types.DockerRegistryAuth, images []string) (*DockerConfig, error) {
+func GenDockerConfig(auths map[string]DockerRegistryAuth, images []string) (*DockerConfig, error) {
 	dockerConfig := &DockerConfig{Auths: make(map[string]DockerConfigAuth)}
 	for _, image := range images {
 		ref, err := name.ParseReference(image, name.WeakValidation)

--- a/internal/services/runservice/api/executor.go
+++ b/internal/services/runservice/api/executor.go
@@ -70,7 +70,7 @@ func (h *ExecutorStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		}
 
 		if executor == nil {
-			executor = types.NewExecutor()
+			executor = types.NewExecutor(tx)
 		}
 
 		executor.ExecutorID = recExecutor.ExecutorID

--- a/internal/services/runservice/common/common.go
+++ b/internal/services/runservice/common/common.go
@@ -20,6 +20,7 @@ import (
 
 	"agola.io/agola/internal/errors"
 	"agola.io/agola/internal/runconfig"
+	"agola.io/agola/internal/sql"
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/runservice/types"
 )
@@ -168,10 +169,10 @@ func GenExecutorTaskSpecData(r *types.Run, rt *types.RunTask, rc *types.RunConfi
 	return data
 }
 
-func GenExecutorTask(r *types.Run, rt *types.RunTask, rc *types.RunConfig, executor *types.Executor) *types.ExecutorTask {
+func GenExecutorTask(tx *sql.Tx, r *types.Run, rt *types.RunTask, rc *types.RunConfig, executor *types.Executor) *types.ExecutorTask {
 	rct := rc.Tasks[rt.ID]
 
-	et := types.NewExecutorTask()
+	et := types.NewExecutorTask(tx)
 	et.Spec = types.ExecutorTaskSpec{
 		ExecutorID: executor.ExecutorID,
 		RunID:      r.ID,

--- a/internal/services/runservice/common/events.go
+++ b/internal/services/runservice/common/events.go
@@ -22,7 +22,7 @@ import (
 )
 
 func NewRunEvent(d *db.DB, tx *sql.Tx, runID string, phase types.RunPhase, result types.RunResult) (*types.RunEvent, error) {
-	runEvent := types.NewRunEvent()
+	runEvent := types.NewRunEvent(tx)
 	runEvent.RunID = runID
 	runEvent.Phase = phase
 	runEvent.Result = result

--- a/internal/services/runservice/db/db.go
+++ b/internal/services/runservice/db/db.go
@@ -203,7 +203,7 @@ func (d *DB) NextSequence(tx *sql.Tx, sequenceType types.SequenceType) (uint64, 
 		return 0, errors.WithStack(err)
 	}
 	if seq == nil {
-		seq = types.NewSequence(sequenceType)
+		seq = types.NewSequence(tx, sequenceType)
 	}
 
 	seq.Value++
@@ -433,7 +433,7 @@ func (d *DB) NextRunCounter(tx *sql.Tx, groupID string) (uint64, error) {
 		return 0, errors.WithStack(err)
 	}
 	if runCounter == nil {
-		runCounter = types.NewRunCounter(groupID)
+		runCounter = types.NewRunCounter(tx, groupID)
 	}
 
 	runCounter.Value++

--- a/internal/services/runservice/db/fetch.go
+++ b/internal/services/runservice/db/fetch.go
@@ -19,7 +19,7 @@ func (d *DB) fetchSequences(tx *sql.Tx, q sq.Sqlizer) ([]*types.Sequence, []stri
 	}
 	defer rows.Close()
 
-	return d.scanSequences(rows)
+	return d.scanSequences(rows, tx.ID())
 }
 
 func (d *DB) scanSequence(rows *stdsql.Rows, additionalFields []interface{}) (*types.Sequence, string, error) {
@@ -42,7 +42,7 @@ func (d *DB) scanSequence(rows *stdsql.Rows, additionalFields []interface{}) (*t
 	return &v, id, nil
 }
 
-func (d *DB) scanSequences(rows *stdsql.Rows) ([]*types.Sequence, []string, error) {
+func (d *DB) scanSequences(rows *stdsql.Rows, txID string) ([]*types.Sequence, []string, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -69,6 +69,7 @@ func (d *DB) scanSequences(rows *stdsql.Rows) ([]*types.Sequence, []string, erro
 			rows.Close()
 			return nil, nil, errors.WithStack(err)
 		}
+		v.TxID = txID
 		vs = append(vs, v)
 		ids = append(ids, id)
 	}
@@ -85,7 +86,7 @@ func (d *DB) fetchChangeGroups(tx *sql.Tx, q sq.Sqlizer) ([]*types.ChangeGroup, 
 	}
 	defer rows.Close()
 
-	return d.scanChangeGroups(rows)
+	return d.scanChangeGroups(rows, tx.ID())
 }
 
 func (d *DB) scanChangeGroup(rows *stdsql.Rows, additionalFields []interface{}) (*types.ChangeGroup, string, error) {
@@ -108,7 +109,7 @@ func (d *DB) scanChangeGroup(rows *stdsql.Rows, additionalFields []interface{}) 
 	return &v, id, nil
 }
 
-func (d *DB) scanChangeGroups(rows *stdsql.Rows) ([]*types.ChangeGroup, []string, error) {
+func (d *DB) scanChangeGroups(rows *stdsql.Rows, txID string) ([]*types.ChangeGroup, []string, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -135,6 +136,7 @@ func (d *DB) scanChangeGroups(rows *stdsql.Rows) ([]*types.ChangeGroup, []string
 			rows.Close()
 			return nil, nil, errors.WithStack(err)
 		}
+		v.TxID = txID
 		vs = append(vs, v)
 		ids = append(ids, id)
 	}
@@ -151,7 +153,7 @@ func (d *DB) fetchRuns(tx *sql.Tx, q sq.Sqlizer) ([]*types.Run, []string, error)
 	}
 	defer rows.Close()
 
-	return d.scanRuns(rows)
+	return d.scanRuns(rows, tx.ID())
 }
 
 func (d *DB) scanRun(rows *stdsql.Rows, additionalFields []interface{}) (*types.Run, string, error) {
@@ -174,7 +176,7 @@ func (d *DB) scanRun(rows *stdsql.Rows, additionalFields []interface{}) (*types.
 	return &v, id, nil
 }
 
-func (d *DB) scanRuns(rows *stdsql.Rows) ([]*types.Run, []string, error) {
+func (d *DB) scanRuns(rows *stdsql.Rows, txID string) ([]*types.Run, []string, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -201,6 +203,7 @@ func (d *DB) scanRuns(rows *stdsql.Rows) ([]*types.Run, []string, error) {
 			rows.Close()
 			return nil, nil, errors.WithStack(err)
 		}
+		v.TxID = txID
 		vs = append(vs, v)
 		ids = append(ids, id)
 	}
@@ -217,7 +220,7 @@ func (d *DB) fetchRunConfigs(tx *sql.Tx, q sq.Sqlizer) ([]*types.RunConfig, []st
 	}
 	defer rows.Close()
 
-	return d.scanRunConfigs(rows)
+	return d.scanRunConfigs(rows, tx.ID())
 }
 
 func (d *DB) scanRunConfig(rows *stdsql.Rows, additionalFields []interface{}) (*types.RunConfig, string, error) {
@@ -240,7 +243,7 @@ func (d *DB) scanRunConfig(rows *stdsql.Rows, additionalFields []interface{}) (*
 	return &v, id, nil
 }
 
-func (d *DB) scanRunConfigs(rows *stdsql.Rows) ([]*types.RunConfig, []string, error) {
+func (d *DB) scanRunConfigs(rows *stdsql.Rows, txID string) ([]*types.RunConfig, []string, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -267,6 +270,7 @@ func (d *DB) scanRunConfigs(rows *stdsql.Rows) ([]*types.RunConfig, []string, er
 			rows.Close()
 			return nil, nil, errors.WithStack(err)
 		}
+		v.TxID = txID
 		vs = append(vs, v)
 		ids = append(ids, id)
 	}
@@ -283,7 +287,7 @@ func (d *DB) fetchRunCounters(tx *sql.Tx, q sq.Sqlizer) ([]*types.RunCounter, []
 	}
 	defer rows.Close()
 
-	return d.scanRunCounters(rows)
+	return d.scanRunCounters(rows, tx.ID())
 }
 
 func (d *DB) scanRunCounter(rows *stdsql.Rows, additionalFields []interface{}) (*types.RunCounter, string, error) {
@@ -306,7 +310,7 @@ func (d *DB) scanRunCounter(rows *stdsql.Rows, additionalFields []interface{}) (
 	return &v, id, nil
 }
 
-func (d *DB) scanRunCounters(rows *stdsql.Rows) ([]*types.RunCounter, []string, error) {
+func (d *DB) scanRunCounters(rows *stdsql.Rows, txID string) ([]*types.RunCounter, []string, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -333,6 +337,7 @@ func (d *DB) scanRunCounters(rows *stdsql.Rows) ([]*types.RunCounter, []string, 
 			rows.Close()
 			return nil, nil, errors.WithStack(err)
 		}
+		v.TxID = txID
 		vs = append(vs, v)
 		ids = append(ids, id)
 	}
@@ -349,7 +354,7 @@ func (d *DB) fetchRunEvents(tx *sql.Tx, q sq.Sqlizer) ([]*types.RunEvent, []stri
 	}
 	defer rows.Close()
 
-	return d.scanRunEvents(rows)
+	return d.scanRunEvents(rows, tx.ID())
 }
 
 func (d *DB) scanRunEvent(rows *stdsql.Rows, additionalFields []interface{}) (*types.RunEvent, string, error) {
@@ -372,7 +377,7 @@ func (d *DB) scanRunEvent(rows *stdsql.Rows, additionalFields []interface{}) (*t
 	return &v, id, nil
 }
 
-func (d *DB) scanRunEvents(rows *stdsql.Rows) ([]*types.RunEvent, []string, error) {
+func (d *DB) scanRunEvents(rows *stdsql.Rows, txID string) ([]*types.RunEvent, []string, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -399,6 +404,7 @@ func (d *DB) scanRunEvents(rows *stdsql.Rows) ([]*types.RunEvent, []string, erro
 			rows.Close()
 			return nil, nil, errors.WithStack(err)
 		}
+		v.TxID = txID
 		vs = append(vs, v)
 		ids = append(ids, id)
 	}
@@ -415,7 +421,7 @@ func (d *DB) fetchExecutors(tx *sql.Tx, q sq.Sqlizer) ([]*types.Executor, []stri
 	}
 	defer rows.Close()
 
-	return d.scanExecutors(rows)
+	return d.scanExecutors(rows, tx.ID())
 }
 
 func (d *DB) scanExecutor(rows *stdsql.Rows, additionalFields []interface{}) (*types.Executor, string, error) {
@@ -438,7 +444,7 @@ func (d *DB) scanExecutor(rows *stdsql.Rows, additionalFields []interface{}) (*t
 	return &v, id, nil
 }
 
-func (d *DB) scanExecutors(rows *stdsql.Rows) ([]*types.Executor, []string, error) {
+func (d *DB) scanExecutors(rows *stdsql.Rows, txID string) ([]*types.Executor, []string, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -465,6 +471,7 @@ func (d *DB) scanExecutors(rows *stdsql.Rows) ([]*types.Executor, []string, erro
 			rows.Close()
 			return nil, nil, errors.WithStack(err)
 		}
+		v.TxID = txID
 		vs = append(vs, v)
 		ids = append(ids, id)
 	}
@@ -481,7 +488,7 @@ func (d *DB) fetchExecutorTasks(tx *sql.Tx, q sq.Sqlizer) ([]*types.ExecutorTask
 	}
 	defer rows.Close()
 
-	return d.scanExecutorTasks(rows)
+	return d.scanExecutorTasks(rows, tx.ID())
 }
 
 func (d *DB) scanExecutorTask(rows *stdsql.Rows, additionalFields []interface{}) (*types.ExecutorTask, string, error) {
@@ -504,7 +511,7 @@ func (d *DB) scanExecutorTask(rows *stdsql.Rows, additionalFields []interface{})
 	return &v, id, nil
 }
 
-func (d *DB) scanExecutorTasks(rows *stdsql.Rows) ([]*types.ExecutorTask, []string, error) {
+func (d *DB) scanExecutorTasks(rows *stdsql.Rows, txID string) ([]*types.ExecutorTask, []string, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -531,6 +538,7 @@ func (d *DB) scanExecutorTasks(rows *stdsql.Rows) ([]*types.ExecutorTask, []stri
 			rows.Close()
 			return nil, nil, errors.WithStack(err)
 		}
+		v.TxID = txID
 		vs = append(vs, v)
 		ids = append(ids, id)
 	}

--- a/internal/services/runservice/db/insert_delete.go
+++ b/internal/services/runservice/db/insert_delete.go
@@ -29,6 +29,10 @@ func (d *DB) InsertSequence(tx *sql.Tx, v *types.Sequence) error {
 		return errors.Errorf("expected revision 0 got %d", v.Revision)
 	}
 
+	if v.TxID != tx.ID() {
+		return errors.Errorf("object was not created by this transaction")
+	}
+
 	data, err := d.insertSequenceData(tx, v)
 	if err != nil {
 		return errors.WithStack(err)
@@ -93,6 +97,10 @@ func (d *DB) updateSequenceData(tx *sql.Tx, v *types.Sequence) ([]byte, error) {
 		return nil, errors.Errorf("expected revision > 0 got %d", v.Revision)
 	}
 
+	if v.TxID != tx.ID() {
+		return nil, errors.Errorf("object was not fetched by this transaction")
+	}
+
 	curRevision := v.Revision
 	v.Revision++
 
@@ -154,6 +162,10 @@ func (d *DB) InsertOrUpdateChangeGroup(tx *sql.Tx, v *types.ChangeGroup) error {
 func (d *DB) InsertChangeGroup(tx *sql.Tx, v *types.ChangeGroup) error {
 	if v.Revision != 0 {
 		return errors.Errorf("expected revision 0 got %d", v.Revision)
+	}
+
+	if v.TxID != tx.ID() {
+		return errors.Errorf("object was not created by this transaction")
 	}
 
 	data, err := d.insertChangeGroupData(tx, v)
@@ -220,6 +232,10 @@ func (d *DB) updateChangeGroupData(tx *sql.Tx, v *types.ChangeGroup) ([]byte, er
 		return nil, errors.Errorf("expected revision > 0 got %d", v.Revision)
 	}
 
+	if v.TxID != tx.ID() {
+		return nil, errors.Errorf("object was not fetched by this transaction")
+	}
+
 	curRevision := v.Revision
 	v.Revision++
 
@@ -281,6 +297,10 @@ func (d *DB) InsertOrUpdateRun(tx *sql.Tx, v *types.Run) error {
 func (d *DB) InsertRun(tx *sql.Tx, v *types.Run) error {
 	if v.Revision != 0 {
 		return errors.Errorf("expected revision 0 got %d", v.Revision)
+	}
+
+	if v.TxID != tx.ID() {
+		return errors.Errorf("object was not created by this transaction")
 	}
 
 	data, err := d.insertRunData(tx, v)
@@ -347,6 +367,10 @@ func (d *DB) updateRunData(tx *sql.Tx, v *types.Run) ([]byte, error) {
 		return nil, errors.Errorf("expected revision > 0 got %d", v.Revision)
 	}
 
+	if v.TxID != tx.ID() {
+		return nil, errors.Errorf("object was not fetched by this transaction")
+	}
+
 	curRevision := v.Revision
 	v.Revision++
 
@@ -408,6 +432,10 @@ func (d *DB) InsertOrUpdateRunConfig(tx *sql.Tx, v *types.RunConfig) error {
 func (d *DB) InsertRunConfig(tx *sql.Tx, v *types.RunConfig) error {
 	if v.Revision != 0 {
 		return errors.Errorf("expected revision 0 got %d", v.Revision)
+	}
+
+	if v.TxID != tx.ID() {
+		return errors.Errorf("object was not created by this transaction")
 	}
 
 	data, err := d.insertRunConfigData(tx, v)
@@ -474,6 +502,10 @@ func (d *DB) updateRunConfigData(tx *sql.Tx, v *types.RunConfig) ([]byte, error)
 		return nil, errors.Errorf("expected revision > 0 got %d", v.Revision)
 	}
 
+	if v.TxID != tx.ID() {
+		return nil, errors.Errorf("object was not fetched by this transaction")
+	}
+
 	curRevision := v.Revision
 	v.Revision++
 
@@ -535,6 +567,10 @@ func (d *DB) InsertOrUpdateRunCounter(tx *sql.Tx, v *types.RunCounter) error {
 func (d *DB) InsertRunCounter(tx *sql.Tx, v *types.RunCounter) error {
 	if v.Revision != 0 {
 		return errors.Errorf("expected revision 0 got %d", v.Revision)
+	}
+
+	if v.TxID != tx.ID() {
+		return errors.Errorf("object was not created by this transaction")
 	}
 
 	data, err := d.insertRunCounterData(tx, v)
@@ -601,6 +637,10 @@ func (d *DB) updateRunCounterData(tx *sql.Tx, v *types.RunCounter) ([]byte, erro
 		return nil, errors.Errorf("expected revision > 0 got %d", v.Revision)
 	}
 
+	if v.TxID != tx.ID() {
+		return nil, errors.Errorf("object was not fetched by this transaction")
+	}
+
 	curRevision := v.Revision
 	v.Revision++
 
@@ -662,6 +702,10 @@ func (d *DB) InsertOrUpdateRunEvent(tx *sql.Tx, v *types.RunEvent) error {
 func (d *DB) InsertRunEvent(tx *sql.Tx, v *types.RunEvent) error {
 	if v.Revision != 0 {
 		return errors.Errorf("expected revision 0 got %d", v.Revision)
+	}
+
+	if v.TxID != tx.ID() {
+		return errors.Errorf("object was not created by this transaction")
 	}
 
 	data, err := d.insertRunEventData(tx, v)
@@ -728,6 +772,10 @@ func (d *DB) updateRunEventData(tx *sql.Tx, v *types.RunEvent) ([]byte, error) {
 		return nil, errors.Errorf("expected revision > 0 got %d", v.Revision)
 	}
 
+	if v.TxID != tx.ID() {
+		return nil, errors.Errorf("object was not fetched by this transaction")
+	}
+
 	curRevision := v.Revision
 	v.Revision++
 
@@ -789,6 +837,10 @@ func (d *DB) InsertOrUpdateExecutor(tx *sql.Tx, v *types.Executor) error {
 func (d *DB) InsertExecutor(tx *sql.Tx, v *types.Executor) error {
 	if v.Revision != 0 {
 		return errors.Errorf("expected revision 0 got %d", v.Revision)
+	}
+
+	if v.TxID != tx.ID() {
+		return errors.Errorf("object was not created by this transaction")
 	}
 
 	data, err := d.insertExecutorData(tx, v)
@@ -855,6 +907,10 @@ func (d *DB) updateExecutorData(tx *sql.Tx, v *types.Executor) ([]byte, error) {
 		return nil, errors.Errorf("expected revision > 0 got %d", v.Revision)
 	}
 
+	if v.TxID != tx.ID() {
+		return nil, errors.Errorf("object was not fetched by this transaction")
+	}
+
 	curRevision := v.Revision
 	v.Revision++
 
@@ -916,6 +972,10 @@ func (d *DB) InsertOrUpdateExecutorTask(tx *sql.Tx, v *types.ExecutorTask) error
 func (d *DB) InsertExecutorTask(tx *sql.Tx, v *types.ExecutorTask) error {
 	if v.Revision != 0 {
 		return errors.Errorf("expected revision 0 got %d", v.Revision)
+	}
+
+	if v.TxID != tx.ID() {
+		return errors.Errorf("object was not created by this transaction")
 	}
 
 	data, err := d.insertExecutorTaskData(tx, v)
@@ -980,6 +1040,10 @@ func (d *DB) UpdateExecutorTask(tx *sql.Tx, v *types.ExecutorTask) error {
 func (d *DB) updateExecutorTaskData(tx *sql.Tx, v *types.ExecutorTask) ([]byte, error) {
 	if v.Revision < 1 {
 		return nil, errors.Errorf("expected revision > 0 got %d", v.Revision)
+	}
+
+	if v.TxID != tx.ID() {
+		return nil, errors.Errorf("object was not fetched by this transaction")
 	}
 
 	curRevision := v.Revision

--- a/internal/sql/db.go
+++ b/internal/sql/db.go
@@ -8,6 +8,7 @@ import (
 
 	"agola.io/agola/internal/errors"
 
+	"github.com/gofrs/uuid"
 	"github.com/lib/pq"
 	"github.com/mattn/go-sqlite3"
 )
@@ -136,6 +137,7 @@ func (db *DB) Type() Type {
 // * Setup the transaction (set isolation levels etc...)
 // * Apply some statement mutations before executing it
 type Tx struct {
+	id  string
 	db  *DB
 	tx  *sql.Tx
 	ctx context.Context
@@ -152,6 +154,7 @@ func (db *DB) Conn(ctx context.Context) (*sql.Conn, error) {
 
 func (db *DB) NewUnstartedTx() *Tx {
 	return &Tx{
+		id: uuid.Must(uuid.NewV4()).String(),
 		db: db,
 	}
 }
@@ -215,6 +218,14 @@ func (db *DB) do(ctx context.Context, f func(tx *Tx) error) error {
 		return errors.WithStack(err)
 	}
 	return tx.Commit()
+}
+
+func (tx *Tx) ID() string {
+	if tx == nil {
+		return ""
+	}
+
+	return tx.id
 }
 
 func (tx *Tx) DBType() Type {

--- a/services/configstore/types/invitation.go
+++ b/services/configstore/types/invitation.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"agola.io/agola/internal/sql"
 	stypes "agola.io/agola/services/types"
 	"github.com/gofrs/uuid"
 )
@@ -33,14 +34,15 @@ type OrgInvitation struct {
 	Role           MemberRole `json:"role,omitempty"`
 }
 
-func NewOrgInvitation() *OrgInvitation {
+func NewOrgInvitation(tx *sql.Tx) *OrgInvitation {
 	return &OrgInvitation{
 		TypeMeta: stypes.TypeMeta{
 			Kind:    OrgInvitationKind,
 			Version: OrgInvitationVersion,
 		},
 		ObjectMeta: stypes.ObjectMeta{
-			ID: uuid.Must(uuid.NewV4()).String(),
+			ID:   uuid.Must(uuid.NewV4()).String(),
+			TxID: tx.ID(),
 		},
 	}
 }

--- a/services/configstore/types/org.go
+++ b/services/configstore/types/org.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"agola.io/agola/internal/sql"
 	stypes "agola.io/agola/services/types"
 
 	"github.com/gofrs/uuid"
@@ -38,14 +39,15 @@ type Organization struct {
 	CreatorUserID string `json:"creator_user_id,omitempty"`
 }
 
-func NewOrganization() *Organization {
+func NewOrganization(tx *sql.Tx) *Organization {
 	return &Organization{
 		TypeMeta: stypes.TypeMeta{
 			Kind:    OrganizationKind,
 			Version: OrganizationVersion,
 		},
 		ObjectMeta: stypes.ObjectMeta{
-			ID: uuid.Must(uuid.NewV4()).String(),
+			ID:   uuid.Must(uuid.NewV4()).String(),
+			TxID: tx.ID(),
 		},
 	}
 }
@@ -65,14 +67,15 @@ type OrganizationMember struct {
 	MemberRole MemberRole `json:"member_role,omitempty"`
 }
 
-func NewOrganizationMember() *OrganizationMember {
+func NewOrganizationMember(tx *sql.Tx) *OrganizationMember {
 	return &OrganizationMember{
 		TypeMeta: stypes.TypeMeta{
 			Kind:    OrganizationMemberKind,
 			Version: OrganizationMemberVersion,
 		},
 		ObjectMeta: stypes.ObjectMeta{
-			ID: uuid.Must(uuid.NewV4()).String(),
+			ID:   uuid.Must(uuid.NewV4()).String(),
+			TxID: tx.ID(),
 		},
 	}
 }

--- a/services/configstore/types/project.go
+++ b/services/configstore/types/project.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"agola.io/agola/internal/sql"
 	stypes "agola.io/agola/services/types"
 
 	"github.com/gofrs/uuid"
@@ -90,14 +91,15 @@ type Project struct {
 	DefaultBranch string `json:"default_branch,omitempty"`
 }
 
-func NewProject() *Project {
+func NewProject(tx *sql.Tx) *Project {
 	return &Project{
 		TypeMeta: stypes.TypeMeta{
 			Kind:    ProjectKind,
 			Version: ProjectVersion,
 		},
 		ObjectMeta: stypes.ObjectMeta{
-			ID: uuid.Must(uuid.NewV4()).String(),
+			ID:   uuid.Must(uuid.NewV4()).String(),
+			TxID: tx.ID(),
 		},
 	}
 }

--- a/services/configstore/types/projectgroup.go
+++ b/services/configstore/types/projectgroup.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"agola.io/agola/internal/sql"
 	stypes "agola.io/agola/services/types"
 
 	"github.com/gofrs/uuid"
@@ -36,14 +37,15 @@ type ProjectGroup struct {
 	Visibility Visibility `json:"visibility,omitempty"`
 }
 
-func NewProjectGroup() *ProjectGroup {
+func NewProjectGroup(tx *sql.Tx) *ProjectGroup {
 	return &ProjectGroup{
 		TypeMeta: stypes.TypeMeta{
 			Kind:    ProjectGroupKind,
 			Version: ProjectGroupVersion,
 		},
 		ObjectMeta: stypes.ObjectMeta{
-			ID: uuid.Must(uuid.NewV4()).String(),
+			ID:   uuid.Must(uuid.NewV4()).String(),
+			TxID: tx.ID(),
 		},
 	}
 }

--- a/services/configstore/types/remotesource.go
+++ b/services/configstore/types/remotesource.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 
 	"agola.io/agola/internal/errors"
+	"agola.io/agola/internal/sql"
 	stypes "agola.io/agola/services/types"
 	"agola.io/agola/util"
 
@@ -68,14 +69,15 @@ type RemoteSource struct {
 	LoginEnabled        *bool `json:"login_enabled,omitempty"`
 }
 
-func NewRemoteSource() *RemoteSource {
+func NewRemoteSource(tx *sql.Tx) *RemoteSource {
 	return &RemoteSource{
 		TypeMeta: stypes.TypeMeta{
 			Kind:    RemoteSourceKind,
 			Version: RemoteSourceVersion,
 		},
 		ObjectMeta: stypes.ObjectMeta{
-			ID: uuid.Must(uuid.NewV4()).String(),
+			ID:   uuid.Must(uuid.NewV4()).String(),
+			TxID: tx.ID(),
 		},
 	}
 }

--- a/services/configstore/types/secret.go
+++ b/services/configstore/types/secret.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"agola.io/agola/internal/sql"
 	stypes "agola.io/agola/services/types"
 
 	"github.com/gofrs/uuid"
@@ -58,14 +59,15 @@ type Secret struct {
 	Path             string `json:"path,omitempty"`
 }
 
-func NewSecret() *Secret {
+func NewSecret(tx *sql.Tx) *Secret {
 	return &Secret{
 		TypeMeta: stypes.TypeMeta{
 			Kind:    SecretKind,
 			Version: SecretVersion,
 		},
 		ObjectMeta: stypes.ObjectMeta{
-			ID: uuid.Must(uuid.NewV4()).String(),
+			ID:   uuid.Must(uuid.NewV4()).String(),
+			TxID: tx.ID(),
 		},
 	}
 }

--- a/services/configstore/types/user.go
+++ b/services/configstore/types/user.go
@@ -17,6 +17,7 @@ package types
 import (
 	"time"
 
+	"agola.io/agola/internal/sql"
 	stypes "agola.io/agola/services/types"
 
 	"github.com/gofrs/uuid"
@@ -41,14 +42,15 @@ type User struct {
 	Admin bool `json:"admin,omitempty"`
 }
 
-func NewUser() *User {
+func NewUser(tx *sql.Tx) *User {
 	return &User{
 		TypeMeta: stypes.TypeMeta{
 			Kind:    UserKind,
 			Version: UserVersion,
 		},
 		ObjectMeta: stypes.ObjectMeta{
-			ID: uuid.Must(uuid.NewV4()).String(),
+			ID:   uuid.Must(uuid.NewV4()).String(),
+			TxID: tx.ID(),
 		},
 	}
 }
@@ -68,14 +70,15 @@ type UserToken struct {
 	UserID string `json:"user_id,omitempty"`
 }
 
-func NewUserToken() *UserToken {
+func NewUserToken(tx *sql.Tx) *UserToken {
 	return &UserToken{
 		TypeMeta: stypes.TypeMeta{
 			Kind:    UserTokenKind,
 			Version: UserTokenVersion,
 		},
 		ObjectMeta: stypes.ObjectMeta{
-			ID: uuid.Must(uuid.NewV4()).String(),
+			ID:   uuid.Must(uuid.NewV4()).String(),
+			TxID: tx.ID(),
 		},
 	}
 }
@@ -104,14 +107,15 @@ type LinkedAccount struct {
 	Oauth2AccessTokenExpiresAt time.Time `json:"oauth_2_access_token_expires_at,omitempty"`
 }
 
-func NewLinkedAccount() *LinkedAccount {
+func NewLinkedAccount(tx *sql.Tx) *LinkedAccount {
 	return &LinkedAccount{
 		TypeMeta: stypes.TypeMeta{
 			Kind:    LinkedAccountKind,
 			Version: LinkedAccountVersion,
 		},
 		ObjectMeta: stypes.ObjectMeta{
-			ID: uuid.Must(uuid.NewV4()).String(),
+			ID:   uuid.Must(uuid.NewV4()).String(),
+			TxID: tx.ID(),
 		},
 	}
 }

--- a/services/configstore/types/variable.go
+++ b/services/configstore/types/variable.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"agola.io/agola/internal/sql"
 	stypes "agola.io/agola/services/types"
 
 	"github.com/gofrs/uuid"
@@ -43,14 +44,15 @@ type Variable struct {
 	Values []VariableValue `json:"values,omitempty"`
 }
 
-func NewVariable() *Variable {
+func NewVariable(tx *sql.Tx) *Variable {
 	return &Variable{
 		TypeMeta: stypes.TypeMeta{
 			Kind:    VariableKind,
 			Version: VariableVersion,
 		},
 		ObjectMeta: stypes.ObjectMeta{
-			ID: uuid.Must(uuid.NewV4()).String(),
+			ID:   uuid.Must(uuid.NewV4()).String(),
+			TxID: tx.ID(),
 		},
 	}
 }

--- a/services/runservice/types/changegroup.go
+++ b/services/runservice/types/changegroup.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"agola.io/agola/internal/sql"
 	stypes "agola.io/agola/services/types"
 
 	"github.com/gofrs/uuid"
@@ -26,14 +27,15 @@ type ChangeGroup struct {
 	Value string `json:"value"`
 }
 
-func NewChangeGroup() *ChangeGroup {
+func NewChangeGroup(tx *sql.Tx) *ChangeGroup {
 	return &ChangeGroup{
 		TypeMeta: stypes.TypeMeta{
 			Kind:    ChangeGroupKind,
 			Version: ChangeGroupVersion,
 		},
 		ObjectMeta: stypes.ObjectMeta{
-			ID: uuid.Must(uuid.NewV4()).String(),
+			ID:   uuid.Must(uuid.NewV4()).String(),
+			TxID: tx.ID(),
 		},
 	}
 }

--- a/services/runservice/types/executor.go
+++ b/services/runservice/types/executor.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"agola.io/agola/internal/sql"
 	stypes "agola.io/agola/services/types"
 
 	"github.com/gofrs/uuid"
@@ -49,14 +50,15 @@ func (e *Executor) DeepCopy() *Executor {
 	return ne.(*Executor)
 }
 
-func NewExecutor() *Executor {
+func NewExecutor(tx *sql.Tx) *Executor {
 	return &Executor{
 		TypeMeta: stypes.TypeMeta{
 			Kind:    ExecutorKind,
 			Version: ExecutorVersion,
 		},
 		ObjectMeta: stypes.ObjectMeta{
-			ID: uuid.Must(uuid.NewV4()).String(),
+			ID:   uuid.Must(uuid.NewV4()).String(),
+			TxID: tx.ID(),
 		},
 	}
 }

--- a/services/runservice/types/executortask.go
+++ b/services/runservice/types/executortask.go
@@ -3,6 +3,7 @@ package types
 import (
 	"time"
 
+	"agola.io/agola/internal/sql"
 	stypes "agola.io/agola/services/types"
 
 	"github.com/gofrs/uuid"
@@ -113,14 +114,15 @@ type WorkspaceOperation struct {
 	Overwrite bool   `json:"overwrite,omitempty"`
 }
 
-func NewExecutorTask() *ExecutorTask {
+func NewExecutorTask(tx *sql.Tx) *ExecutorTask {
 	return &ExecutorTask{
 		TypeMeta: stypes.TypeMeta{
 			Kind:    ExecutorTaskKind,
 			Version: ExecutorTaskVersion,
 		},
 		ObjectMeta: stypes.ObjectMeta{
-			ID: uuid.Must(uuid.NewV4()).String(),
+			ID:   uuid.Must(uuid.NewV4()).String(),
+			TxID: tx.ID(),
 		},
 	}
 }

--- a/services/runservice/types/run.go
+++ b/services/runservice/types/run.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"agola.io/agola/internal/sql"
 	stypes "agola.io/agola/services/types"
 	"agola.io/agola/util"
 
@@ -261,14 +262,15 @@ type RunTaskStep struct {
 	EndTime   *time.Time `json:"end_time,omitempty"`
 }
 
-func NewRun() *Run {
+func NewRun(tx *sql.Tx) *Run {
 	return &Run{
 		TypeMeta: stypes.TypeMeta{
 			Kind:    RunKind,
 			Version: RunVersion,
 		},
 		ObjectMeta: stypes.ObjectMeta{
-			ID: uuid.Must(uuid.NewV4()).String(),
+			ID:   uuid.Must(uuid.NewV4()).String(),
+			TxID: tx.ID(),
 		},
 	}
 }

--- a/services/runservice/types/runconfig.go
+++ b/services/runservice/types/runconfig.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"agola.io/agola/internal/errors"
+	"agola.io/agola/internal/sql"
 	stypes "agola.io/agola/services/types"
 	"agola.io/agola/util"
 
@@ -258,14 +259,15 @@ func (et *Steps) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func NewRunConfig() *RunConfig {
+func NewRunConfig(tx *sql.Tx) *RunConfig {
 	return &RunConfig{
 		TypeMeta: stypes.TypeMeta{
 			Kind:    RunConfigKind,
 			Version: RunConfigVersion,
 		},
 		ObjectMeta: stypes.ObjectMeta{
-			ID: uuid.Must(uuid.NewV4()).String(),
+			ID:   uuid.Must(uuid.NewV4()).String(),
+			TxID: tx.ID(),
 		},
 	}
 }

--- a/services/runservice/types/runcounter.go
+++ b/services/runservice/types/runcounter.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"agola.io/agola/internal/sql"
 	stypes "agola.io/agola/services/types"
 
 	"github.com/gofrs/uuid"
@@ -19,14 +20,15 @@ type RunCounter struct {
 	Value   uint64
 }
 
-func NewRunCounter(groupID string) *RunCounter {
+func NewRunCounter(tx *sql.Tx, groupID string) *RunCounter {
 	return &RunCounter{
 		TypeMeta: stypes.TypeMeta{
 			Kind:    RunCounterKind,
 			Version: RunCounterVersion,
 		},
 		ObjectMeta: stypes.ObjectMeta{
-			ID: uuid.Must(uuid.NewV4()).String(),
+			ID:   uuid.Must(uuid.NewV4()).String(),
+			TxID: tx.ID(),
 		},
 		GroupID: groupID,
 	}

--- a/services/runservice/types/runevent.go
+++ b/services/runservice/types/runevent.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"agola.io/agola/internal/sql"
 	stypes "agola.io/agola/services/types"
 
 	"github.com/gofrs/uuid"
@@ -22,14 +23,15 @@ type RunEvent struct {
 	Result RunResult
 }
 
-func NewRunEvent() *RunEvent {
+func NewRunEvent(tx *sql.Tx) *RunEvent {
 	return &RunEvent{
 		TypeMeta: stypes.TypeMeta{
 			Kind:    RunEventKind,
 			Version: RunEventVersion,
 		},
 		ObjectMeta: stypes.ObjectMeta{
-			ID: uuid.Must(uuid.NewV4()).String(),
+			ID:   uuid.Must(uuid.NewV4()).String(),
+			TxID: tx.ID(),
 		},
 	}
 }

--- a/services/runservice/types/sequence.go
+++ b/services/runservice/types/sequence.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"agola.io/agola/internal/sql"
 	stypes "agola.io/agola/services/types"
 
 	"github.com/gofrs/uuid"
@@ -27,14 +28,15 @@ type Sequence struct {
 	SequenceType SequenceType `json:"sequence_type"`
 }
 
-func NewSequence(sequenceType SequenceType) *Sequence {
+func NewSequence(tx *sql.Tx, sequenceType SequenceType) *Sequence {
 	return &Sequence{
 		TypeMeta: stypes.TypeMeta{
 			Kind:    SequenceKind,
 			Version: SequenceVersion,
 		},
 		ObjectMeta: stypes.ObjectMeta{
-			ID: uuid.Must(uuid.NewV4()).String(),
+			ID:   uuid.Must(uuid.NewV4()).String(),
+			TxID: tx.ID(),
 		},
 		SequenceType: sequenceType,
 	}

--- a/services/types/object.go
+++ b/services/types/object.go
@@ -42,6 +42,9 @@ type ObjectMeta struct {
 	// Revision is the object revision, it's not saved in the object but
 	// populated by the fetch from the database
 	Revision uint64 `json:"-"`
+
+	// TxID is the current transaction id, used internally and must not be saved in the object
+	TxID string `json:"-"`
 }
 
 func (m *ObjectMeta) GetID() string {


### PR DESCRIPTION
Since the transactions can be repeated (i.e. due to serializable errors in postgres or locked errors in sqlite) we should ensure that the objects are created inside the transaction or at the second execution the transaction will fail since the object revision has been updated by the previous one.

This patch adds a txID to every transaction that it's set on objects fetched as an helper to ensure that the object is created/fetched inside the same transaction.

To handle cases were the object is fetched/created outside the transaction we MUST manually ensure that the object is still valid (the tx logic must be self consistent) and only in such case restore the txID to the current transactions and revision to the original value at the start of the transaction.