### PR TITLE
migrateexport: defer sqlite foreign keys

### DIFF
--- a/doc/migrating_from_v0.7.x.md
+++ b/doc/migrating_from_v0.7.x.md
@@ -19,7 +19,7 @@ We suggest to test this migration on a test environment before doing this on you
 
    `cat /tmp/runservice-export | ./tmp/agola migrateexport --service runservice > /tmp/runservice-migrated`
 
-   `cat /tmp/runservice-export | ./tmp/agola migratexporte --service configstore > /tmp/configstore-migrated`
+   `cat /tmp/runservice-export | ./tmp/agola migrateexport --service configstore > /tmp/configstore-migrated`
 
 1. Update the agola binaries on your environment or use a test enviroment and start only the runservice and configstore.
 1. Update the agola config file and remove the runservice, configstore, notification service etcd entries and add the db entries. Every component should have its own dedicated database. DO NOT use the same database for all the services. For PostgresSQL it can be the same postgres instance but with different databases.

--- a/internal/migration/248a9e0ad/configstore.go
+++ b/internal/migration/248a9e0ad/configstore.go
@@ -61,6 +61,10 @@ func MigrateConfigStore(ctx context.Context, r io.Reader, w io.Writer) error {
 		return errors.WithStack(err)
 	}
 
+	if _, err := tx.Exec("PRAGMA defer_foreign_keys = ON"); err != nil {
+		return errors.WithStack(err)
+	}
+
 	for {
 		var data json.RawMessage
 

--- a/internal/migration/248a9e0ad/runservice.go
+++ b/internal/migration/248a9e0ad/runservice.go
@@ -61,6 +61,10 @@ func MigrateRunService(ctx context.Context, r io.Reader, w io.Writer) error {
 		return errors.WithStack(err)
 	}
 
+	if _, err := tx.Exec("PRAGMA defer_foreign_keys = ON"); err != nil {
+		return errors.WithStack(err)
+	}
+
 	for {
 		var data json.RawMessage
 

--- a/internal/migration/v0.7.x/configstore.go
+++ b/internal/migration/v0.7.x/configstore.go
@@ -63,6 +63,10 @@ func MigrateConfigStore(ctx context.Context, r io.Reader, w io.Writer) error {
 		return errors.WithStack(err)
 	}
 
+	if _, err := tx.Exec("PRAGMA defer_foreign_keys = ON"); err != nil {
+		return errors.WithStack(err)
+	}
+
 	for {
 		var de *DataEntry
 

--- a/internal/migration/v0.7.x/runservice.go
+++ b/internal/migration/v0.7.x/runservice.go
@@ -66,6 +66,10 @@ func MigrateRunService(ctx context.Context, r io.Reader, w io.Writer) error {
 		return errors.WithStack(err)
 	}
 
+	if _, err := tx.Exec("PRAGMA defer_foreign_keys = ON"); err != nil {
+		return errors.WithStack(err)
+	}
+
 	var curNewRunSequence uint64
 	var prevOldRunSequence string
 	for {


### PR DESCRIPTION
Entries could be out of order causing foreign keys constraints failures.
Defer foreign key validation at commit time.

Also fix migration doc typo.