### PR TITLE
util: add wrapper error helper type

### DIFF
--- a/internal/objectstorage/objectstorage.go
+++ b/internal/objectstorage/objectstorage.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"agola.io/agola/internal/errors"
+	"agola.io/agola/internal/util"
 )
 
 type Storage interface {
@@ -35,21 +36,13 @@ type Storage interface {
 }
 
 type ErrNotExist struct {
-	err error
-
-	*errors.Stack
+	*util.WrapperError
 }
 
-func NewErrNotExist(err error) error {
-	return &ErrNotExist{err: err, Stack: errors.Callers(0)}
-}
-
-func (e *ErrNotExist) Error() string {
-	return e.err.Error()
-}
-
-func (e *ErrNotExist) Unwrap() error {
-	return e.err
+func NewErrNotExist(err error, format string, args ...interface{}) error {
+	return &ErrNotExist{
+		util.NewWrapperError(err, format, args...),
+	}
 }
 
 func IsNotExist(err error) bool {

--- a/internal/objectstorage/posix.go
+++ b/internal/objectstorage/posix.go
@@ -65,7 +65,7 @@ func (s *PosixStorage) Stat(p string) (*ObjectInfo, error) {
 	fi, err := os.Stat(fspath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, NewErrNotExist(errors.Errorf("object %q doesn't exist", p))
+			return nil, NewErrNotExist(err, "object %q doesn't exist", p)
 		}
 		return nil, errors.WithStack(err)
 	}
@@ -81,7 +81,7 @@ func (s *PosixStorage) ReadObject(p string) (ReadSeekCloser, error) {
 
 	f, err := os.Open(fspath)
 	if err != nil && errors.Is(err, os.ErrNotExist) {
-		return nil, NewErrNotExist(errors.Errorf("object %q doesn't exist", p))
+		return nil, NewErrNotExist(err, "object %q doesn't exist", p)
 	}
 	return f, errors.WithStack(err)
 }
@@ -114,7 +114,7 @@ func (s *PosixStorage) DeleteObject(p string) error {
 
 	if err := os.Remove(fspath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return NewErrNotExist(errors.Errorf("object %q doesn't exist", p))
+			return NewErrNotExist(err, "object %q doesn't exist", p)
 		}
 		return errors.WithStack(err)
 	}

--- a/internal/objectstorage/posixflat.go
+++ b/internal/objectstorage/posixflat.go
@@ -239,7 +239,7 @@ func (s *PosixFlatStorage) Stat(p string) (*ObjectInfo, error) {
 	fi, err := os.Stat(fspath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, NewErrNotExist(errors.Errorf("object %q doesn't exist", p))
+			return nil, NewErrNotExist(err, "object %q doesn't exist", p)
 		}
 		return nil, errors.WithStack(err)
 	}
@@ -255,7 +255,7 @@ func (s *PosixFlatStorage) ReadObject(p string) (ReadSeekCloser, error) {
 
 	f, err := os.Open(fspath)
 	if err != nil && errors.Is(err, os.ErrNotExist) {
-		return nil, NewErrNotExist(errors.Errorf("object %q doesn't exist", p))
+		return nil, NewErrNotExist(err, "object %q doesn't exist", p)
 	}
 	return f, errors.WithStack(err)
 }
@@ -288,7 +288,7 @@ func (s *PosixFlatStorage) DeleteObject(p string) error {
 
 	if err := os.Remove(fspath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return NewErrNotExist(errors.Errorf("object %q doesn't exist", p))
+			return NewErrNotExist(err, "object %q doesn't exist", p)
 		}
 		return errors.WithStack(err)
 	}

--- a/internal/objectstorage/s3.go
+++ b/internal/objectstorage/s3.go
@@ -64,7 +64,7 @@ func (s *S3Storage) Stat(p string) (*ObjectInfo, error) {
 	if err != nil {
 		merr := minio.ToErrorResponse(err)
 		if merr.StatusCode == http.StatusNotFound {
-			return nil, NewErrNotExist(errors.Errorf("object %q doesn't exist", p))
+			return nil, NewErrNotExist(err, "object %q doesn't exist", p)
 		}
 		return nil, errors.WithStack(merr)
 	}
@@ -76,7 +76,7 @@ func (s *S3Storage) ReadObject(filepath string) (ReadSeekCloser, error) {
 	if _, err := s.minioClient.StatObject(s.bucket, filepath, minio.StatObjectOptions{}); err != nil {
 		merr := minio.ToErrorResponse(err)
 		if merr.StatusCode == http.StatusNotFound {
-			return nil, NewErrNotExist(errors.Errorf("object %q doesn't exist", filepath))
+			return nil, NewErrNotExist(err, "object %q doesn't exist", filepath)
 		}
 		return nil, errors.WithStack(merr)
 	}

--- a/internal/services/configstore/configstore_test.go
+++ b/internal/services/configstore/configstore_test.go
@@ -433,12 +433,12 @@ func TestUser(t *testing.T) {
 	})
 
 	t.Run("create duplicated user", func(t *testing.T) {
-		expectedErr := fmt.Sprintf("user with name %q already exists", "user01")
+		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("user with name %q already exists", "user01"))
 		_, err := cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: "user01"})
 		if err == nil {
 			t.Fatalf("expected error %v, got nil err", expectedErr)
 		}
-		if err.Error() != expectedErr {
+		if err.Error() != expectedErr.Error() {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
 	})
@@ -554,49 +554,49 @@ func TestProjectGroupsAndProjectsCreate(t *testing.T) {
 
 	t.Run("create duplicated project in user root project group", func(t *testing.T) {
 		projectName := "project01"
-		expectedErr := fmt.Sprintf("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, projectName))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, projectName)))
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: projectName, Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
-		if err.Error() != expectedErr {
+		if err.Error() != expectedErr.Error() {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
 	})
 	t.Run("create duplicated project in org root project group", func(t *testing.T) {
 		projectName := "project01"
-		expectedErr := fmt.Sprintf("project with name %q, path %q already exists", projectName, path.Join("org", org.Name, projectName))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with name %q, path %q already exists", projectName, path.Join("org", org.Name, projectName)))
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: projectName, Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
-		if err.Error() != expectedErr {
+		if err.Error() != expectedErr.Error() {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
 	})
 
 	t.Run("create duplicated project in user non root project group", func(t *testing.T) {
 		projectName := "project01"
-		expectedErr := fmt.Sprintf("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, "projectgroup01", projectName))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, "projectgroup01", projectName)))
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: projectName, Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
-		if err.Error() != expectedErr {
+		if err.Error() != expectedErr.Error() {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
 	})
 	t.Run("create duplicated project in org non root project group", func(t *testing.T) {
 		projectName := "project01"
-		expectedErr := fmt.Sprintf("project with name %q, path %q already exists", projectName, path.Join("org", org.Name, "projectgroup01", projectName))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with name %q, path %q already exists", projectName, path.Join("org", org.Name, "projectgroup01", projectName)))
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: projectName, Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("org", org.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
-		if err.Error() != expectedErr {
+		if err.Error() != expectedErr.Error() {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
 	})
 
 	t.Run("create project in unexistent project group", func(t *testing.T) {
-		expectedErr := `project group with id "unexistentid" doesn't exist`
+		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf(`project group with id "unexistentid" doesn't exist`))
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: "unexistentid"}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
-		if err.Error() != expectedErr {
+		if err.Error() != expectedErr.Error() {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
 	})
 	t.Run("create project without parent id specified", func(t *testing.T) {
-		expectedErr := "project parent id required"
+		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("project parent id required"))
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
-		if err.Error() != expectedErr {
+		if err.Error() != expectedErr.Error() {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
 	})
@@ -671,10 +671,10 @@ func TestProjectUpdate(t *testing.T) {
 	})
 	t.Run("move project to project group having project with same name", func(t *testing.T) {
 		projectName := "project01"
-		expectedErr := fmt.Sprintf("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, projectName))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, projectName)))
 		p02.Parent.ID = path.Join("user", user.Name)
 		_, err := cs.ah.UpdateProject(ctx, path.Join("user", user.Name, "projectgroup01", projectName), p02)
-		if err.Error() != expectedErr {
+		if err.Error() != expectedErr.Error() {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
 	})
@@ -741,10 +741,10 @@ func TestProjectGroupUpdate(t *testing.T) {
 	})
 	t.Run("move project to project group having project with same name", func(t *testing.T) {
 		projectGroupName := "pg01"
-		expectedErr := fmt.Sprintf("project group with name %q, path %q already exists", projectGroupName, path.Join("user", user.Name, projectGroupName))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("project group with name %q, path %q already exists", projectGroupName, path.Join("user", user.Name, projectGroupName)))
 		pg05req.Parent.ID = path.Join("user", user.Name)
 		_, err := cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name, "pg02", projectGroupName), pg05req)
-		if err.Error() != expectedErr {
+		if err.Error() != expectedErr.Error() {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
 	})
@@ -762,19 +762,19 @@ func TestProjectGroupUpdate(t *testing.T) {
 	})
 	t.Run("move project group inside itself", func(t *testing.T) {
 		projectGroupName := "pg02"
-		expectedErr := "cannot move project group inside itself or child project group"
+		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot move project group inside itself or child project group"))
 		pg02req.Parent.ID = path.Join("user", user.Name, "pg02")
 		_, err := cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name, projectGroupName), pg02req)
-		if err.Error() != expectedErr {
+		if err.Error() != expectedErr.Error() {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
 	})
 	t.Run("move project group to child project group", func(t *testing.T) {
 		projectGroupName := "pg01"
-		expectedErr := "cannot move project group inside itself or child project group"
+		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot move project group inside itself or child project group"))
 		pg01req.Parent.ID = path.Join("user", user.Name, "pg01", "pg01")
 		_, err := cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name, projectGroupName), pg01req)
-		if err.Error() != expectedErr {
+		if err.Error() != expectedErr.Error() {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
 	})
@@ -787,9 +787,9 @@ func TestProjectGroupUpdate(t *testing.T) {
 		rootPG.Parent.Kind = types.ObjectKindProjectGroup
 		rootPG.Name = "rootpg"
 
-		expectedErr := "changing project group parent kind isn't supported"
+		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("changing project group parent kind isn't supported"))
 		_, err = cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name), &action.CreateUpdateProjectGroupRequest{Name: rootPG.Name, Parent: rootPG.Parent, Visibility: rootPG.Visibility})
-		if err.Error() != expectedErr {
+		if err.Error() != expectedErr.Error() {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
 	})
@@ -801,9 +801,9 @@ func TestProjectGroupUpdate(t *testing.T) {
 		}
 		rootPG.Parent.ID = path.Join("user", user.Name, "pg01")
 
-		expectedErr := "cannot change root project group parent kind or id"
+		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot change root project group parent kind or id"))
 		_, err = cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name), &action.CreateUpdateProjectGroupRequest{Name: rootPG.Name, Parent: rootPG.Parent, Visibility: rootPG.Visibility})
-		if err.Error() != expectedErr {
+		if err.Error() != expectedErr.Error() {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
 	})
@@ -815,9 +815,9 @@ func TestProjectGroupUpdate(t *testing.T) {
 		}
 		rootPG.Name = "rootpgnewname"
 
-		expectedErr := "project group name for root project group must be empty"
+		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("project group name for root project group must be empty"))
 		_, err = cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name), &action.CreateUpdateProjectGroupRequest{Name: rootPG.Name, Parent: rootPG.Parent, Visibility: rootPG.Visibility})
-		if err.Error() != expectedErr {
+		if err.Error() != expectedErr.Error() {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
 	})
@@ -872,9 +872,9 @@ func TestProjectGroupDelete(t *testing.T) {
 	}
 
 	t.Run("delete root project group", func(t *testing.T) {
-		expectedErr := "cannot delete root project group"
+		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot delete root project group"))
 		err := cs.ah.DeleteProjectGroup(ctx, path.Join("org", org.Name))
-		if err.Error() != expectedErr {
+		if err.Error() != expectedErr.Error() {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
 	})

--- a/internal/util/http.go
+++ b/internal/util/http.go
@@ -37,9 +37,9 @@ func ErrorResponseFromError(err error) *ErrorResponse {
 		return nil
 	}
 
-	var derr *APIError
-	if errors.As(err, &derr) {
-		return &ErrorResponse{Code: string(derr.Code), Message: derr.Message}
+	var aerr *APIError
+	if errors.As(err, &aerr) {
+		return &ErrorResponse{Code: string(aerr.Code), Message: aerr.Message}
 	}
 
 	// on generic error return an error response without any code
@@ -60,9 +60,9 @@ func HTTPError(w http.ResponseWriter, err error) bool {
 
 	code := http.StatusInternalServerError
 
-	var derr *APIError
-	if errors.As(err, &derr) {
-		switch derr.Kind {
+	var aerr *APIError
+	if errors.As(err, &aerr) {
+		switch aerr.Kind {
 		case ErrBadRequest:
 			code = http.StatusBadRequest
 		case ErrNotExist:


### PR DESCRIPTION
* Add a WrapperError helper type that can be embedded by custom errors to easily implement the stacktracing and wrapping ability.

* Make APIError and objectStorage.ErrNotExist use it.