### PR TITLE
runservice/db: fix get run query

### DIFF
--- a/internal/migration/destination/runservice/db/db.go
+++ b/internal/migration/destination/runservice/db/db.go
@@ -240,10 +240,10 @@ func (d *DB) getGroupRunsFilteredQuery(phaseFilter []types.RunPhase, resultFilte
 		q.OrderBy("run.counter").Desc()
 	}
 	if len(phaseFilter) > 0 {
-		q.Where(q.E("phase", phaseFilter))
+		q.Where(q.In("phase", sq.Flatten(phaseFilter)...))
 	}
 	if len(resultFilter) > 0 {
-		q.Where(q.E("result", resultFilter))
+		q.Where(q.In("result", sq.Flatten(resultFilter)...))
 	}
 	if startRunCounter > 0 {
 		switch sortOrder {

--- a/internal/services/runservice/db/db.go
+++ b/internal/services/runservice/db/db.go
@@ -242,10 +242,10 @@ func (d *DB) getGroupRunsFilteredQuery(phaseFilter []types.RunPhase, resultFilte
 		q.OrderBy("run.counter").Desc()
 	}
 	if len(phaseFilter) > 0 {
-		q.Where(q.E("phase", phaseFilter))
+		q.Where(q.In("phase", sq.Flatten(phaseFilter)...))
 	}
 	if len(resultFilter) > 0 {
-		q.Where(q.E("result", resultFilter))
+		q.Where(q.In("result", sq.Flatten(resultFilter)...))
 	}
 	if startRunCounter > 0 {
 		switch sortOrder {


### PR DESCRIPTION
Since the filters for run phase and result are slices, don't use sql "EQUAL" but "IN".