### PR TITLE
config: add global urls fields

### DIFF
--- a/internal/services/config/config.go
+++ b/internal/services/config/config.go
@@ -43,6 +43,19 @@ type Config struct {
 	Executor     Executor     `yaml:"executor"`
 	Configstore  Configstore  `yaml:"configstore"`
 	Gitserver    Gitserver    `yaml:"gitserver"`
+
+	// Global urls to avoid repeating them for every service
+
+	// APIExposedURL is the gateway API exposed url i.e. https://myagola.example.com
+	APIExposedURL string `yaml:"apiExposedURL"`
+
+	// WebExposedURL is the web interface exposed url i.e. https://myagola.example.com
+	// This is used for generating the redirect_url in oauth2 redirects
+	WebExposedURL string `yaml:"webExposedURL"`
+
+	RunserviceURL  string `yaml:"runserviceURL"`
+	ConfigstoreURL string `yaml:"configstoreURL"`
+	GitserverURL   string `yaml:"gitserverURL"`
 }
 
 type Gateway struct {
@@ -86,7 +99,8 @@ type Notification struct {
 	// This is used for generating the redirect_url in oauth2 redirects
 	WebExposedURL string `yaml:"webExposedURL"`
 
-	RunserviceURL  string `yaml:"runserviceURL"`
+	RunserviceURL string `yaml:"runserviceURL"`
+
 	ConfigstoreURL string `yaml:"configstoreURL"`
 
 	DB DB `yaml:"db"`
@@ -117,7 +131,8 @@ type Executor struct {
 	DataDir string `yaml:"dataDir"`
 
 	RunserviceURL string `yaml:"runserviceURL"`
-	ToolboxPath   string `yaml:"toolboxPath"`
+
+	ToolboxPath string `yaml:"toolboxPath"`
 
 	Web Web `yaml:"web"`
 
@@ -165,7 +180,8 @@ type Configstore struct {
 
 	DB DB `yaml:"db"`
 
-	Web           Web           `yaml:"web"`
+	Web Web `yaml:"web"`
+
 	ObjectStorage ObjectStorage `yaml:"objectStorage"`
 }
 
@@ -174,7 +190,8 @@ type Gitserver struct {
 
 	DataDir string `yaml:"dataDir"`
 
-	Web           Web           `yaml:"web"`
+	Web Web `yaml:"web"`
+
 	ObjectStorage ObjectStorage `yaml:"objectStorage"`
 
 	RepositoryCleanupInterval    time.Duration `yaml:"repositoryCleanupInterval"`
@@ -315,6 +332,41 @@ func Parse(configFile string, componentsNames []string) (*Config, error) {
 	c := defaultConfig()
 	if err := yaml.Unmarshal(configData, &c); err != nil {
 		return nil, errors.WithStack(err)
+	}
+
+	// Use global values if service values are empty
+	if c.Gateway.APIExposedURL == "" {
+		c.Gateway.APIExposedURL = c.APIExposedURL
+	}
+	if c.Gateway.WebExposedURL == "" {
+		c.Gateway.WebExposedURL = c.WebExposedURL
+	}
+	if c.Gateway.RunserviceURL == "" {
+		c.Gateway.RunserviceURL = c.RunserviceURL
+	}
+	if c.Gateway.ConfigstoreURL == "" {
+		c.Gateway.ConfigstoreURL = c.ConfigstoreURL
+	}
+	if c.Gateway.GitserverURL == "" {
+		c.Gateway.GitserverURL = c.GitserverURL
+	}
+
+	if c.Scheduler.RunserviceURL == "" {
+		c.Scheduler.RunserviceURL = c.RunserviceURL
+	}
+
+	if c.Notification.WebExposedURL == "" {
+		c.Notification.WebExposedURL = c.WebExposedURL
+	}
+	if c.Notification.RunserviceURL == "" {
+		c.Notification.RunserviceURL = c.RunserviceURL
+	}
+	if c.Notification.ConfigstoreURL == "" {
+		c.Notification.ConfigstoreURL = c.ConfigstoreURL
+	}
+
+	if c.Executor.RunserviceURL == "" {
+		c.Executor.RunserviceURL = c.RunserviceURL
 	}
 
 	return c, Validate(c, componentsNames)

--- a/internal/services/config/config_test.go
+++ b/internal/services/config/config_test.go
@@ -18,7 +18,9 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/sorintlab/errors"
 )
 
@@ -27,6 +29,7 @@ func TestParseConfig(t *testing.T) {
 		name     string
 		services []string
 		in       string
+		out      *Config
 		err      error
 	}{
 		{
@@ -61,7 +64,7 @@ configstore:
   dataDir: /data/agola/configstore
   db:
     type: sqlite3
-    connString: /opt/data/agola/configstore/db
+    connString: /data/agola/configstore/db
   objectStorage:
     type: posix
     path: /agola/configstore/ost
@@ -70,10 +73,10 @@ configstore:
 
 runservice:
   #debug: true
-  dataDir: /opt/data/agola/runservice
+  dataDir: /data/agola/runservice
   db:
     type: sqlite3
-    connString: /opt/data/agola/runservice/db
+    connString: /data/agola/runservice/db
   objectStorage:
     type: posix
     path: /agola/runservice/ost
@@ -93,9 +96,61 @@ executor:
 
 gitserver:
   dataDir: /data/agola/gitserver
-  gatewayURL: "http://localhost:8000"
   web:
-    listenAddress: ":4003"`,
+    listenAddress: ":4003"
+`,
+			out: &Config{
+				ID: "agola",
+				Gateway: Gateway{
+					APIExposedURL:                "http://localhost:8000",
+					WebExposedURL:                "http://localhost:8000",
+					RunserviceURL:                "http://localhost:4000",
+					ConfigstoreURL:               "http://localhost:4002",
+					GitserverURL:                 "http://localhost:4003",
+					Web:                          Web{ListenAddress: ":8000"},
+					TokenSigning:                 TokenSigning{Duration: 12 * time.Hour, Method: "hmac", Key: "supersecretsigningkey"},
+					CookieSigning:                CookieSigning{Duration: 12 * time.Hour, Key: "supersecretsigningkey"},
+					AdminToken:                   "admintoken",
+					OrganizationMemberAddingMode: defaultOrganizationMemberAddingMode,
+				},
+				Scheduler: Scheduler{RunserviceURL: "http://localhost:4000"},
+				Notification: Notification{
+					WebExposedURL:  "http://localhost:8000",
+					RunserviceURL:  "http://localhost:4000",
+					ConfigstoreURL: "http://localhost:4002",
+				},
+				Runservice: Runservice{
+					DataDir:                    "/data/agola/runservice",
+					DB:                         DB{Type: "sqlite3", ConnString: "/data/agola/runservice/db"},
+					Web:                        Web{ListenAddress: ":4000"},
+					ObjectStorage:              ObjectStorage{Type: "posix", Path: "/agola/runservice/ost"},
+					RunCacheExpireInterval:     7 * 24 * time.Hour,
+					RunWorkspaceExpireInterval: 7 * 24 * time.Hour,
+					RunLogExpireInterval:       30 * 24 * time.Hour,
+				},
+				Executor: Executor{
+					DataDir:                   "/data/agola/executor",
+					RunserviceURL:             "http://localhost:4000",
+					ToolboxPath:               "./bin",
+					Web:                       Web{ListenAddress: ":4001"},
+					Driver:                    Driver{Type: "docker"},
+					InitImage:                 InitImage{Image: "busybox:stable"},
+					ActiveTasksLimit:          5,
+					AllowPrivilegedContainers: true,
+				},
+				Configstore: Configstore{
+					DataDir:       "/data/agola/configstore",
+					DB:            DB{Type: "sqlite3", ConnString: "/data/agola/configstore/db"},
+					Web:           Web{ListenAddress: ":4002"},
+					ObjectStorage: ObjectStorage{Type: "posix", Path: "/agola/configstore/ost"},
+				},
+				Gitserver: Gitserver{
+					DataDir:                      "/data/agola/gitserver",
+					Web:                          Web{ListenAddress: ":4003"},
+					RepositoryCleanupInterval:    24 * time.Hour,
+					RepositoryRefsExpireInterval: 30 * 24 * time.Hour,
+				},
+			},
 		},
 		{
 			name:     "test config for all-base components",
@@ -129,7 +184,7 @@ configstore:
   dataDir: /data/agola/configstore
   db:
     type: sqlite3
-    connString: /opt/data/agola/configstore/db
+    connString: /data/agola/configstore/db
   objectStorage:
     type: posix
     path: /agola/configstore/ost
@@ -140,7 +195,7 @@ runservice:
   dataDir: /data/agola/runservice
   db:
     type: sqlite3
-    connString: /opt/data/agola/runservice/db
+    connString: /data/agola/runservice/db
   objectStorage:
     type: posix
     path: /agola/runservice/ost
@@ -149,9 +204,57 @@ runservice:
 
 gitserver:
   dataDir: /data/agola/gitserver
-  gatewayURL: "http://localhost:8000"
   web:
-    listenAddress: ":4003"`,
+    listenAddress: ":4003"
+    `,
+			out: &Config{
+				ID: "agola",
+				Gateway: Gateway{
+					APIExposedURL:                "http://localhost:8000",
+					WebExposedURL:                "http://localhost:8000",
+					RunserviceURL:                "http://localhost:4000",
+					ConfigstoreURL:               "http://localhost:4002",
+					GitserverURL:                 "http://localhost:4003",
+					Web:                          Web{ListenAddress: ":8000"},
+					TokenSigning:                 TokenSigning{Duration: 12 * time.Hour, Method: "hmac", Key: "supersecretsigningkey"},
+					CookieSigning:                CookieSigning{Duration: 12 * time.Hour, Key: "supersecretsigningkey"},
+					AdminToken:                   "admintoken",
+					OrganizationMemberAddingMode: defaultOrganizationMemberAddingMode,
+				},
+				Scheduler: Scheduler{RunserviceURL: "http://localhost:4000"},
+				Notification: Notification{
+					WebExposedURL:  "http://localhost:8000",
+					RunserviceURL:  "http://localhost:4000",
+					ConfigstoreURL: "http://localhost:4002",
+				},
+				Runservice: Runservice{
+					DataDir:                    "/data/agola/runservice",
+					DB:                         DB{Type: "sqlite3", ConnString: "/data/agola/runservice/db"},
+					Web:                        Web{ListenAddress: ":4000"},
+					ObjectStorage:              ObjectStorage{Type: "posix", Path: "/agola/runservice/ost"},
+					RunCacheExpireInterval:     7 * 24 * time.Hour,
+					RunWorkspaceExpireInterval: 7 * 24 * time.Hour,
+					RunLogExpireInterval:       30 * 24 * time.Hour,
+				},
+				Executor: Executor{
+					InitImage: InitImage{
+						Image: "busybox:stable",
+					},
+					ActiveTasksLimit: 2,
+				},
+				Configstore: Configstore{
+					DataDir:       "/data/agola/configstore",
+					DB:            DB{Type: "sqlite3", ConnString: "/data/agola/configstore/db"},
+					Web:           Web{ListenAddress: ":4002"},
+					ObjectStorage: ObjectStorage{Type: "posix", Path: "/agola/configstore/ost"},
+				},
+				Gitserver: Gitserver{
+					DataDir:                      "/data/agola/gitserver",
+					Web:                          Web{ListenAddress: ":4003"},
+					RepositoryCleanupInterval:    24 * time.Hour,
+					RepositoryRefsExpireInterval: 30 * 24 * time.Hour,
+				},
+			},
 		},
 		{
 			name:     "test config for gateway, scheduler and notification",
@@ -188,7 +291,39 @@ runservice:
   dataDir:
 
 gitserver:
-  dataDir:`,
+  dataDir:
+`,
+			out: &Config{
+				ID: "agola",
+				Gateway: Gateway{
+					APIExposedURL:                "http://localhost:8000",
+					WebExposedURL:                "http://localhost:8000",
+					RunserviceURL:                "http://localhost:4000",
+					ConfigstoreURL:               "http://localhost:4002",
+					GitserverURL:                 "http://localhost:4003",
+					Web:                          Web{ListenAddress: ":8000"},
+					TokenSigning:                 TokenSigning{Duration: 12 * time.Hour, Method: "hmac", Key: "supersecretsigningkey"},
+					CookieSigning:                CookieSigning{Duration: 12 * time.Hour, Key: "supersecretsigningkey"},
+					AdminToken:                   "admintoken",
+					OrganizationMemberAddingMode: defaultOrganizationMemberAddingMode,
+				},
+				Scheduler: Scheduler{RunserviceURL: "http://localhost:4000"},
+				Notification: Notification{
+					WebExposedURL:  "http://localhost:8000",
+					RunserviceURL:  "http://localhost:4000",
+					ConfigstoreURL: "http://localhost:4002",
+				},
+				Runservice: Runservice{
+					RunCacheExpireInterval:     7 * 24 * time.Hour,
+					RunWorkspaceExpireInterval: 7 * 24 * time.Hour,
+					RunLogExpireInterval:       30 * 24 * time.Hour,
+				},
+				Executor: Executor{InitImage: InitImage{Image: "busybox:stable"}, ActiveTasksLimit: 2},
+				Gitserver: Gitserver{
+					RepositoryCleanupInterval:    24 * time.Hour,
+					RepositoryRefsExpireInterval: 30 * 24 * time.Hour,
+				},
+			},
 		},
 		{
 			name:     "test config for gateway, scheduler, notification and gitserver without dataDir",
@@ -225,12 +360,135 @@ runservice:
   dataDir:
 
 gitserver:
-  dataDir:`,
+  dataDir:
+`,
 			err: errors.Errorf("git server dataDir is empty"),
+		},
+
+		{
+			name:     "test config with global urls",
+			services: []string{"all-base", "executor"},
+			in: `
+apiExposedURL: "http://localhost:8000"
+webExposedURL: "http://localhost:8000"
+runserviceURL: "http://localhost:4000"
+configstoreURL: "http://localhost:4002"
+gitserverURL: "http://localhost:4003"
+
+gateway:
+  web:
+    listenAddress: ":8000"
+  tokenSigning:
+    method: hmac
+    key: supersecretsigningkey
+  cookieSigning:
+    key: supersecretsigningkey
+  adminToken: "admintoken"
+
+scheduler:
+
+notification:
+
+configstore:
+  dataDir: /data/agola/configstore
+  db:
+    type: sqlite3
+    connString: /data/agola/configstore/db
+  objectStorage:
+    type: posix
+    path: /agola/configstore/ost
+  web:
+    listenAddress: ":4002"
+
+runservice:
+  #debug: true
+  dataDir: /data/agola/runservice
+  db:
+    type: sqlite3
+    connString: /data/agola/runservice/db
+  objectStorage:
+    type: posix
+    path: /agola/runservice/ost
+  web:
+    listenAddress: ":4000"
+
+executor:
+  allowPrivilegedContainers: true
+  dataDir: /data/agola/executor
+  toolboxPath: ./bin
+  web:
+    listenAddress: ":4001"
+  activeTasksLimit: 5
+  driver:
+    type: docker
+
+gitserver:
+  dataDir: /data/agola/gitserver
+  web:
+    listenAddress: ":4003"
+`,
+			out: &Config{
+				ID:             "agola",
+				APIExposedURL:  "http://localhost:8000",
+				WebExposedURL:  "http://localhost:8000",
+				RunserviceURL:  "http://localhost:4000",
+				ConfigstoreURL: "http://localhost:4002",
+				GitserverURL:   "http://localhost:4003",
+				Gateway: Gateway{
+					APIExposedURL:                "http://localhost:8000",
+					WebExposedURL:                "http://localhost:8000",
+					RunserviceURL:                "http://localhost:4000",
+					ConfigstoreURL:               "http://localhost:4002",
+					GitserverURL:                 "http://localhost:4003",
+					Web:                          Web{ListenAddress: ":8000"},
+					TokenSigning:                 TokenSigning{Duration: 12 * time.Hour, Method: "hmac", Key: "supersecretsigningkey"},
+					CookieSigning:                CookieSigning{Duration: 12 * time.Hour, Key: "supersecretsigningkey"},
+					AdminToken:                   "admintoken",
+					OrganizationMemberAddingMode: defaultOrganizationMemberAddingMode,
+				},
+				Scheduler: Scheduler{RunserviceURL: "http://localhost:4000"},
+				Notification: Notification{
+					WebExposedURL:  "http://localhost:8000",
+					RunserviceURL:  "http://localhost:4000",
+					ConfigstoreURL: "http://localhost:4002",
+				},
+				Runservice: Runservice{
+					DataDir:                    "/data/agola/runservice",
+					DB:                         DB{Type: "sqlite3", ConnString: "/data/agola/runservice/db"},
+					Web:                        Web{ListenAddress: ":4000"},
+					ObjectStorage:              ObjectStorage{Type: "posix", Path: "/agola/runservice/ost"},
+					RunCacheExpireInterval:     7 * 24 * time.Hour,
+					RunWorkspaceExpireInterval: 7 * 24 * time.Hour,
+					RunLogExpireInterval:       30 * 24 * time.Hour,
+				},
+				Executor: Executor{
+					DataDir:                   "/data/agola/executor",
+					RunserviceURL:             "http://localhost:4000",
+					ToolboxPath:               "./bin",
+					Web:                       Web{ListenAddress: ":4001"},
+					Driver:                    Driver{Type: "docker"},
+					InitImage:                 InitImage{Image: "busybox:stable"},
+					ActiveTasksLimit:          5,
+					AllowPrivilegedContainers: true,
+				},
+				Configstore: Configstore{
+					DataDir:       "/data/agola/configstore",
+					DB:            DB{Type: "sqlite3", ConnString: "/data/agola/configstore/db"},
+					Web:           Web{ListenAddress: ":4002"},
+					ObjectStorage: ObjectStorage{Type: "posix", Path: "/agola/configstore/ost"},
+				},
+				Gitserver: Gitserver{
+					DataDir:                      "/data/agola/gitserver",
+					Web:                          Web{ListenAddress: ":4003"},
+					RepositoryCleanupInterval:    24 * time.Hour,
+					RepositoryRefsExpireInterval: 30 * 24 * time.Hour,
+				},
+			},
 		},
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 
@@ -239,7 +497,8 @@ gitserver:
 			if err != nil {
 				t.Fatalf("unexpected err: %v", err)
 			}
-			if _, err := Parse(path.Join(dir, "config.yml"), tt.services); err != nil {
+			c, err := Parse(path.Join(dir, "config.yml"), tt.services)
+			if err != nil {
 				if tt.err == nil {
 					t.Fatalf("got error: %v, expected no error", err)
 				}
@@ -249,6 +508,10 @@ gitserver:
 			} else {
 				if tt.err != nil {
 					t.Fatalf("got nil error, want error: %v", tt.err)
+				}
+
+				if diff := cmp.Diff(tt.out, c); diff != "" {
+					t.Errorf("config mismatch (-want +got):\n%s", diff)
 				}
 			}
 		})


### PR DESCRIPTION
Add global url fields that will be used by all the services (when not defined in the service config)

This avoids repeating them for every service.