### PR TITLE
cmd: rename gateway client variable.

### DIFF
--- a/cmd/agola/cmd/directrunstart.go
+++ b/cmd/agola/cmd/directrunstart.go
@@ -94,7 +94,7 @@ func parseVariable(variable string) (string, string, error) {
 }
 
 func directRunStart(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	for _, res := range directRunStartOpts.prRefRegexes {
 		if _, err := regexp.Compile(res); err != nil {
@@ -126,7 +126,7 @@ func directRunStart(cmd *cobra.Command, args []string) error {
 		return errors.Errorf(`only one of "--branch", "--tag" or "--ref" can be provided`)
 	}
 
-	user, _, err := gwclient.GetCurrentUser(context.TODO())
+	user, _, err := gwClient.GetCurrentUser(context.TODO())
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -214,7 +214,7 @@ func directRunStart(cmd *cobra.Command, args []string) error {
 		PullRequestRefRegexes: directRunStartOpts.prRefRegexes,
 		Variables:             variables,
 	}
-	if _, err := gwclient.UserCreateRun(context.TODO(), req); err != nil {
+	if _, err := gwClient.UserCreateRun(context.TODO(), req); err != nil {
 		return errors.WithStack(err)
 	}
 

--- a/cmd/agola/cmd/logdelete.go
+++ b/cmd/agola/cmd/logdelete.go
@@ -89,7 +89,7 @@ func logDelete(cmd *cobra.Command, args []string) error {
 		return errors.Errorf("%d is an invalid step number, it must be equal or greater than zero", logDeleteOpts.step)
 	}
 
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	isProject := !flags.Changed("username")
 
@@ -103,9 +103,9 @@ func logDelete(cmd *cobra.Command, args []string) error {
 		var run *gwapitypes.RunResponse
 		var err error
 		if isProject {
-			run, _, err = gwclient.GetProjectRun(context.TODO(), logDeleteOpts.projectRef, logDeleteOpts.runNumber)
+			run, _, err = gwClient.GetProjectRun(context.TODO(), logDeleteOpts.projectRef, logDeleteOpts.runNumber)
 		} else {
-			run, _, err = gwclient.GetUserRun(context.TODO(), logDeleteOpts.username, logDeleteOpts.runNumber)
+			run, _, err = gwClient.GetUserRun(context.TODO(), logDeleteOpts.username, logDeleteOpts.runNumber)
 		}
 		if err != nil {
 			return errors.WithStack(err)
@@ -127,9 +127,9 @@ func logDelete(cmd *cobra.Command, args []string) error {
 
 	var err error
 	if isProject {
-		_, err = gwclient.DeleteProjectLogs(context.TODO(), logDeleteOpts.projectRef, logDeleteOpts.runNumber, taskid, logDeleteOpts.setup, logDeleteOpts.step)
+		_, err = gwClient.DeleteProjectLogs(context.TODO(), logDeleteOpts.projectRef, logDeleteOpts.runNumber, taskid, logDeleteOpts.setup, logDeleteOpts.step)
 	} else {
-		_, err = gwclient.DeleteUserLogs(context.TODO(), logDeleteOpts.username, logDeleteOpts.runNumber, taskid, logDeleteOpts.setup, logDeleteOpts.step)
+		_, err = gwClient.DeleteUserLogs(context.TODO(), logDeleteOpts.username, logDeleteOpts.runNumber, taskid, logDeleteOpts.setup, logDeleteOpts.step)
 	}
 
 	if err != nil {

--- a/cmd/agola/cmd/logget.go
+++ b/cmd/agola/cmd/logget.go
@@ -99,7 +99,7 @@ func logGet(cmd *cobra.Command, args []string) error {
 		return errors.Errorf(`only one of "--follow" or "--output" can be provided`)
 	}
 
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	isProject := !flags.Changed("username")
 
@@ -113,9 +113,9 @@ func logGet(cmd *cobra.Command, args []string) error {
 		var run *gwapitypes.RunResponse
 		var err error
 		if isProject {
-			run, _, err = gwclient.GetProjectRun(context.TODO(), logGetOpts.projectRef, logGetOpts.runNumber)
+			run, _, err = gwClient.GetProjectRun(context.TODO(), logGetOpts.projectRef, logGetOpts.runNumber)
 		} else {
-			run, _, err = gwclient.GetUserRun(context.TODO(), logGetOpts.username, logGetOpts.runNumber)
+			run, _, err = gwClient.GetUserRun(context.TODO(), logGetOpts.username, logGetOpts.runNumber)
 		}
 		if err != nil {
 			return errors.WithStack(err)
@@ -139,9 +139,9 @@ func logGet(cmd *cobra.Command, args []string) error {
 	var resp *http.Response
 	var err error
 	if isProject {
-		resp, err = gwclient.GetProjectLogs(context.TODO(), logGetOpts.projectRef, logGetOpts.runNumber, taskid, logGetOpts.setup, logGetOpts.step, logGetOpts.follow)
+		resp, err = gwClient.GetProjectLogs(context.TODO(), logGetOpts.projectRef, logGetOpts.runNumber, taskid, logGetOpts.setup, logGetOpts.step, logGetOpts.follow)
 	} else {
-		resp, err = gwclient.GetUserLogs(context.TODO(), logGetOpts.username, logGetOpts.runNumber, taskid, logGetOpts.setup, logGetOpts.step, logGetOpts.follow)
+		resp, err = gwClient.GetUserLogs(context.TODO(), logGetOpts.username, logGetOpts.runNumber, taskid, logGetOpts.setup, logGetOpts.step, logGetOpts.follow)
 	}
 	if err != nil {
 		return errors.Wrapf(err, "failed to get log")

--- a/cmd/agola/cmd/orgcreate.go
+++ b/cmd/agola/cmd/orgcreate.go
@@ -56,7 +56,7 @@ func init() {
 }
 
 func orgCreate(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	// TODO(sgotti) make this a custom pflag Value?
 	if !IsValidVisibility(orgCreateOpts.visibility) {
@@ -69,7 +69,7 @@ func orgCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	log.Info().Msgf("creating org")
-	org, _, err := gwclient.CreateOrg(context.TODO(), req)
+	org, _, err := gwClient.CreateOrg(context.TODO(), req)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create org")
 	}

--- a/cmd/agola/cmd/orgdelete.go
+++ b/cmd/agola/cmd/orgdelete.go
@@ -53,10 +53,10 @@ func init() {
 }
 
 func orgDelete(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	log.Info().Msgf("deleting organization %q", orgDeleteOpts.name)
-	if _, err := gwclient.DeleteOrg(context.TODO(), orgDeleteOpts.name); err != nil {
+	if _, err := gwClient.DeleteOrg(context.TODO(), orgDeleteOpts.name); err != nil {
 		return errors.Wrapf(err, "failed to delete organization")
 	}
 

--- a/cmd/agola/cmd/orgmemberadd.go
+++ b/cmd/agola/cmd/orgmemberadd.go
@@ -61,10 +61,10 @@ func init() {
 }
 
 func orgMemberAdd(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	log.Info().Msgf("adding/updating member %q to organization %q with role %q", orgMemberAddOpts.username, orgMemberAddOpts.orgname, orgMemberAddOpts.role)
-	_, _, err := gwclient.AddOrgMember(context.TODO(), orgMemberAddOpts.orgname, orgMemberAddOpts.username, gwapitypes.MemberRole(orgMemberAddOpts.role))
+	_, _, err := gwClient.AddOrgMember(context.TODO(), orgMemberAddOpts.orgname, orgMemberAddOpts.username, gwapitypes.MemberRole(orgMemberAddOpts.role))
 	if err != nil {
 		return errors.Wrapf(err, "failed to add/update organization member")
 	}

--- a/cmd/agola/cmd/orgmemberlist.go
+++ b/cmd/agola/cmd/orgmemberlist.go
@@ -55,9 +55,9 @@ func init() {
 }
 
 func orgMemberList(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
-	orgMembers, _, err := gwclient.GetOrgMembers(context.TODO(), orgMemberListOpts.orgname)
+	orgMembers, _, err := gwClient.GetOrgMembers(context.TODO(), orgMemberListOpts.orgname)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get organization member")
 	}

--- a/cmd/agola/cmd/orgmemberremove.go
+++ b/cmd/agola/cmd/orgmemberremove.go
@@ -58,10 +58,10 @@ func init() {
 }
 
 func orgMemberRemove(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	log.Info().Msgf("removing member %q from organization %q", orgMemberRemoveOpts.username, orgMemberRemoveOpts.orgname)
-	_, err := gwclient.RemoveOrgMember(context.TODO(), orgMemberRemoveOpts.orgname, orgMemberRemoveOpts.username)
+	_, err := gwClient.RemoveOrgMember(context.TODO(), orgMemberRemoveOpts.orgname, orgMemberRemoveOpts.username)
 	if err != nil {
 		return errors.Wrapf(err, "failed to remove organization member")
 	}

--- a/cmd/agola/cmd/projectcreate.go
+++ b/cmd/agola/cmd/projectcreate.go
@@ -85,7 +85,7 @@ func IsValidVisibility(v string) bool {
 }
 
 func projectCreate(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	// TODO(sgotti) make this a custom pflag Value?
 	if !IsValidVisibility(projectCreateOpts.visibility) {
@@ -104,7 +104,7 @@ func projectCreate(cmd *cobra.Command, args []string) error {
 
 	log.Info().Msgf("creating project")
 
-	project, _, err := gwclient.CreateProject(context.TODO(), req)
+	project, _, err := gwClient.CreateProject(context.TODO(), req)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create project")
 	}

--- a/cmd/agola/cmd/projectdelete.go
+++ b/cmd/agola/cmd/projectdelete.go
@@ -53,11 +53,11 @@ func init() {
 }
 
 func projectDelete(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	log.Info().Msgf("deleting project")
 
-	if _, err := gwclient.DeleteProject(context.TODO(), projectDeleteOpts.ref); err != nil {
+	if _, err := gwClient.DeleteProject(context.TODO(), projectDeleteOpts.ref); err != nil {
 		return errors.Wrapf(err, "failed to delete project")
 	}
 

--- a/cmd/agola/cmd/projectgroupcreate.go
+++ b/cmd/agola/cmd/projectgroupcreate.go
@@ -61,7 +61,7 @@ func init() {
 }
 
 func projectGroupCreate(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	// TODO(sgotti) make this a custom pflag Value?
 	if !IsValidVisibility(projectGroupCreateOpts.visibility) {
@@ -76,7 +76,7 @@ func projectGroupCreate(cmd *cobra.Command, args []string) error {
 
 	log.Info().Msgf("creating project group")
 
-	projectGroup, _, err := gwclient.CreateProjectGroup(context.TODO(), req)
+	projectGroup, _, err := gwClient.CreateProjectGroup(context.TODO(), req)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create project group")
 	}

--- a/cmd/agola/cmd/projectgroupdelete.go
+++ b/cmd/agola/cmd/projectgroupdelete.go
@@ -53,11 +53,11 @@ func init() {
 }
 
 func projectGroupDelete(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	log.Info().Msgf("deleting project group")
 
-	if _, err := gwclient.DeleteProjectGroup(context.TODO(), projectGroupDeleteOpts.ref); err != nil {
+	if _, err := gwClient.DeleteProjectGroup(context.TODO(), projectGroupDeleteOpts.ref); err != nil {
 		return errors.Wrapf(err, "failed to delete project group")
 	}
 

--- a/cmd/agola/cmd/projectgroupupdate.go
+++ b/cmd/agola/cmd/projectgroupupdate.go
@@ -61,7 +61,7 @@ func init() {
 }
 
 func projectGroupUpdate(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	req := &gwapitypes.UpdateProjectGroupRequest{}
 
@@ -80,7 +80,7 @@ func projectGroupUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	log.Info().Msgf("updating project group")
-	projectGroup, _, err := gwclient.UpdateProjectGroup(context.TODO(), projectGroupUpdateOpts.ref, req)
+	projectGroup, _, err := gwClient.UpdateProjectGroup(context.TODO(), projectGroupUpdateOpts.ref, req)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update project group")
 	}

--- a/cmd/agola/cmd/projectlist.go
+++ b/cmd/agola/cmd/projectlist.go
@@ -61,9 +61,9 @@ func printProjects(projects []*gwapitypes.ProjectResponse) {
 }
 
 func projectList(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
-	projects, _, err := gwclient.GetProjectGroupProjects(context.TODO(), projectListOpts.parentPath)
+	projects, _, err := gwClient.GetProjectGroupProjects(context.TODO(), projectListOpts.parentPath)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/cmd/agola/cmd/projectreconfig.go
+++ b/cmd/agola/cmd/projectreconfig.go
@@ -53,10 +53,10 @@ func init() {
 }
 
 func projectReconfig(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	log.Info().Msgf("reconfiguring remote project")
-	if _, err := gwclient.ReconfigProject(context.TODO(), projectReconfigOpts.name); err != nil {
+	if _, err := gwClient.ReconfigProject(context.TODO(), projectReconfigOpts.name); err != nil {
 		return errors.Wrapf(err, "failed to reconfigure remote project")
 	}
 	log.Info().Msgf("project reconfigured")

--- a/cmd/agola/cmd/projectsecretcreate.go
+++ b/cmd/agola/cmd/projectsecretcreate.go
@@ -74,7 +74,7 @@ func init() {
 }
 
 func secretCreate(cmd *cobra.Command, ownertype string, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	// "github.com/ghodss/yaml" doesn't provide a streaming decoder
 	var data []byte
@@ -104,14 +104,14 @@ func secretCreate(cmd *cobra.Command, ownertype string, args []string) error {
 	switch ownertype {
 	case "project":
 		log.Info().Msgf("creating project secret")
-		secret, _, err := gwclient.CreateProjectSecret(context.TODO(), secretCreateOpts.parentRef, req)
+		secret, _, err := gwClient.CreateProjectSecret(context.TODO(), secretCreateOpts.parentRef, req)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create project secret")
 		}
 		log.Info().Msgf("project secret %q created, ID: %q", secret.Name, secret.ID)
 	case "projectgroup":
 		log.Info().Msgf("creating project group secret")
-		secret, _, err := gwclient.CreateProjectGroupSecret(context.TODO(), secretCreateOpts.parentRef, req)
+		secret, _, err := gwClient.CreateProjectGroupSecret(context.TODO(), secretCreateOpts.parentRef, req)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create project group secret")
 		}

--- a/cmd/agola/cmd/projectsecretdelete.go
+++ b/cmd/agola/cmd/projectsecretdelete.go
@@ -58,19 +58,19 @@ func init() {
 }
 
 func secretDelete(cmd *cobra.Command, ownertype string, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	switch ownertype {
 	case "project":
 		log.Info().Msgf("deleting project secret")
-		_, err := gwclient.DeleteProjectSecret(context.TODO(), secretDeleteOpts.parentRef, secretDeleteOpts.name)
+		_, err := gwClient.DeleteProjectSecret(context.TODO(), secretDeleteOpts.parentRef, secretDeleteOpts.name)
 		if err != nil {
 			return errors.Wrapf(err, "failed to delete project secret")
 		}
 		log.Info().Msgf("project secret deleted")
 	case "projectgroup":
 		log.Info().Msgf("deleting project group secret")
-		_, err := gwclient.DeleteProjectGroupSecret(context.TODO(), secretDeleteOpts.parentRef, secretDeleteOpts.name)
+		_, err := gwClient.DeleteProjectGroupSecret(context.TODO(), secretDeleteOpts.parentRef, secretDeleteOpts.name)
 		if err != nil {
 			return errors.Wrapf(err, "failed to delete project group secret")
 		}

--- a/cmd/agola/cmd/projectsecretlist.go
+++ b/cmd/agola/cmd/projectsecretlist.go
@@ -70,13 +70,13 @@ func printSecrets(ownertype, description string, tree, removeoverridden bool) er
 	var err error
 	var secrets []*gwapitypes.SecretResponse
 
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	switch ownertype {
 	case "project":
-		secrets, _, err = gwclient.GetProjectSecrets(context.TODO(), secretListOpts.parentRef, tree, removeoverridden)
+		secrets, _, err = gwClient.GetProjectSecrets(context.TODO(), secretListOpts.parentRef, tree, removeoverridden)
 	case "projectgroup":
-		secrets, _, err = gwclient.GetProjectGroupSecrets(context.TODO(), secretListOpts.parentRef, tree, removeoverridden)
+		secrets, _, err = gwClient.GetProjectGroupSecrets(context.TODO(), secretListOpts.parentRef, tree, removeoverridden)
 	}
 	if err != nil {
 		return errors.Wrapf(err, "failed to list %s secrets", ownertype)

--- a/cmd/agola/cmd/projectsecretupdate.go
+++ b/cmd/agola/cmd/projectsecretupdate.go
@@ -76,7 +76,7 @@ func init() {
 }
 
 func secretUpdate(cmd *cobra.Command, ownertype string, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	// "github.com/ghodss/yaml" doesn't provide a streaming decoder
 	var data []byte
@@ -111,14 +111,14 @@ func secretUpdate(cmd *cobra.Command, ownertype string, args []string) error {
 	switch ownertype {
 	case "project":
 		log.Info().Msgf("creating project secret")
-		secret, _, err := gwclient.UpdateProjectSecret(context.TODO(), secretUpdateOpts.parentRef, secretUpdateOpts.name, req)
+		secret, _, err := gwClient.UpdateProjectSecret(context.TODO(), secretUpdateOpts.parentRef, secretUpdateOpts.name, req)
 		if err != nil {
 			return errors.Wrapf(err, "failed to update project secret")
 		}
 		log.Info().Msgf("project secret %q updated, ID: %q", secret.Name, secret.ID)
 	case "projectgroup":
 		log.Info().Msgf("creating project group secret")
-		secret, _, err := gwclient.UpdateProjectGroupSecret(context.TODO(), secretUpdateOpts.parentRef, secretUpdateOpts.name, req)
+		secret, _, err := gwClient.UpdateProjectGroupSecret(context.TODO(), secretUpdateOpts.parentRef, secretUpdateOpts.name, req)
 		if err != nil {
 			return errors.Wrapf(err, "failed to update project group secret")
 		}

--- a/cmd/agola/cmd/projectupdate.go
+++ b/cmd/agola/cmd/projectupdate.go
@@ -63,7 +63,7 @@ func init() {
 }
 
 func projectUpdate(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	req := &gwapitypes.UpdateProjectRequest{}
 
@@ -86,7 +86,7 @@ func projectUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	log.Info().Msgf("updating project")
-	project, _, err := gwclient.UpdateProject(context.TODO(), projectUpdateOpts.ref, req)
+	project, _, err := gwClient.UpdateProject(context.TODO(), projectUpdateOpts.ref, req)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update project")
 	}

--- a/cmd/agola/cmd/projectvariablecreate.go
+++ b/cmd/agola/cmd/projectvariablecreate.go
@@ -97,7 +97,7 @@ type VariableValue struct {
 }
 
 func variableCreate(cmd *cobra.Command, ownertype string, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	// "github.com/ghodss/yaml" doesn't provide a streaming decoder
 	var data []byte
@@ -134,14 +134,14 @@ func variableCreate(cmd *cobra.Command, ownertype string, args []string) error {
 	switch ownertype {
 	case "project":
 		log.Info().Msgf("creating project variable")
-		variable, _, err := gwclient.CreateProjectVariable(context.TODO(), variableCreateOpts.parentRef, req)
+		variable, _, err := gwClient.CreateProjectVariable(context.TODO(), variableCreateOpts.parentRef, req)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create project variable")
 		}
 		log.Info().Msgf("project variable %q created, ID: %q", variable.Name, variable.ID)
 	case "projectgroup":
 		log.Info().Msgf("creating project group variable")
-		variable, _, err := gwclient.CreateProjectGroupVariable(context.TODO(), variableCreateOpts.parentRef, req)
+		variable, _, err := gwClient.CreateProjectGroupVariable(context.TODO(), variableCreateOpts.parentRef, req)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create project group variable")
 		}

--- a/cmd/agola/cmd/projectvariabledelete.go
+++ b/cmd/agola/cmd/projectvariabledelete.go
@@ -58,19 +58,19 @@ func init() {
 }
 
 func variableDelete(cmd *cobra.Command, ownertype string, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	switch ownertype {
 	case "project":
 		log.Info().Msgf("deleting project variable")
-		_, err := gwclient.DeleteProjectVariable(context.TODO(), variableDeleteOpts.parentRef, variableDeleteOpts.name)
+		_, err := gwClient.DeleteProjectVariable(context.TODO(), variableDeleteOpts.parentRef, variableDeleteOpts.name)
 		if err != nil {
 			return errors.Wrapf(err, "failed to delete project variable")
 		}
 		log.Info().Msgf("project variable deleted")
 	case "projectgroup":
 		log.Info().Msgf("deleting project group variable")
-		_, err := gwclient.DeleteProjectGroupVariable(context.TODO(), variableDeleteOpts.parentRef, variableDeleteOpts.name)
+		_, err := gwClient.DeleteProjectGroupVariable(context.TODO(), variableDeleteOpts.parentRef, variableDeleteOpts.name)
 		if err != nil {
 			return errors.Wrapf(err, "failed to delete project group variable")
 		}

--- a/cmd/agola/cmd/projectvariablelist.go
+++ b/cmd/agola/cmd/projectvariablelist.go
@@ -70,13 +70,13 @@ func printVariables(ownertype, description string, tree, removeoverridden bool) 
 	var err error
 	var variables []*gwapitypes.VariableResponse
 
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	switch ownertype {
 	case "project":
-		variables, _, err = gwclient.GetProjectVariables(context.TODO(), variableListOpts.parentRef, tree, removeoverridden)
+		variables, _, err = gwClient.GetProjectVariables(context.TODO(), variableListOpts.parentRef, tree, removeoverridden)
 	case "projectgroup":
-		variables, _, err = gwclient.GetProjectGroupVariables(context.TODO(), variableListOpts.parentRef, tree, removeoverridden)
+		variables, _, err = gwClient.GetProjectGroupVariables(context.TODO(), variableListOpts.parentRef, tree, removeoverridden)
 	}
 	if err != nil {
 		return errors.Wrapf(err, "failed to list %s variables", ownertype)

--- a/cmd/agola/cmd/projectvariableupdate.go
+++ b/cmd/agola/cmd/projectvariableupdate.go
@@ -69,7 +69,7 @@ func init() {
 }
 
 func variableUpdate(cmd *cobra.Command, ownertype string, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	// "github.com/ghodss/yaml" doesn't provide a streaming decoder
 	var data []byte
@@ -111,14 +111,14 @@ func variableUpdate(cmd *cobra.Command, ownertype string, args []string) error {
 	switch ownertype {
 	case "project":
 		log.Info().Msgf("updating project variable")
-		variable, _, err := gwclient.UpdateProjectVariable(context.TODO(), variableUpdateOpts.parentRef, variableUpdateOpts.name, req)
+		variable, _, err := gwClient.UpdateProjectVariable(context.TODO(), variableUpdateOpts.parentRef, variableUpdateOpts.name, req)
 		if err != nil {
 			return errors.Wrapf(err, "failed to update project variable")
 		}
 		log.Info().Msgf("project variable %q updated, ID: %q", variable.Name, variable.ID)
 	case "projectgroup":
 		log.Info().Msgf("updating project group variable")
-		variable, _, err := gwclient.UpdateProjectGroupVariable(context.TODO(), variableUpdateOpts.parentRef, variableUpdateOpts.name, req)
+		variable, _, err := gwClient.UpdateProjectGroupVariable(context.TODO(), variableUpdateOpts.parentRef, variableUpdateOpts.name, req)
 		if err != nil {
 			return errors.Wrapf(err, "failed to update project group variable")
 		}

--- a/cmd/agola/cmd/remotesourcecreate.go
+++ b/cmd/agola/cmd/remotesourcecreate.go
@@ -82,7 +82,7 @@ func init() {
 }
 
 func remoteSourceCreate(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	flags := cmd.Flags()
 
@@ -115,7 +115,7 @@ func remoteSourceCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	log.Info().Msgf("creating remotesource")
-	remoteSource, _, err := gwclient.CreateRemoteSource(context.TODO(), req)
+	remoteSource, _, err := gwClient.CreateRemoteSource(context.TODO(), req)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create remotesource")
 	}

--- a/cmd/agola/cmd/remotesourcelist.go
+++ b/cmd/agola/cmd/remotesourcelist.go
@@ -59,9 +59,9 @@ func printRemoteSources(remoteSources []*gwapitypes.RemoteSourceResponse) {
 }
 
 func remoteSourceList(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
-	remouteSources, _, err := gwclient.GetRemoteSources(context.TODO(), remoteSourceListOpts.start, remoteSourceListOpts.limit, false)
+	remouteSources, _, err := gwClient.GetRemoteSources(context.TODO(), remoteSourceListOpts.start, remoteSourceListOpts.limit, false)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/cmd/agola/cmd/remotesourceupdate.go
+++ b/cmd/agola/cmd/remotesourceupdate.go
@@ -73,7 +73,7 @@ func init() {
 }
 
 func remoteSourceUpdate(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	req := &gwapitypes.UpdateRemoteSourceRequest{}
 
@@ -107,7 +107,7 @@ func remoteSourceUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	log.Info().Msgf("updating remotesource")
-	remoteSource, _, err := gwclient.UpdateRemoteSource(context.TODO(), remoteSourceUpdateOpts.ref, req)
+	remoteSource, _, err := gwClient.UpdateRemoteSource(context.TODO(), remoteSourceUpdateOpts.ref, req)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update remotesource")
 	}

--- a/cmd/agola/cmd/runcreate.go
+++ b/cmd/agola/cmd/runcreate.go
@@ -62,7 +62,7 @@ func init() {
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	set := 0
 	flags := cmd.Flags()
@@ -86,7 +86,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		CommitSHA: runCreateOpts.commitSHA,
 	}
 
-	_, err := gwclient.ProjectCreateRun(context.TODO(), runCreateOpts.projectRef, req)
+	_, err := gwClient.ProjectCreateRun(context.TODO(), runCreateOpts.projectRef, req)
 
 	return errors.WithStack(err)
 }

--- a/cmd/agola/cmd/runlist.go
+++ b/cmd/agola/cmd/runlist.go
@@ -101,16 +101,16 @@ func runList(cmd *cobra.Command, args []string) error {
 		return errors.Errorf(`one of "--username" or "--project" must be provided`)
 	}
 
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	isProject := !flags.Changed("username")
 
 	var runsResp []*gwapitypes.RunsResponse
 	var err error
 	if isProject {
-		runsResp, _, err = gwclient.GetProjectRuns(context.TODO(), runListOpts.projectRef, runListOpts.phaseFilter, nil, runListOpts.start, runListOpts.limit, false)
+		runsResp, _, err = gwClient.GetProjectRuns(context.TODO(), runListOpts.projectRef, runListOpts.phaseFilter, nil, runListOpts.start, runListOpts.limit, false)
 	} else {
-		runsResp, _, err = gwclient.GetUserRuns(context.TODO(), runListOpts.username, runListOpts.phaseFilter, nil, runListOpts.start, runListOpts.limit, false)
+		runsResp, _, err = gwClient.GetUserRuns(context.TODO(), runListOpts.username, runListOpts.phaseFilter, nil, runListOpts.start, runListOpts.limit, false)
 	}
 	if err != nil {
 		return errors.WithStack(err)
@@ -121,9 +121,9 @@ func runList(cmd *cobra.Command, args []string) error {
 		var err error
 		var run *gwapitypes.RunResponse
 		if isProject {
-			run, _, err = gwclient.GetProjectRun(context.TODO(), runListOpts.projectRef, runResponse.Number)
+			run, _, err = gwClient.GetProjectRun(context.TODO(), runListOpts.projectRef, runResponse.Number)
 		} else {
-			run, _, err = gwclient.GetUserRun(context.TODO(), runListOpts.username, runResponse.Number)
+			run, _, err = gwClient.GetUserRun(context.TODO(), runListOpts.username, runResponse.Number)
 		}
 		if err != nil {
 			return errors.WithStack(err)
@@ -133,9 +133,9 @@ func runList(cmd *cobra.Command, args []string) error {
 		for _, task := range run.Tasks {
 			var runTaskResponse *gwapitypes.RunTaskResponse
 			if isProject {
-				runTaskResponse, _, err = gwclient.GetProjectRunTask(context.TODO(), runListOpts.projectRef, run.Number, task.ID)
+				runTaskResponse, _, err = gwClient.GetProjectRunTask(context.TODO(), runListOpts.projectRef, run.Number, task.ID)
 			} else {
-				runTaskResponse, _, err = gwclient.GetUserRunTask(context.TODO(), runListOpts.username, run.Number, task.ID)
+				runTaskResponse, _, err = gwClient.GetUserRunTask(context.TODO(), runListOpts.username, run.Number, task.ID)
 			}
 			t := &taskDetails{
 				name:            task.Name,

--- a/cmd/agola/cmd/usercreate.go
+++ b/cmd/agola/cmd/usercreate.go
@@ -54,14 +54,14 @@ func init() {
 }
 
 func userCreate(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	req := &gwapitypes.CreateUserRequest{
 		UserName: userCreateOpts.username,
 	}
 
 	log.Info().Msgf("creating user")
-	user, _, err := gwclient.CreateUser(context.TODO(), req)
+	user, _, err := gwClient.CreateUser(context.TODO(), req)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create user")
 	}

--- a/cmd/agola/cmd/userdelete.go
+++ b/cmd/agola/cmd/userdelete.go
@@ -53,10 +53,10 @@ func init() {
 }
 
 func userDelete(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	log.Info().Msgf("deleting user %q", userDeleteOpts.username)
-	if _, err := gwclient.DeleteUser(context.TODO(), userDeleteOpts.username); err != nil {
+	if _, err := gwClient.DeleteUser(context.TODO(), userDeleteOpts.username); err != nil {
 		return errors.Wrapf(err, "failed to delete user")
 	}
 

--- a/cmd/agola/cmd/userlacreate.go
+++ b/cmd/agola/cmd/userlacreate.go
@@ -63,7 +63,7 @@ func init() {
 }
 
 func userLACreate(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	req := &gwapitypes.CreateUserLARequest{
 		RemoteSourceName:          userLACreateOpts.remoteSourceName,
@@ -72,7 +72,7 @@ func userLACreate(cmd *cobra.Command, args []string) error {
 	}
 
 	log.Info().Msgf("creating linked account for user %q", userLACreateOpts.username)
-	resp, _, err := gwclient.CreateUserLA(context.TODO(), userLACreateOpts.username, req)
+	resp, _, err := gwClient.CreateUserLA(context.TODO(), userLACreateOpts.username, req)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create linked account")
 	}

--- a/cmd/agola/cmd/userladelete.go
+++ b/cmd/agola/cmd/userladelete.go
@@ -58,13 +58,13 @@ func init() {
 }
 
 func userLADelete(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	userName := userLADeleteOpts.userName
 	laID := userLADeleteOpts.laID
 
 	log.Info().Msgf("deleting linked account %q for user %q", laID, userName)
-	_, err := gwclient.DeleteUserLA(context.TODO(), userName, laID)
+	_, err := gwClient.DeleteUserLA(context.TODO(), userName, laID)
 	if err != nil {
 		return errors.Wrapf(err, "failed to delete linked account")
 	}

--- a/cmd/agola/cmd/userlist.go
+++ b/cmd/agola/cmd/userlist.go
@@ -59,9 +59,9 @@ func printUsers(users []*gwapitypes.PrivateUserResponse) {
 }
 
 func userList(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
-	users, _, err := gwclient.GetUsers(context.TODO(), userListOpts.start, userListOpts.limit, false)
+	users, _, err := gwClient.GetUsers(context.TODO(), userListOpts.start, userListOpts.limit, false)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/cmd/agola/cmd/usertokencreate.go
+++ b/cmd/agola/cmd/usertokencreate.go
@@ -60,14 +60,14 @@ func init() {
 }
 
 func userTokenCreate(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	req := &gwapitypes.CreateUserTokenRequest{
 		TokenName: userTokenCreateOpts.tokenName,
 	}
 
 	log.Info().Msgf("creating token for user %q", userTokenCreateOpts.username)
-	resp, _, err := gwclient.CreateUserToken(context.TODO(), userTokenCreateOpts.username, req)
+	resp, _, err := gwClient.CreateUserToken(context.TODO(), userTokenCreateOpts.username, req)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create token")
 	}

--- a/cmd/agola/cmd/usertokendelete.go
+++ b/cmd/agola/cmd/usertokendelete.go
@@ -58,13 +58,13 @@ func init() {
 }
 
 func userTokenDelete(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
 	userName := userTokenDeleteOpts.userName
 	tokenName := userTokenDeleteOpts.tokenName
 
 	log.Info().Msgf("deleting token %q for user %q", tokenName, userName)
-	_, err := gwclient.DeleteUserToken(context.TODO(), userName, tokenName)
+	_, err := gwClient.DeleteUserToken(context.TODO(), userName, tokenName)
 	if err != nil {
 		return errors.Wrapf(err, "failed to delete user token")
 	}

--- a/cmd/agola/cmd/version.go
+++ b/cmd/agola/cmd/version.go
@@ -40,9 +40,9 @@ func init() {
 }
 
 func printVersions(cmd *cobra.Command, args []string) error {
-	gwclient := gwclient.NewClient(gatewayURL, token)
+	gwClient := gwclient.NewClient(gatewayURL, token)
 
-	gwversion, _, err := gwclient.GetVersion(context.TODO())
+	gwversion, _, err := gwClient.GetVersion(context.TODO())
 	if err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
Avoid using the same name "gwclient" for both the variable and the package name.