### PR TITLE
util: fix empty APIError error message printing

### DIFF
--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -94,17 +94,21 @@ type APIError struct {
 	Code    ErrorCode
 	Message string
 
-	*errors.Stack
+	stack *errors.Stack
 }
 
 func NewAPIError(kind ErrorKind, err error, options ...APIErrorOption) error {
-	derr := &APIError{err: err, Kind: kind, Stack: errors.Callers(0)}
+	derr := &APIError{err: err, Kind: kind, stack: errors.Callers(0)}
 
 	for _, opt := range options {
 		opt(derr)
 	}
 
 	return derr
+}
+
+func (e *APIError) StackTrace() errors.StackTrace {
+	return e.stack.StackTrace()
 }
 
 func (e *APIError) Error() string {


### PR DESCRIPTION
Fix empty APIError error message printing using standard fmt.Sprintf. This went unnoticed since we were always using zerolog for logging but in tests it may appear.

Since errors.Stack was embededded in APIError its Format method is used instead of the APIError.Error() method and when not using "%+v" it prints an empty string.

Fix this by not embedding errors.Stack and returning the stack by implementing the StackTracer interface.