### PR TITLE
sqlg: add support for blob/byte array base type

### DIFF
--- a/internal/sqlg/object.go
+++ b/internal/sqlg/object.go
@@ -123,6 +123,8 @@ func (oi ObjectInfo) PopulatePostgres() ObjectInfo {
 				field.SQLType = "timestamptz"
 			case "time.Duration":
 				field.SQLType = "bigint"
+			case "[]byte":
+				field.SQLType = "bytea"
 
 			default:
 				panic(fmt.Errorf("unknown field type: %q", field.BaseType))
@@ -163,6 +165,8 @@ func (oi ObjectInfo) PopulateSqlite3() ObjectInfo {
 				field.SQLType = "timestamp"
 			case "time.Duration":
 				field.SQLType = "bigint"
+			case "[]byte":
+				field.SQLType = "blob"
 
 			default:
 				panic(fmt.Errorf("unknown field type: %q", field.BaseType))


### PR DESCRIPTION
A field can be defined as a byte array by defining the type []byte. This will set the sqlType to "bytea" for postgres and "blob" for sqlite3.