### PR TITLE
gitsources: split oauth2Client from gitsource

### DIFF
--- a/internal/gitsources/gitsource.go
+++ b/internal/gitsources/gitsource.go
@@ -72,6 +72,9 @@ type PasswordSource interface {
 
 type Oauth2Source interface {
 	UserSource
+}
+
+type Oauth2Client interface {
 	// GetOauth2AuthorizationURL return the authorization request URL to the
 	// authorization server
 	GetOauth2AuthorizationURL(callbackURL, state string) (redirectURL string, err error)

--- a/internal/services/common/gitsource.go
+++ b/internal/services/common/gitsource.go
@@ -26,11 +26,9 @@ import (
 
 func newGitea(rs *cstypes.RemoteSource, accessToken string) (*gitea.Client, error) {
 	c, err := gitea.New(gitea.Opts{
-		APIURL:         rs.APIURL,
-		SkipVerify:     rs.SkipVerify,
-		Token:          accessToken,
-		Oauth2ClientID: rs.Oauth2ClientID,
-		Oauth2Secret:   rs.Oauth2ClientSecret,
+		APIURL:     rs.APIURL,
+		SkipVerify: rs.SkipVerify,
+		Token:      accessToken,
 	})
 
 	return c, errors.WithStack(err)
@@ -38,10 +36,19 @@ func newGitea(rs *cstypes.RemoteSource, accessToken string) (*gitea.Client, erro
 
 func newGiteaWithBasicAuth(rs *cstypes.RemoteSource, username, password string) (*gitea.Client, error) {
 	c, err := gitea.NewWithBasicAuth(gitea.Opts{
+		APIURL:     rs.APIURL,
+		SkipVerify: rs.SkipVerify,
+		UserName:   username,
+		Password:   password,
+	})
+
+	return c, errors.WithStack(err)
+}
+
+func newGiteaOauth2Client(rs *cstypes.RemoteSource) (*gitea.Oauth2Client, error) {
+	c, err := gitea.NewOauth2Client(gitea.Oauth2Opts{
 		APIURL:         rs.APIURL,
 		SkipVerify:     rs.SkipVerify,
-		UserName:       username,
-		Password:       password,
 		Oauth2ClientID: rs.Oauth2ClientID,
 		Oauth2Secret:   rs.Oauth2ClientSecret,
 	})
@@ -51,9 +58,18 @@ func newGiteaWithBasicAuth(rs *cstypes.RemoteSource, username, password string) 
 
 func newGitlab(rs *cstypes.RemoteSource, accessToken string) (*gitlab.Client, error) {
 	c, err := gitlab.New(gitlab.Opts{
+		APIURL:     rs.APIURL,
+		SkipVerify: rs.SkipVerify,
+		Token:      accessToken,
+	})
+
+	return c, errors.WithStack(err)
+}
+
+func newGitlabOauth2Client(rs *cstypes.RemoteSource) (*gitlab.Oauth2Client, error) {
+	c, err := gitlab.NewOauth2Client(gitlab.Oauth2Opts{
 		APIURL:         rs.APIURL,
 		SkipVerify:     rs.SkipVerify,
-		Token:          accessToken,
 		Oauth2ClientID: rs.Oauth2ClientID,
 		Oauth2Secret:   rs.Oauth2ClientSecret,
 	})
@@ -63,9 +79,18 @@ func newGitlab(rs *cstypes.RemoteSource, accessToken string) (*gitlab.Client, er
 
 func newGithub(rs *cstypes.RemoteSource, accessToken string) (*github.Client, error) {
 	c, err := github.New(github.Opts{
+		APIURL:     rs.APIURL,
+		SkipVerify: rs.SkipVerify,
+		Token:      accessToken,
+	})
+
+	return c, errors.WithStack(err)
+}
+
+func newGithubOauth2Client(rs *cstypes.RemoteSource) (*github.Oauth2Client, error) {
+	c, err := github.NewOauth2Client(github.Oauth2Opts{
 		APIURL:         rs.APIURL,
 		SkipVerify:     rs.SkipVerify,
-		Token:          accessToken,
 		Oauth2ClientID: rs.Oauth2ClientID,
 		Oauth2Secret:   rs.Oauth2ClientSecret,
 	})
@@ -166,4 +191,21 @@ func GetPasswordSource(rs *cstypes.RemoteSource, username, password string) (git
 	}
 
 	return passwordSource, errors.WithStack(err)
+}
+
+func GetOauth2Client(rs *cstypes.RemoteSource) (gitsource.Oauth2Client, error) {
+	var oauth2Client gitsource.Oauth2Client
+	var err error
+	switch rs.Type {
+	case cstypes.RemoteSourceTypeGitea:
+		oauth2Client, err = newGiteaOauth2Client(rs)
+	case cstypes.RemoteSourceTypeGitlab:
+		oauth2Client, err = newGitlabOauth2Client(rs)
+	case cstypes.RemoteSourceTypeGithub:
+		oauth2Client, err = newGithubOauth2Client(rs)
+	default:
+		return nil, errors.Errorf("remote source %s isn't a valid oauth2 source", rs.Name)
+	}
+
+	return oauth2Client, errors.WithStack(err)
 }


### PR DESCRIPTION
Split an oauth2Client from the gitsource. While the gitsource creates a client to the remote source an Oauth2Client doesn't requires a client to the remote sources but only handles the oauth2 flow.

This also fixes an issue with gitea 1.14 (fixed in later gitea versions) where the /version endpoint requires authentication but during the oauth2 flow we don't have any auth data and so we cannot create the gitea client because during gite client creation a call to the version endpoint is done and returns an error.