### PR TITLE
gateway: skip csrf check only on successful token auth

### DIFF
--- a/internal/services/gateway/common/auth.go
+++ b/internal/services/gateway/common/auth.go
@@ -18,6 +18,8 @@ const (
 	ContextKeyUserID ContextKey = iota
 	ContextKeyUsername
 	ContextKeyUserAdmin
+
+	ContextKeyTokenAuth
 )
 
 func CurrentUserID(ctx context.Context) string {

--- a/tests/cookieclient_test.go
+++ b/tests/cookieclient_test.go
@@ -108,3 +108,18 @@ func (c *CookieClient) GetCurrentUser(ctx context.Context, cookies []*http.Cooki
 	resp, err := c.getParsedResponse(ctx, "GET", "/user", nil, jsonContent, cookies, nil, user)
 	return user, resp, errors.WithStack(err)
 }
+
+func (c *CookieClient) CreateOrg(ctx context.Context, req *gwapitypes.CreateOrgRequest, header http.Header, cookies []*http.Cookie) (*gwapitypes.OrgResponse, *http.Response, error) {
+	reqj, err := json.Marshal(req)
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+
+	for k, v := range jsonContent {
+		header[k] = v
+	}
+
+	org := new(gwapitypes.OrgResponse)
+	resp, err := c.getParsedResponse(ctx, "POST", "/orgs", nil, header, cookies, bytes.NewReader(reqj), org)
+	return org, resp, errors.WithStack(err)
+}


### PR DESCRIPTION
* skip csrf check only on successful token auth and not only if the token has been provided.
* improve checkers logic to tell when auth should fail in the checker response so we could return an unauthorized error