### PR TITLE
*: cursor based list api.

### DIFF
--- a/cmd/agola/cmd/logget.go
+++ b/cmd/agola/cmd/logget.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"context"
 	"io"
-	"net/http"
 	"os"
 
 	"github.com/rs/zerolog/log"
@@ -136,7 +135,7 @@ func logGet(cmd *cobra.Command, args []string) error {
 
 	log.Info().Msgf("getting log")
 
-	var resp *http.Response
+	var resp *gwclient.Response
 	var err error
 	if isProject {
 		resp, err = gwClient.GetProjectLogs(context.TODO(), logGetOpts.projectRef, logGetOpts.runNumber, taskid, logGetOpts.setup, logGetOpts.step, logGetOpts.follow)

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/securecookie v1.1.1
 	github.com/hashicorp/go-sockaddr v1.0.2
-	github.com/huandu/go-sqlbuilder v1.21.0
+	github.com/huandu/go-sqlbuilder v1.22.0
 	github.com/huandu/xstrings v1.4.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/lib/pq v1.10.7

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,8 @@ github.com/huandu/go-assert v1.1.5 h1:fjemmA7sSfYHJD7CUqs9qTwwfdNAx7/j2/ZlHXzNB3
 github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0JrPVhn/06U=
 github.com/huandu/go-sqlbuilder v1.21.0 h1:+NLH8PQg5/WGMXJLIpAXTdoH1pv9Q3BU6w4P7OabBmc=
 github.com/huandu/go-sqlbuilder v1.21.0/go.mod h1:nUVmMitjOmn/zacMLXT0d3Yd3RHoO2K+vy906JzqxMI=
+github.com/huandu/go-sqlbuilder v1.22.0 h1:69SpvXvhAoeb7y5uERUCB0/Ck09DwQ6ccYovejm1zHA=
+github.com/huandu/go-sqlbuilder v1.22.0/go.mod h1:nUVmMitjOmn/zacMLXT0d3Yd3RHoO2K+vy906JzqxMI=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=

--- a/internal/services/gateway/action/action.go
+++ b/internal/services/gateway/action/action.go
@@ -22,6 +22,13 @@ import (
 	rsclient "agola.io/agola/services/runservice/client"
 )
 
+type SortDirection string
+
+const (
+	SortDirectionAsc  SortDirection = "asc"
+	SortDirectionDesc SortDirection = "desc"
+)
+
 type ActionHandler struct {
 	log                          zerolog.Logger
 	sd                           *scommon.TokenSigningData

--- a/internal/services/gateway/action/auth.go
+++ b/internal/services/gateway/action/auth.go
@@ -228,7 +228,7 @@ func (h *ActionHandler) IsOrgMember(ctx context.Context, userRef, orgRef string)
 		return false, errors.Wrapf(err, "failed to get user %s:", userRef)
 	}
 
-	orgMembers, err := h.GetOrgMembers(ctx, orgRef)
+	orgMembers, err := h.GetOrgMembers(ctx, &GetOrgMembersRequest{OrgRef: orgRef})
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to get org %s members:", orgRef)
 	}

--- a/internal/services/gateway/action/cursor.go
+++ b/internal/services/gateway/action/cursor.go
@@ -1,0 +1,38 @@
+package action
+
+import (
+	"encoding/base64"
+	"encoding/json"
+
+	"github.com/sorintlab/errors"
+
+	util "agola.io/agola/internal/util"
+)
+
+func MarshalCursor(c any) (string, error) {
+	cj, err := json.Marshal(c)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	return base64.StdEncoding.EncodeToString(cj), nil
+}
+
+func UnmarshalCursor(cs string, c any) error {
+	cj, err := base64.StdEncoding.DecodeString(cs)
+	if err != nil {
+		return util.NewAPIError(util.ErrBadRequest, err)
+	}
+
+	if err := json.Unmarshal(cj, c); err != nil {
+		return util.NewAPIError(util.ErrBadRequest, err)
+	}
+
+	return nil
+}
+
+type StartCursor struct {
+	Start string
+
+	SortDirection SortDirection
+}

--- a/internal/services/gateway/action/maintenance.go
+++ b/internal/services/gateway/action/maintenance.go
@@ -23,6 +23,8 @@ import (
 
 	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
+	csclient "agola.io/agola/services/configstore/client"
+	rsclient "agola.io/agola/services/runservice/client"
 )
 
 const (
@@ -95,12 +97,16 @@ func (h *ActionHandler) Export(ctx context.Context, serviceName string) (*http.R
 	}
 
 	var err error
-	var resp *http.Response
+	var res *http.Response
 	switch serviceName {
 	case ConfigstoreService:
+		var resp *csclient.Response
 		resp, err = h.configstoreClient.Export(ctx)
+		res = resp.Response
 	case RunserviceService:
+		var resp *rsclient.Response
 		resp, err = h.runserviceClient.Export(ctx)
+		res = resp.Response
 	default:
 		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid service name %q", serviceName))
 	}
@@ -108,7 +114,7 @@ func (h *ActionHandler) Export(ctx context.Context, serviceName string) (*http.R
 		return nil, errors.WithStack(err)
 	}
 
-	return resp, nil
+	return res, nil
 }
 
 func (h *ActionHandler) Import(ctx context.Context, r io.Reader, serviceName string) error {

--- a/internal/services/gateway/action/run.go
+++ b/internal/services/gateway/action/run.go
@@ -154,7 +154,7 @@ func (h *ActionHandler) GetLogs(ctx context.Context, req *GetLogsRequest) (*http
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
 	}
 
-	return resp, nil
+	return resp.Response, nil
 }
 
 type DeleteLogsRequest struct {

--- a/internal/services/gateway/api/api.go
+++ b/internal/services/gateway/api/api.go
@@ -17,12 +17,23 @@ package api
 import (
 	"net/http"
 	"net/url"
+	"strconv"
 
 	"github.com/gorilla/mux"
 	"github.com/sorintlab/errors"
 
 	util "agola.io/agola/internal/util"
 	cstypes "agola.io/agola/services/configstore/types"
+	gwapitypes "agola.io/agola/services/gateway/api/types"
+)
+
+const (
+	DefaultLimit = 30
+	MaxLimit     = 30
+)
+
+const (
+	agolaCursorHeader = "X-Agola-Cursor"
 )
 
 func GetConfigTypeRef(r *http.Request) (cstypes.ObjectKind, string, error) {
@@ -44,4 +55,58 @@ func GetConfigTypeRef(r *http.Request) (cstypes.ObjectKind, string, error) {
 	}
 
 	return "", "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot get project or projectgroup ref"))
+}
+
+type requestOptions struct {
+	Cursor string
+
+	Limit         int
+	SortDirection gwapitypes.SortDirection
+}
+
+func parseRequestOptions(r *http.Request) (*requestOptions, error) {
+	query := r.URL.Query()
+
+	cursor := query.Get("cursor")
+
+	limit := DefaultLimit
+	limitS := query.Get("limit")
+	if limitS != "" {
+		var err error
+		limit, err = strconv.Atoi(limitS)
+		if err != nil {
+			return nil, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse limit"))
+		}
+	}
+	if limit < 0 {
+		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("limit must be greater or equal than 0"))
+	}
+	if limit > MaxLimit {
+		limit = MaxLimit
+	}
+
+	sortDirection := gwapitypes.SortDirection(query.Get("sortdirection"))
+	if sortDirection != "" {
+		switch sortDirection {
+		case gwapitypes.SortDirectionAsc:
+		case gwapitypes.SortDirectionDesc:
+		default:
+			return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("wrong sort direction %q", sortDirection))
+		}
+	}
+
+	if cursor != "" && sortDirection != "" {
+		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("only one of cursor or sortdirection should be provided"))
+	}
+
+	return &requestOptions{
+		Cursor: cursor,
+
+		Limit:         limit,
+		SortDirection: sortDirection,
+	}, nil
+}
+
+func addCursorHeader(w http.ResponseWriter, cursor string) {
+	w.Header().Add(agolaCursorHeader, cursor)
 }

--- a/internal/services/gateway/gateway.go
+++ b/internal/services/gateway/gateway.go
@@ -152,9 +152,9 @@ func (g *Gateway) Run(ctx context.Context) error {
 
 	if len(g.c.Web.AllowedOrigins) > 0 {
 		corsAllowedMethodsOptions := ghandlers.AllowedMethods([]string{"GET", "HEAD", "POST", "PUT", "DELETE"})
-		corsAllowedHeadersOptions := ghandlers.AllowedHeaders([]string{"Accept", "Accept-Encoding", "Content-Length", "Content-Type", "Content-Range", "X-Csrf-Token", "Authorization"})
+		corsAllowedHeadersOptions := ghandlers.AllowedHeaders([]string{"Accept", "Accept-Encoding", "Content-Length", "Content-Type", "Content-Range", "X-Csrf-Token", "X-Agola-Cursor", "Authorization"})
 		corsAllowedOriginsOptions := ghandlers.AllowedOrigins(g.c.Web.AllowedOrigins)
-		corsExposeHeadersOptions := ghandlers.ExposedHeaders([]string{"X-Csrf-Token"})
+		corsExposeHeadersOptions := ghandlers.ExposedHeaders([]string{"X-Csrf-Token", "X-Agola-Cursor"})
 		corsHandler = ghandlers.CORS(corsAllowedMethodsOptions, corsAllowedHeadersOptions, corsAllowedOriginsOptions, corsExposeHeadersOptions, ghandlers.AllowCredentials())
 	}
 

--- a/services/configstore/client/client.go
+++ b/services/configstore/client/client.go
@@ -628,9 +628,26 @@ func (c *Client) GetOrg(ctx context.Context, orgRef string) (*cstypes.Organizati
 	return org, resp, errors.WithStack(err)
 }
 
-func (c *Client) GetOrgMembers(ctx context.Context, orgRef string) ([]*csapitypes.OrgMemberResponse, *Response, error) {
+type GetOrgMembersOptions struct {
+	*ListOptions
+
+	StartUserName string
+}
+
+func (o *GetOrgMembersOptions) Add(q url.Values) {
+	o.ListOptions.Add(q)
+
+	if o.StartUserName != "" {
+		q.Add("startusername", o.StartUserName)
+	}
+}
+
+func (c *Client) GetOrgMembers(ctx context.Context, orgRef string, opts *GetOrgMembersOptions) ([]*csapitypes.OrgMemberResponse, *Response, error) {
+	q := url.Values{}
+	opts.Add(q)
+
 	orgMembers := []*csapitypes.OrgMemberResponse{}
-	resp, err := c.GetParsedResponse(ctx, "GET", fmt.Sprintf("/orgs/%s/members", orgRef), nil, common.JSONContent, nil, &orgMembers)
+	resp, err := c.GetParsedResponse(ctx, "GET", fmt.Sprintf("/orgs/%s/members", orgRef), q, common.JSONContent, nil, &orgMembers)
 	return orgMembers, resp, errors.WithStack(err)
 }
 

--- a/services/configstore/client/client.go
+++ b/services/configstore/client/client.go
@@ -26,10 +26,15 @@ import (
 
 	"github.com/sorintlab/errors"
 
+	"agola.io/agola/internal/util"
 	"agola.io/agola/services/common"
 	csapitypes "agola.io/agola/services/configstore/api/types"
 	cstypes "agola.io/agola/services/configstore/types"
 )
+
+type Response struct {
+	*http.Response
+}
 
 type Client struct {
 	*common.Client
@@ -41,25 +46,52 @@ func NewClient(url, token string) *Client {
 	return &Client{c}
 }
 
-func (c *Client) GetProjectGroup(ctx context.Context, projectGroupRef string) (*csapitypes.ProjectGroup, *http.Response, error) {
+func (c *Client) GetResponse(ctx context.Context, method, path string, query url.Values, contentLength int64, header http.Header, ibody io.Reader) (*Response, error) {
+	cresp, err := c.Client.DoRequest(ctx, method, path, query, contentLength, header, ibody)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	resp := &Response{Response: cresp}
+
+	if err := util.ErrFromRemote(resp.Response); err != nil {
+		return resp, errors.WithStack(err)
+	}
+
+	return resp, nil
+}
+
+func (c *Client) GetParsedResponse(ctx context.Context, method, path string, query url.Values, header http.Header, ibody io.Reader, obj interface{}) (*Response, error) {
+	resp, err := c.GetResponse(ctx, method, path, query, -1, header, ibody)
+	if err != nil {
+		return resp, errors.WithStack(err)
+	}
+	defer resp.Body.Close()
+
+	d := json.NewDecoder(resp.Body)
+
+	return resp, errors.WithStack(d.Decode(obj))
+}
+
+func (c *Client) GetProjectGroup(ctx context.Context, projectGroupRef string) (*csapitypes.ProjectGroup, *Response, error) {
 	projectGroup := new(csapitypes.ProjectGroup)
 	resp, err := c.GetParsedResponse(ctx, "GET", fmt.Sprintf("/projectgroups/%s", url.PathEscape(projectGroupRef)), nil, common.JSONContent, nil, projectGroup)
 	return projectGroup, resp, errors.WithStack(err)
 }
 
-func (c *Client) GetProjectGroupSubgroups(ctx context.Context, projectGroupRef string) ([]*csapitypes.ProjectGroup, *http.Response, error) {
+func (c *Client) GetProjectGroupSubgroups(ctx context.Context, projectGroupRef string) ([]*csapitypes.ProjectGroup, *Response, error) {
 	projectGroups := []*csapitypes.ProjectGroup{}
 	resp, err := c.GetParsedResponse(ctx, "GET", fmt.Sprintf("/projectgroups/%s/subgroups", url.PathEscape(projectGroupRef)), nil, common.JSONContent, nil, &projectGroups)
 	return projectGroups, resp, errors.WithStack(err)
 }
 
-func (c *Client) GetProjectGroupProjects(ctx context.Context, projectGroupRef string) ([]*csapitypes.Project, *http.Response, error) {
+func (c *Client) GetProjectGroupProjects(ctx context.Context, projectGroupRef string) ([]*csapitypes.Project, *Response, error) {
 	projects := []*csapitypes.Project{}
 	resp, err := c.GetParsedResponse(ctx, "GET", fmt.Sprintf("/projectgroups/%s/projects", url.PathEscape(projectGroupRef)), nil, common.JSONContent, nil, &projects)
 	return projects, resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateProjectGroup(ctx context.Context, req *csapitypes.CreateUpdateProjectGroupRequest) (*csapitypes.ProjectGroup, *http.Response, error) {
+func (c *Client) CreateProjectGroup(ctx context.Context, req *csapitypes.CreateUpdateProjectGroupRequest) (*csapitypes.ProjectGroup, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -70,7 +102,7 @@ func (c *Client) CreateProjectGroup(ctx context.Context, req *csapitypes.CreateU
 	return resProjectGroup, resp, errors.WithStack(err)
 }
 
-func (c *Client) UpdateProjectGroup(ctx context.Context, projectGroupRef string, req *csapitypes.CreateUpdateProjectGroupRequest) (*csapitypes.ProjectGroup, *http.Response, error) {
+func (c *Client) UpdateProjectGroup(ctx context.Context, projectGroupRef string, req *csapitypes.CreateUpdateProjectGroupRequest) (*csapitypes.ProjectGroup, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -81,18 +113,18 @@ func (c *Client) UpdateProjectGroup(ctx context.Context, projectGroupRef string,
 	return resProjectGroup, resp, errors.WithStack(err)
 }
 
-func (c *Client) DeleteProjectGroup(ctx context.Context, projectGroupRef string) (*http.Response, error) {
+func (c *Client) DeleteProjectGroup(ctx context.Context, projectGroupRef string) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "DELETE", fmt.Sprintf("/projectgroups/%s", url.PathEscape(projectGroupRef)), nil, -1, common.JSONContent, nil)
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) GetProject(ctx context.Context, projectRef string) (*csapitypes.Project, *http.Response, error) {
+func (c *Client) GetProject(ctx context.Context, projectRef string) (*csapitypes.Project, *Response, error) {
 	project := new(csapitypes.Project)
 	resp, err := c.GetParsedResponse(ctx, "GET", fmt.Sprintf("/projects/%s", url.PathEscape(projectRef)), nil, common.JSONContent, nil, project)
 	return project, resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateProject(ctx context.Context, req *csapitypes.CreateUpdateProjectRequest) (*csapitypes.Project, *http.Response, error) {
+func (c *Client) CreateProject(ctx context.Context, req *csapitypes.CreateUpdateProjectRequest) (*csapitypes.Project, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -103,7 +135,7 @@ func (c *Client) CreateProject(ctx context.Context, req *csapitypes.CreateUpdate
 	return resProject, resp, errors.WithStack(err)
 }
 
-func (c *Client) UpdateProject(ctx context.Context, projectRef string, req *csapitypes.CreateUpdateProjectRequest) (*csapitypes.Project, *http.Response, error) {
+func (c *Client) UpdateProject(ctx context.Context, projectRef string, req *csapitypes.CreateUpdateProjectRequest) (*csapitypes.Project, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -114,12 +146,12 @@ func (c *Client) UpdateProject(ctx context.Context, projectRef string, req *csap
 	return resProject, resp, errors.WithStack(err)
 }
 
-func (c *Client) DeleteProject(ctx context.Context, projectRef string) (*http.Response, error) {
+func (c *Client) DeleteProject(ctx context.Context, projectRef string) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "DELETE", fmt.Sprintf("/projects/%s", url.PathEscape(projectRef)), nil, -1, common.JSONContent, nil)
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) GetProjectGroupSecrets(ctx context.Context, projectGroupRef string, tree bool) ([]*csapitypes.Secret, *http.Response, error) {
+func (c *Client) GetProjectGroupSecrets(ctx context.Context, projectGroupRef string, tree bool) ([]*csapitypes.Secret, *Response, error) {
 	q := url.Values{}
 	if tree {
 		q.Add("tree", "")
@@ -130,7 +162,7 @@ func (c *Client) GetProjectGroupSecrets(ctx context.Context, projectGroupRef str
 	return secrets, resp, errors.WithStack(err)
 }
 
-func (c *Client) GetProjectSecrets(ctx context.Context, projectRef string, tree bool) ([]*csapitypes.Secret, *http.Response, error) {
+func (c *Client) GetProjectSecrets(ctx context.Context, projectRef string, tree bool) ([]*csapitypes.Secret, *Response, error) {
 	q := url.Values{}
 	if tree {
 		q.Add("tree", "")
@@ -141,7 +173,7 @@ func (c *Client) GetProjectSecrets(ctx context.Context, projectRef string, tree 
 	return secrets, resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateProjectGroupSecret(ctx context.Context, projectGroupRef string, req *csapitypes.CreateUpdateSecretRequest) (*csapitypes.Secret, *http.Response, error) {
+func (c *Client) CreateProjectGroupSecret(ctx context.Context, projectGroupRef string, req *csapitypes.CreateUpdateSecretRequest) (*csapitypes.Secret, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -152,7 +184,7 @@ func (c *Client) CreateProjectGroupSecret(ctx context.Context, projectGroupRef s
 	return resSecret, resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateProjectSecret(ctx context.Context, projectRef string, req *csapitypes.CreateUpdateSecretRequest) (*csapitypes.Secret, *http.Response, error) {
+func (c *Client) CreateProjectSecret(ctx context.Context, projectRef string, req *csapitypes.CreateUpdateSecretRequest) (*csapitypes.Secret, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -163,7 +195,7 @@ func (c *Client) CreateProjectSecret(ctx context.Context, projectRef string, req
 	return resSecret, resp, errors.WithStack(err)
 }
 
-func (c *Client) UpdateProjectGroupSecret(ctx context.Context, projectGroupRef, secretName string, req *csapitypes.CreateUpdateSecretRequest) (*csapitypes.Secret, *http.Response, error) {
+func (c *Client) UpdateProjectGroupSecret(ctx context.Context, projectGroupRef, secretName string, req *csapitypes.CreateUpdateSecretRequest) (*csapitypes.Secret, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -174,7 +206,7 @@ func (c *Client) UpdateProjectGroupSecret(ctx context.Context, projectGroupRef, 
 	return resSecret, resp, errors.WithStack(err)
 }
 
-func (c *Client) UpdateProjectSecret(ctx context.Context, projectRef, secretName string, req *csapitypes.CreateUpdateSecretRequest) (*csapitypes.Secret, *http.Response, error) {
+func (c *Client) UpdateProjectSecret(ctx context.Context, projectRef, secretName string, req *csapitypes.CreateUpdateSecretRequest) (*csapitypes.Secret, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -185,17 +217,17 @@ func (c *Client) UpdateProjectSecret(ctx context.Context, projectRef, secretName
 	return resSecret, resp, errors.WithStack(err)
 }
 
-func (c *Client) DeleteProjectGroupSecret(ctx context.Context, projectGroupRef, secretName string) (*http.Response, error) {
+func (c *Client) DeleteProjectGroupSecret(ctx context.Context, projectGroupRef, secretName string) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "DELETE", fmt.Sprintf("/projectgroups/%s/secrets/%s", url.PathEscape(projectGroupRef), secretName), nil, -1, common.JSONContent, nil)
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) DeleteProjectSecret(ctx context.Context, projectRef, secretName string) (*http.Response, error) {
+func (c *Client) DeleteProjectSecret(ctx context.Context, projectRef, secretName string) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "DELETE", fmt.Sprintf("/projects/%s/secrets/%s", url.PathEscape(projectRef), secretName), nil, -1, common.JSONContent, nil)
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) GetProjectGroupVariables(ctx context.Context, projectGroupRef string, tree bool) ([]*csapitypes.Variable, *http.Response, error) {
+func (c *Client) GetProjectGroupVariables(ctx context.Context, projectGroupRef string, tree bool) ([]*csapitypes.Variable, *Response, error) {
 	q := url.Values{}
 	if tree {
 		q.Add("tree", "")
@@ -206,7 +238,7 @@ func (c *Client) GetProjectGroupVariables(ctx context.Context, projectGroupRef s
 	return variables, resp, errors.WithStack(err)
 }
 
-func (c *Client) GetProjectVariables(ctx context.Context, projectRef string, tree bool) ([]*csapitypes.Variable, *http.Response, error) {
+func (c *Client) GetProjectVariables(ctx context.Context, projectRef string, tree bool) ([]*csapitypes.Variable, *Response, error) {
 	q := url.Values{}
 	if tree {
 		q.Add("tree", "")
@@ -217,7 +249,7 @@ func (c *Client) GetProjectVariables(ctx context.Context, projectRef string, tre
 	return variables, resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateProjectGroupVariable(ctx context.Context, projectGroupRef string, req *csapitypes.CreateUpdateVariableRequest) (*csapitypes.Variable, *http.Response, error) {
+func (c *Client) CreateProjectGroupVariable(ctx context.Context, projectGroupRef string, req *csapitypes.CreateUpdateVariableRequest) (*csapitypes.Variable, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -228,7 +260,7 @@ func (c *Client) CreateProjectGroupVariable(ctx context.Context, projectGroupRef
 	return resVariable, resp, errors.WithStack(err)
 }
 
-func (c *Client) UpdateProjectGroupVariable(ctx context.Context, projectGroupRef, variableName string, req *csapitypes.CreateUpdateVariableRequest) (*csapitypes.Variable, *http.Response, error) {
+func (c *Client) UpdateProjectGroupVariable(ctx context.Context, projectGroupRef, variableName string, req *csapitypes.CreateUpdateVariableRequest) (*csapitypes.Variable, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -239,7 +271,7 @@ func (c *Client) UpdateProjectGroupVariable(ctx context.Context, projectGroupRef
 	return resVariable, resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateProjectVariable(ctx context.Context, projectRef string, req *csapitypes.CreateUpdateVariableRequest) (*csapitypes.Variable, *http.Response, error) {
+func (c *Client) CreateProjectVariable(ctx context.Context, projectRef string, req *csapitypes.CreateUpdateVariableRequest) (*csapitypes.Variable, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -250,7 +282,7 @@ func (c *Client) CreateProjectVariable(ctx context.Context, projectRef string, r
 	return resVariable, resp, errors.WithStack(err)
 }
 
-func (c *Client) UpdateProjectVariable(ctx context.Context, projectRef, variableName string, req *csapitypes.CreateUpdateVariableRequest) (*csapitypes.Variable, *http.Response, error) {
+func (c *Client) UpdateProjectVariable(ctx context.Context, projectRef, variableName string, req *csapitypes.CreateUpdateVariableRequest) (*csapitypes.Variable, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -261,23 +293,23 @@ func (c *Client) UpdateProjectVariable(ctx context.Context, projectRef, variable
 	return resVariable, resp, errors.WithStack(err)
 }
 
-func (c *Client) DeleteProjectGroupVariable(ctx context.Context, projectGroupRef, variableName string) (*http.Response, error) {
+func (c *Client) DeleteProjectGroupVariable(ctx context.Context, projectGroupRef, variableName string) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "DELETE", fmt.Sprintf("/projectgroups/%s/variables/%s", url.PathEscape(projectGroupRef), variableName), nil, -1, common.JSONContent, nil)
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) DeleteProjectVariable(ctx context.Context, projectRef, variableName string) (*http.Response, error) {
+func (c *Client) DeleteProjectVariable(ctx context.Context, projectRef, variableName string) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "DELETE", fmt.Sprintf("/projects/%s/variables/%s", url.PathEscape(projectRef), variableName), nil, -1, common.JSONContent, nil)
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) GetUser(ctx context.Context, userRef string) (*cstypes.User, *http.Response, error) {
+func (c *Client) GetUser(ctx context.Context, userRef string) (*cstypes.User, *Response, error) {
 	user := new(cstypes.User)
 	resp, err := c.GetParsedResponse(ctx, "GET", fmt.Sprintf("/users/%s", userRef), nil, common.JSONContent, nil, user)
 	return user, resp, errors.WithStack(err)
 }
 
-func (c *Client) GetUserByToken(ctx context.Context, token string) (*cstypes.User, *http.Response, error) {
+func (c *Client) GetUserByToken(ctx context.Context, token string) (*cstypes.User, *Response, error) {
 	q := url.Values{}
 	q.Add("query_type", "bytoken")
 	q.Add("token", token)
@@ -290,7 +322,7 @@ func (c *Client) GetUserByToken(ctx context.Context, token string) (*cstypes.Use
 	return users[0], resp, errors.WithStack(err)
 }
 
-func (c *Client) GetUserByLinkedAccountRemoteUserAndSource(ctx context.Context, remoteUserID, remoteSourceID string) (*cstypes.User, *http.Response, error) {
+func (c *Client) GetUserByLinkedAccountRemoteUserAndSource(ctx context.Context, remoteUserID, remoteSourceID string) (*cstypes.User, *Response, error) {
 	q := url.Values{}
 	q.Add("query_type", "byremoteuser")
 	q.Add("remoteuserid", remoteUserID)
@@ -304,7 +336,7 @@ func (c *Client) GetUserByLinkedAccountRemoteUserAndSource(ctx context.Context, 
 	return users[0], resp, errors.WithStack(err)
 }
 
-func (c *Client) GetUserByLinkedAccount(ctx context.Context, linkedAccountID string) (*cstypes.User, *http.Response, error) {
+func (c *Client) GetUserByLinkedAccount(ctx context.Context, linkedAccountID string) (*cstypes.User, *Response, error) {
 	q := url.Values{}
 	q.Add("query_type", "bylinkedaccount")
 	q.Add("linkedaccountid", linkedAccountID)
@@ -317,7 +349,7 @@ func (c *Client) GetUserByLinkedAccount(ctx context.Context, linkedAccountID str
 	return users[0], resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateUser(ctx context.Context, req *csapitypes.CreateUserRequest) (*cstypes.User, *http.Response, error) {
+func (c *Client) CreateUser(ctx context.Context, req *csapitypes.CreateUserRequest) (*cstypes.User, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -328,7 +360,7 @@ func (c *Client) CreateUser(ctx context.Context, req *csapitypes.CreateUserReque
 	return user, resp, errors.WithStack(err)
 }
 
-func (c *Client) UpdateUser(ctx context.Context, userRef string, req *csapitypes.UpdateUserRequest) (*cstypes.User, *http.Response, error) {
+func (c *Client) UpdateUser(ctx context.Context, userRef string, req *csapitypes.UpdateUserRequest) (*cstypes.User, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -339,12 +371,12 @@ func (c *Client) UpdateUser(ctx context.Context, userRef string, req *csapitypes
 	return user, resp, errors.WithStack(err)
 }
 
-func (c *Client) DeleteUser(ctx context.Context, userRef string) (*http.Response, error) {
+func (c *Client) DeleteUser(ctx context.Context, userRef string) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "DELETE", fmt.Sprintf("/users/%s", userRef), nil, -1, common.JSONContent, nil)
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) GetUsers(ctx context.Context, start string, limit int, asc bool) ([]*cstypes.User, *http.Response, error) {
+func (c *Client) GetUsers(ctx context.Context, start string, limit int, asc bool) ([]*cstypes.User, *Response, error) {
 	q := url.Values{}
 	if start != "" {
 		q.Add("start", start)
@@ -361,13 +393,13 @@ func (c *Client) GetUsers(ctx context.Context, start string, limit int, asc bool
 	return users, resp, errors.WithStack(err)
 }
 
-func (c *Client) GetUserLinkedAccounts(ctx context.Context, userRef string) ([]*cstypes.LinkedAccount, *http.Response, error) {
+func (c *Client) GetUserLinkedAccounts(ctx context.Context, userRef string) ([]*cstypes.LinkedAccount, *Response, error) {
 	linkedAccounts := []*cstypes.LinkedAccount{}
 	resp, err := c.GetParsedResponse(ctx, "GET", fmt.Sprintf("/users/%s/linkedaccounts", userRef), nil, common.JSONContent, nil, &linkedAccounts)
 	return linkedAccounts, resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateUserLA(ctx context.Context, userRef string, req *csapitypes.CreateUserLARequest) (*cstypes.LinkedAccount, *http.Response, error) {
+func (c *Client) CreateUserLA(ctx context.Context, userRef string, req *csapitypes.CreateUserLARequest) (*cstypes.LinkedAccount, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -378,12 +410,12 @@ func (c *Client) CreateUserLA(ctx context.Context, userRef string, req *csapityp
 	return la, resp, errors.WithStack(err)
 }
 
-func (c *Client) DeleteUserLA(ctx context.Context, userRef, laID string) (*http.Response, error) {
+func (c *Client) DeleteUserLA(ctx context.Context, userRef, laID string) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "DELETE", fmt.Sprintf("/users/%s/linkedaccounts/%s", userRef, laID), nil, -1, common.JSONContent, nil)
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) UpdateUserLA(ctx context.Context, userRef, laID string, req *csapitypes.UpdateUserLARequest) (*cstypes.LinkedAccount, *http.Response, error) {
+func (c *Client) UpdateUserLA(ctx context.Context, userRef, laID string, req *csapitypes.UpdateUserLARequest) (*cstypes.LinkedAccount, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -394,13 +426,13 @@ func (c *Client) UpdateUserLA(ctx context.Context, userRef, laID string, req *cs
 	return la, resp, errors.WithStack(err)
 }
 
-func (c *Client) GetUserTokens(ctx context.Context, userRef string) ([]*cstypes.UserToken, *http.Response, error) {
+func (c *Client) GetUserTokens(ctx context.Context, userRef string) ([]*cstypes.UserToken, *Response, error) {
 	tokens := []*cstypes.UserToken{}
 	resp, err := c.GetParsedResponse(ctx, "GET", fmt.Sprintf("/users/%s/tokens", userRef), nil, common.JSONContent, nil, &tokens)
 	return tokens, resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateUserToken(ctx context.Context, userRef string, req *csapitypes.CreateUserTokenRequest) (*csapitypes.CreateUserTokenResponse, *http.Response, error) {
+func (c *Client) CreateUserToken(ctx context.Context, userRef string, req *csapitypes.CreateUserTokenRequest) (*csapitypes.CreateUserTokenResponse, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -411,24 +443,24 @@ func (c *Client) CreateUserToken(ctx context.Context, userRef string, req *csapi
 	return tresp, resp, errors.WithStack(err)
 }
 
-func (c *Client) DeleteUserToken(ctx context.Context, userRef, tokenName string) (*http.Response, error) {
+func (c *Client) DeleteUserToken(ctx context.Context, userRef, tokenName string) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "DELETE", fmt.Sprintf("/users/%s/tokens/%s", userRef, tokenName), nil, -1, common.JSONContent, nil)
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) GetUserOrgs(ctx context.Context, userRef string) ([]*csapitypes.UserOrgsResponse, *http.Response, error) {
+func (c *Client) GetUserOrgs(ctx context.Context, userRef string) ([]*csapitypes.UserOrgsResponse, *Response, error) {
 	userOrgs := []*csapitypes.UserOrgsResponse{}
 	resp, err := c.GetParsedResponse(ctx, "GET", fmt.Sprintf("/users/%s/orgs", userRef), nil, common.JSONContent, nil, &userOrgs)
 	return userOrgs, resp, errors.WithStack(err)
 }
 
-func (c *Client) GetRemoteSource(ctx context.Context, rsRef string) (*cstypes.RemoteSource, *http.Response, error) {
+func (c *Client) GetRemoteSource(ctx context.Context, rsRef string) (*cstypes.RemoteSource, *Response, error) {
 	rs := new(cstypes.RemoteSource)
 	resp, err := c.GetParsedResponse(ctx, "GET", fmt.Sprintf("/remotesources/%s", rsRef), nil, common.JSONContent, nil, rs)
 	return rs, resp, errors.WithStack(err)
 }
 
-func (c *Client) GetRemoteSources(ctx context.Context, start string, limit int, asc bool) ([]*cstypes.RemoteSource, *http.Response, error) {
+func (c *Client) GetRemoteSources(ctx context.Context, start string, limit int, asc bool) ([]*cstypes.RemoteSource, *Response, error) {
 	q := url.Values{}
 	if start != "" {
 		q.Add("start", start)
@@ -445,7 +477,7 @@ func (c *Client) GetRemoteSources(ctx context.Context, start string, limit int, 
 	return rss, resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateRemoteSource(ctx context.Context, req *csapitypes.CreateUpdateRemoteSourceRequest) (*cstypes.RemoteSource, *http.Response, error) {
+func (c *Client) CreateRemoteSource(ctx context.Context, req *csapitypes.CreateUpdateRemoteSourceRequest) (*cstypes.RemoteSource, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -456,7 +488,7 @@ func (c *Client) CreateRemoteSource(ctx context.Context, req *csapitypes.CreateU
 	return rs, resp, errors.WithStack(err)
 }
 
-func (c *Client) UpdateRemoteSource(ctx context.Context, remoteSourceRef string, req *csapitypes.CreateUpdateRemoteSourceRequest) (*cstypes.RemoteSource, *http.Response, error) {
+func (c *Client) UpdateRemoteSource(ctx context.Context, remoteSourceRef string, req *csapitypes.CreateUpdateRemoteSourceRequest) (*cstypes.RemoteSource, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -467,12 +499,12 @@ func (c *Client) UpdateRemoteSource(ctx context.Context, remoteSourceRef string,
 	return resRemoteSource, resp, errors.WithStack(err)
 }
 
-func (c *Client) DeleteRemoteSource(ctx context.Context, rsRef string) (*http.Response, error) {
+func (c *Client) DeleteRemoteSource(ctx context.Context, rsRef string) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "DELETE", fmt.Sprintf("/remotesources/%s", rsRef), nil, -1, common.JSONContent, nil)
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) GetLinkedAccountByRemoteUserAndSource(ctx context.Context, remoteUserID, remoteSourceID string) (*cstypes.LinkedAccount, *http.Response, error) {
+func (c *Client) GetLinkedAccountByRemoteUserAndSource(ctx context.Context, remoteUserID, remoteSourceID string) (*cstypes.LinkedAccount, *Response, error) {
 	q := url.Values{}
 	q.Add("query_type", "byremoteuser")
 	q.Add("remoteuserid", remoteUserID)
@@ -486,7 +518,7 @@ func (c *Client) GetLinkedAccountByRemoteUserAndSource(ctx context.Context, remo
 	return linkedAccounts[0], resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateOrg(ctx context.Context, req *csapitypes.CreateOrgRequest) (*cstypes.Organization, *http.Response, error) {
+func (c *Client) CreateOrg(ctx context.Context, req *csapitypes.CreateOrgRequest) (*cstypes.Organization, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -497,12 +529,12 @@ func (c *Client) CreateOrg(ctx context.Context, req *csapitypes.CreateOrgRequest
 	return org, resp, errors.WithStack(err)
 }
 
-func (c *Client) DeleteOrg(ctx context.Context, orgRef string) (*http.Response, error) {
+func (c *Client) DeleteOrg(ctx context.Context, orgRef string) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "DELETE", fmt.Sprintf("/orgs/%s", orgRef), nil, -1, common.JSONContent, nil)
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) UpdateOrg(ctx context.Context, orgRef string, req *csapitypes.UpdateOrgRequest) (*cstypes.Organization, *http.Response, error) {
+func (c *Client) UpdateOrg(ctx context.Context, orgRef string, req *csapitypes.UpdateOrgRequest) (*cstypes.Organization, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -513,7 +545,7 @@ func (c *Client) UpdateOrg(ctx context.Context, orgRef string, req *csapitypes.U
 	return org, resp, errors.WithStack(err)
 }
 
-func (c *Client) AddOrgMember(ctx context.Context, orgRef, userRef string, role cstypes.MemberRole) (*cstypes.OrganizationMember, *http.Response, error) {
+func (c *Client) AddOrgMember(ctx context.Context, orgRef, userRef string, role cstypes.MemberRole) (*cstypes.OrganizationMember, *Response, error) {
 	req := &csapitypes.AddOrgMemberRequest{
 		Role: role,
 	}
@@ -527,12 +559,12 @@ func (c *Client) AddOrgMember(ctx context.Context, orgRef, userRef string, role 
 	return orgmember, resp, errors.WithStack(err)
 }
 
-func (c *Client) RemoveOrgMember(ctx context.Context, orgRef, userRef string) (*http.Response, error) {
+func (c *Client) RemoveOrgMember(ctx context.Context, orgRef, userRef string) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "DELETE", fmt.Sprintf("/orgs/%s/members/%s", orgRef, userRef), nil, -1, common.JSONContent, nil)
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) GetOrgs(ctx context.Context, start string, limit int, asc bool) ([]*cstypes.Organization, *http.Response, error) {
+func (c *Client) GetOrgs(ctx context.Context, start string, limit int, asc bool) ([]*cstypes.Organization, *Response, error) {
 	q := url.Values{}
 	if start != "" {
 		q.Add("start", start)
@@ -549,19 +581,19 @@ func (c *Client) GetOrgs(ctx context.Context, start string, limit int, asc bool)
 	return orgs, resp, errors.WithStack(err)
 }
 
-func (c *Client) GetOrg(ctx context.Context, orgRef string) (*cstypes.Organization, *http.Response, error) {
+func (c *Client) GetOrg(ctx context.Context, orgRef string) (*cstypes.Organization, *Response, error) {
 	org := new(cstypes.Organization)
 	resp, err := c.GetParsedResponse(ctx, "GET", fmt.Sprintf("/orgs/%s", orgRef), nil, common.JSONContent, nil, org)
 	return org, resp, errors.WithStack(err)
 }
 
-func (c *Client) GetOrgMembers(ctx context.Context, orgRef string) ([]*csapitypes.OrgMemberResponse, *http.Response, error) {
+func (c *Client) GetOrgMembers(ctx context.Context, orgRef string) ([]*csapitypes.OrgMemberResponse, *Response, error) {
 	orgMembers := []*csapitypes.OrgMemberResponse{}
 	resp, err := c.GetParsedResponse(ctx, "GET", fmt.Sprintf("/orgs/%s/members", orgRef), nil, common.JSONContent, nil, &orgMembers)
 	return orgMembers, resp, errors.WithStack(err)
 }
 
-func (c *Client) GetUserOrgInvitations(ctx context.Context, userRef string, limit int) ([]*cstypes.OrgInvitation, *http.Response, error) {
+func (c *Client) GetUserOrgInvitations(ctx context.Context, userRef string, limit int) ([]*cstypes.OrgInvitation, *Response, error) {
 	q := url.Values{}
 	if limit > 0 {
 		q.Add("limit", strconv.Itoa(limit))
@@ -572,7 +604,7 @@ func (c *Client) GetUserOrgInvitations(ctx context.Context, userRef string, limi
 	return orgInvitations, resp, errors.WithStack(err)
 }
 
-func (c *Client) GetOrgInvitations(ctx context.Context, orgRef string, limit int) ([]*cstypes.OrgInvitation, *http.Response, error) {
+func (c *Client) GetOrgInvitations(ctx context.Context, orgRef string, limit int) ([]*cstypes.OrgInvitation, *Response, error) {
 	q := url.Values{}
 	if limit > 0 {
 		q.Add("limit", strconv.Itoa(limit))
@@ -583,7 +615,7 @@ func (c *Client) GetOrgInvitations(ctx context.Context, orgRef string, limit int
 	return orgInvitations, resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateOrgInvitation(ctx context.Context, orgRef string, req *csapitypes.CreateOrgInvitationRequest) (*cstypes.OrgInvitation, *http.Response, error) {
+func (c *Client) CreateOrgInvitation(ctx context.Context, orgRef string, req *csapitypes.CreateOrgInvitationRequest) (*cstypes.OrgInvitation, *Response, error) {
 	oj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, err
@@ -594,18 +626,18 @@ func (c *Client) CreateOrgInvitation(ctx context.Context, orgRef string, req *cs
 	return orgInvitation, resp, errors.WithStack(err)
 }
 
-func (c *Client) DeleteOrgInvitation(ctx context.Context, orgRef string, userRef string) (*http.Response, error) {
+func (c *Client) DeleteOrgInvitation(ctx context.Context, orgRef string, userRef string) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "DELETE", fmt.Sprintf("/orgs/%s/invitations/%s", orgRef, userRef), nil, -1, common.JSONContent, nil)
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) GetOrgInvitation(ctx context.Context, orgRef string, userRef string) (*cstypes.OrgInvitation, *http.Response, error) {
+func (c *Client) GetOrgInvitation(ctx context.Context, orgRef string, userRef string) (*cstypes.OrgInvitation, *Response, error) {
 	orgInvitation := new(cstypes.OrgInvitation)
 	resp, err := c.GetParsedResponse(ctx, "GET", fmt.Sprintf("/orgs/%s/invitations/%s", orgRef, userRef), nil, common.JSONContent, nil, orgInvitation)
 	return orgInvitation, resp, errors.WithStack(err)
 }
 
-func (c *Client) UserOrgInvitationAction(ctx context.Context, userRef string, orgRef string, req *csapitypes.OrgInvitationActionRequest) (*http.Response, error) {
+func (c *Client) UserOrgInvitationAction(ctx context.Context, userRef string, orgRef string, req *csapitypes.OrgInvitationActionRequest) (*Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -615,28 +647,28 @@ func (c *Client) UserOrgInvitationAction(ctx context.Context, userRef string, or
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) GetMaintenanceStatus(ctx context.Context) (*csapitypes.MaintenanceStatusResponse, *http.Response, error) {
+func (c *Client) GetMaintenanceStatus(ctx context.Context) (*csapitypes.MaintenanceStatusResponse, *Response, error) {
 	maintenanceStatus := new(csapitypes.MaintenanceStatusResponse)
 	resp, err := c.GetParsedResponse(ctx, "GET", "/maintenance", nil, common.JSONContent, nil, maintenanceStatus)
 	return maintenanceStatus, resp, errors.WithStack(err)
 }
 
-func (c *Client) EnableMaintenance(ctx context.Context) (*http.Response, error) {
+func (c *Client) EnableMaintenance(ctx context.Context) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "PUT", "/maintenance", nil, -1, common.JSONContent, nil)
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) DisableMaintenance(ctx context.Context) (*http.Response, error) {
+func (c *Client) DisableMaintenance(ctx context.Context) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "DELETE", "/maintenance", nil, -1, common.JSONContent, nil)
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) Export(ctx context.Context) (*http.Response, error) {
+func (c *Client) Export(ctx context.Context) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "GET", "/export", nil, -1, common.JSONContent, nil)
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) Import(ctx context.Context, r io.Reader) (*http.Response, error) {
+func (c *Client) Import(ctx context.Context, r io.Reader) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "POST", "/import", nil, -1, common.JSONContent, r)
 	return resp, errors.WithStack(err)
 }

--- a/services/configstore/types/types.go
+++ b/services/configstore/types/types.go
@@ -14,6 +14,13 @@
 
 package types
 
+type SortDirection string
+
+const (
+	SortDirectionAsc  SortDirection = "asc"
+	SortDirectionDesc SortDirection = "desc"
+)
+
 type ObjectKind string
 
 const (

--- a/services/gateway/api/types/types.go
+++ b/services/gateway/api/types/types.go
@@ -1,0 +1,8 @@
+package types
+
+type SortDirection string
+
+const (
+	SortDirectionAsc  SortDirection = "asc"
+	SortDirectionDesc SortDirection = "desc"
+)

--- a/services/gateway/client/client.go
+++ b/services/gateway/client/client.go
@@ -722,9 +722,12 @@ func (c *Client) RemoveOrgMember(ctx context.Context, orgRef, userRef string) (*
 	return c.getResponse(ctx, "DELETE", fmt.Sprintf("/orgs/%s/members/%s", orgRef, userRef), nil, jsonContent, nil)
 }
 
-func (c *Client) GetOrgMembers(ctx context.Context, orgRef string) (*gwapitypes.OrgMembersResponse, *Response, error) {
+func (c *Client) GetOrgMembers(ctx context.Context, orgRef string, opts *ListOptions) (*gwapitypes.OrgMembersResponse, *Response, error) {
+	q := url.Values{}
+	opts.Add(q)
+
 	res := &gwapitypes.OrgMembersResponse{}
-	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/orgs/%s/members", orgRef), nil, jsonContent, nil, &res)
+	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/orgs/%s/members", orgRef), q, jsonContent, nil, &res)
 	return res, resp, errors.WithStack(err)
 }
 

--- a/services/runservice/client/client.go
+++ b/services/runservice/client/client.go
@@ -26,10 +26,15 @@ import (
 
 	"github.com/sorintlab/errors"
 
+	"agola.io/agola/internal/util"
 	"agola.io/agola/services/common"
 	rsapitypes "agola.io/agola/services/runservice/api/types"
 	rstypes "agola.io/agola/services/runservice/types"
 )
+
+type Response struct {
+	*http.Response
+}
 
 type Client struct {
 	*common.Client
@@ -41,7 +46,34 @@ func NewClient(url, token string) *Client {
 	return &Client{c}
 }
 
-func (c *Client) SendExecutorStatus(ctx context.Context, executorID string, executor *rsapitypes.ExecutorStatus) (*http.Response, error) {
+func (c *Client) GetResponse(ctx context.Context, method, path string, query url.Values, contentLength int64, header http.Header, ibody io.Reader) (*Response, error) {
+	cresp, err := c.Client.DoRequest(ctx, method, path, query, contentLength, header, ibody)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	resp := &Response{Response: cresp}
+
+	if err := util.ErrFromRemote(resp.Response); err != nil {
+		return resp, errors.WithStack(err)
+	}
+
+	return resp, nil
+}
+
+func (c *Client) GetParsedResponse(ctx context.Context, method, path string, query url.Values, header http.Header, ibody io.Reader, obj interface{}) (*Response, error) {
+	resp, err := c.GetResponse(ctx, method, path, query, -1, header, ibody)
+	if err != nil {
+		return resp, errors.WithStack(err)
+	}
+	defer resp.Body.Close()
+
+	d := json.NewDecoder(resp.Body)
+
+	return resp, errors.WithStack(d.Decode(obj))
+}
+
+func (c *Client) SendExecutorStatus(ctx context.Context, executorID string, executor *rsapitypes.ExecutorStatus) (*Response, error) {
 	executorj, err := json.Marshal(executor)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -51,7 +83,7 @@ func (c *Client) SendExecutorStatus(ctx context.Context, executorID string, exec
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) SendExecutorTaskStatus(ctx context.Context, executorID, etID string, et *rsapitypes.ExecutorTaskStatus) (*http.Response, error) {
+func (c *Client) SendExecutorTaskStatus(ctx context.Context, executorID, etID string, et *rsapitypes.ExecutorTaskStatus) (*Response, error) {
 	etj, err := json.Marshal(et)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -61,19 +93,19 @@ func (c *Client) SendExecutorTaskStatus(ctx context.Context, executorID, etID st
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) GetExecutorTask(ctx context.Context, executorID, etID string) (*rsapitypes.ExecutorTask, *http.Response, error) {
+func (c *Client) GetExecutorTask(ctx context.Context, executorID, etID string) (*rsapitypes.ExecutorTask, *Response, error) {
 	et := new(rsapitypes.ExecutorTask)
 	resp, err := c.GetParsedResponse(ctx, "GET", fmt.Sprintf("/executor/%s/tasks/%s", executorID, etID), nil, common.JSONContent, nil, et)
 	return et, resp, errors.WithStack(err)
 }
 
-func (c *Client) GetExecutorTasks(ctx context.Context, executorID string) ([]*rsapitypes.ExecutorTask, *http.Response, error) {
+func (c *Client) GetExecutorTasks(ctx context.Context, executorID string) ([]*rsapitypes.ExecutorTask, *Response, error) {
 	ets := []*rsapitypes.ExecutorTask{}
 	resp, err := c.GetParsedResponse(ctx, "GET", fmt.Sprintf("/executor/%s/tasks", executorID), nil, common.JSONContent, nil, &ets)
 	return ets, resp, errors.WithStack(err)
 }
 
-func (c *Client) GetArchive(ctx context.Context, taskID string, step int) (*http.Response, error) {
+func (c *Client) GetArchive(ctx context.Context, taskID string, step int) (*Response, error) {
 	q := url.Values{}
 	q.Add("taskid", taskID)
 	q.Add("step", strconv.Itoa(step))
@@ -82,7 +114,7 @@ func (c *Client) GetArchive(ctx context.Context, taskID string, step int) (*http
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) CheckCache(ctx context.Context, key string, prefix bool) (*http.Response, error) {
+func (c *Client) CheckCache(ctx context.Context, key string, prefix bool) (*Response, error) {
 	q := url.Values{}
 	if prefix {
 		q.Add("prefix", "")
@@ -92,7 +124,7 @@ func (c *Client) CheckCache(ctx context.Context, key string, prefix bool) (*http
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) GetCache(ctx context.Context, key string, prefix bool) (*http.Response, error) {
+func (c *Client) GetCache(ctx context.Context, key string, prefix bool) (*Response, error) {
 	q := url.Values{}
 	if prefix {
 		q.Add("prefix", "")
@@ -102,13 +134,13 @@ func (c *Client) GetCache(ctx context.Context, key string, prefix bool) (*http.R
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) PutCache(ctx context.Context, key string, size int64, r io.Reader) (*http.Response, error) {
+func (c *Client) PutCache(ctx context.Context, key string, size int64, r io.Reader) (*Response, error) {
 
 	resp, err := c.GetResponse(ctx, "POST", fmt.Sprintf("/executor/caches/%s", url.PathEscape(key)), nil, size, nil, r)
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) GetRuns(ctx context.Context, phaseFilter, resultFilter, groups []string, lastRun bool, changeGroups []string, startRunSequence uint64, limit int, asc bool) (*rsapitypes.GetRunsResponse, *http.Response, error) {
+func (c *Client) GetRuns(ctx context.Context, phaseFilter, resultFilter, groups []string, lastRun bool, changeGroups []string, startRunSequence uint64, limit int, asc bool) (*rsapitypes.GetRunsResponse, *Response, error) {
 	q := url.Values{}
 	for _, phase := range phaseFilter {
 		q.Add("phase", phase)
@@ -141,31 +173,31 @@ func (c *Client) GetRuns(ctx context.Context, phaseFilter, resultFilter, groups 
 	return getRunsResponse, resp, errors.WithStack(err)
 }
 
-func (c *Client) GetQueuedRuns(ctx context.Context, startRunSequence uint64, limit int, changeGroups []string) (*rsapitypes.GetRunsResponse, *http.Response, error) {
+func (c *Client) GetQueuedRuns(ctx context.Context, startRunSequence uint64, limit int, changeGroups []string) (*rsapitypes.GetRunsResponse, *Response, error) {
 	return c.GetRuns(ctx, []string{"queued"}, nil, []string{}, false, changeGroups, startRunSequence, limit, true)
 }
 
-func (c *Client) GetRunningRuns(ctx context.Context, startRunSequence uint64, limit int, changeGroups []string) (*rsapitypes.GetRunsResponse, *http.Response, error) {
+func (c *Client) GetRunningRuns(ctx context.Context, startRunSequence uint64, limit int, changeGroups []string) (*rsapitypes.GetRunsResponse, *Response, error) {
 	return c.GetRuns(ctx, []string{"running"}, nil, []string{}, false, changeGroups, startRunSequence, limit, true)
 }
 
-func (c *Client) GetGroupQueuedRuns(ctx context.Context, group string, limit int, changeGroups []string) (*rsapitypes.GetRunsResponse, *http.Response, error) {
+func (c *Client) GetGroupQueuedRuns(ctx context.Context, group string, limit int, changeGroups []string) (*rsapitypes.GetRunsResponse, *Response, error) {
 	return c.GetRuns(ctx, []string{"queued"}, nil, []string{group}, false, changeGroups, 0, limit, false)
 }
 
-func (c *Client) GetGroupRunningRuns(ctx context.Context, group string, limit int, changeGroups []string) (*rsapitypes.GetRunsResponse, *http.Response, error) {
+func (c *Client) GetGroupRunningRuns(ctx context.Context, group string, limit int, changeGroups []string) (*rsapitypes.GetRunsResponse, *Response, error) {
 	return c.GetRuns(ctx, []string{"running"}, nil, []string{group}, false, changeGroups, 0, limit, false)
 }
 
-func (c *Client) GetGroupFirstQueuedRuns(ctx context.Context, group string, changeGroups []string) (*rsapitypes.GetRunsResponse, *http.Response, error) {
+func (c *Client) GetGroupFirstQueuedRuns(ctx context.Context, group string, changeGroups []string) (*rsapitypes.GetRunsResponse, *Response, error) {
 	return c.GetRuns(ctx, []string{"queued"}, nil, []string{group}, false, changeGroups, 0, 1, true)
 }
 
-func (c *Client) GetGroupLastRun(ctx context.Context, group string, changeGroups []string) (*rsapitypes.GetRunsResponse, *http.Response, error) {
+func (c *Client) GetGroupLastRun(ctx context.Context, group string, changeGroups []string) (*rsapitypes.GetRunsResponse, *Response, error) {
 	return c.GetRuns(ctx, nil, nil, []string{group}, false, changeGroups, 0, 1, false)
 }
 
-func (c *Client) GetGroupRuns(ctx context.Context, phaseFilter, resultFilter []string, group string, changeGroups []string, startRunCounter uint64, limit int, asc bool) (*rsapitypes.GetRunsResponse, *http.Response, error) {
+func (c *Client) GetGroupRuns(ctx context.Context, phaseFilter, resultFilter []string, group string, changeGroups []string, startRunCounter uint64, limit int, asc bool) (*rsapitypes.GetRunsResponse, *Response, error) {
 	q := url.Values{}
 	for _, phase := range phaseFilter {
 		q.Add("phase", phase)
@@ -191,7 +223,7 @@ func (c *Client) GetGroupRuns(ctx context.Context, phaseFilter, resultFilter []s
 	return getRunsResponse, resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateRun(ctx context.Context, req *rsapitypes.RunCreateRequest) (*rsapitypes.RunResponse, *http.Response, error) {
+func (c *Client) CreateRun(ctx context.Context, req *rsapitypes.RunCreateRequest) (*rsapitypes.RunResponse, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -202,7 +234,7 @@ func (c *Client) CreateRun(ctx context.Context, req *rsapitypes.RunCreateRequest
 	return res, resp, errors.WithStack(err)
 }
 
-func (c *Client) RunActions(ctx context.Context, runID string, req *rsapitypes.RunActionsRequest) (*http.Response, error) {
+func (c *Client) RunActions(ctx context.Context, runID string, req *rsapitypes.RunActionsRequest) (*Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -212,7 +244,7 @@ func (c *Client) RunActions(ctx context.Context, runID string, req *rsapitypes.R
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) StartRun(ctx context.Context, runID string, changeGroupsUpdateToken string) (*http.Response, error) {
+func (c *Client) StartRun(ctx context.Context, runID string, changeGroupsUpdateToken string) (*Response, error) {
 	req := &rsapitypes.RunActionsRequest{
 		ActionType:              rsapitypes.RunActionTypeChangePhase,
 		Phase:                   rstypes.RunPhaseRunning,
@@ -222,7 +254,7 @@ func (c *Client) StartRun(ctx context.Context, runID string, changeGroupsUpdateT
 	return c.RunActions(ctx, runID, req)
 }
 
-func (c *Client) RunTaskActions(ctx context.Context, runID, taskID string, req *rsapitypes.RunTaskActionsRequest) (*http.Response, error) {
+func (c *Client) RunTaskActions(ctx context.Context, runID, taskID string, req *rsapitypes.RunTaskActionsRequest) (*Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -232,7 +264,7 @@ func (c *Client) RunTaskActions(ctx context.Context, runID, taskID string, req *
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) RunTaskSetAnnotations(ctx context.Context, runID, taskID string, annotations map[string]string, changeGroupsUpdateToken string) (*http.Response, error) {
+func (c *Client) RunTaskSetAnnotations(ctx context.Context, runID, taskID string, annotations map[string]string, changeGroupsUpdateToken string) (*Response, error) {
 	req := &rsapitypes.RunTaskActionsRequest{
 		ActionType:              rsapitypes.RunTaskActionTypeSetAnnotations,
 		Annotations:             annotations,
@@ -242,7 +274,7 @@ func (c *Client) RunTaskSetAnnotations(ctx context.Context, runID, taskID string
 	return c.RunTaskActions(ctx, runID, taskID, req)
 }
 
-func (c *Client) ApproveRunTask(ctx context.Context, runID, taskID string, changeGroupsUpdateToken string) (*http.Response, error) {
+func (c *Client) ApproveRunTask(ctx context.Context, runID, taskID string, changeGroupsUpdateToken string) (*Response, error) {
 	req := &rsapitypes.RunTaskActionsRequest{
 		ActionType:              rsapitypes.RunTaskActionTypeApprove,
 		ChangeGroupsUpdateToken: changeGroupsUpdateToken,
@@ -251,7 +283,7 @@ func (c *Client) ApproveRunTask(ctx context.Context, runID, taskID string, chang
 	return c.RunTaskActions(ctx, runID, taskID, req)
 }
 
-func (c *Client) GetRun(ctx context.Context, runID string, changeGroups []string) (*rsapitypes.RunResponse, *http.Response, error) {
+func (c *Client) GetRun(ctx context.Context, runID string, changeGroups []string) (*rsapitypes.RunResponse, *Response, error) {
 	q := url.Values{}
 	for _, changeGroup := range changeGroups {
 		q.Add("changegroup", changeGroup)
@@ -262,7 +294,7 @@ func (c *Client) GetRun(ctx context.Context, runID string, changeGroups []string
 	return runResponse, resp, errors.WithStack(err)
 }
 
-func (c *Client) GetRunByGroup(ctx context.Context, group string, runNumber uint64, changeGroups []string) (*rsapitypes.RunResponse, *http.Response, error) {
+func (c *Client) GetRunByGroup(ctx context.Context, group string, runNumber uint64, changeGroups []string) (*rsapitypes.RunResponse, *Response, error) {
 	q := url.Values{}
 	for _, changeGroup := range changeGroups {
 		q.Add("changegroup", changeGroup)
@@ -273,7 +305,7 @@ func (c *Client) GetRunByGroup(ctx context.Context, group string, runNumber uint
 	return runResponse, resp, errors.WithStack(err)
 }
 
-func (c *Client) GetLogs(ctx context.Context, runID, taskID string, setup bool, step int, follow bool) (*http.Response, error) {
+func (c *Client) GetLogs(ctx context.Context, runID, taskID string, setup bool, step int, follow bool) (*Response, error) {
 	q := url.Values{}
 	q.Add("runid", runID)
 	q.Add("taskid", taskID)
@@ -290,7 +322,7 @@ func (c *Client) GetLogs(ctx context.Context, runID, taskID string, setup bool, 
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) DeleteLogs(ctx context.Context, runID, taskID string, setup bool, step int) (*http.Response, error) {
+func (c *Client) DeleteLogs(ctx context.Context, runID, taskID string, setup bool, step int) (*Response, error) {
 	q := url.Values{}
 	q.Add("runid", runID)
 	q.Add("taskid", taskID)
@@ -304,7 +336,7 @@ func (c *Client) DeleteLogs(ctx context.Context, runID, taskID string, setup boo
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) GetRunEvents(ctx context.Context, afterSequence uint64) (*http.Response, error) {
+func (c *Client) GetRunEvents(ctx context.Context, afterSequence uint64) (*Response, error) {
 	q := url.Values{}
 	q.Add("afterSequence", strconv.FormatUint(afterSequence, 10))
 
@@ -312,28 +344,28 @@ func (c *Client) GetRunEvents(ctx context.Context, afterSequence uint64) (*http.
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) GetMaintenanceStatus(ctx context.Context) (*rsapitypes.MaintenanceStatusResponse, *http.Response, error) {
+func (c *Client) GetMaintenanceStatus(ctx context.Context) (*rsapitypes.MaintenanceStatusResponse, *Response, error) {
 	maintenanceStatus := new(rsapitypes.MaintenanceStatusResponse)
 	resp, err := c.GetParsedResponse(ctx, "GET", "/maintenance", nil, common.JSONContent, nil, maintenanceStatus)
 	return maintenanceStatus, resp, errors.WithStack(err)
 }
 
-func (c *Client) EnableMaintenance(ctx context.Context) (*http.Response, error) {
+func (c *Client) EnableMaintenance(ctx context.Context) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "PUT", "/maintenance", nil, -1, nil, nil)
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) DisableMaintenance(ctx context.Context) (*http.Response, error) {
+func (c *Client) DisableMaintenance(ctx context.Context) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "DELETE", "/maintenance", nil, -1, nil, nil)
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) Export(ctx context.Context) (*http.Response, error) {
+func (c *Client) Export(ctx context.Context) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "GET", "/export", nil, -1, nil, nil)
 	return resp, errors.WithStack(err)
 }
 
-func (c *Client) Import(ctx context.Context, r io.Reader) (*http.Response, error) {
+func (c *Client) Import(ctx context.Context, r io.Reader) (*Response, error) {
 	resp, err := c.GetResponse(ctx, "POST", "/import", nil, -1, nil, r)
 	return resp, errors.WithStack(err)
 }


### PR DESCRIPTION
This commit adds code required to implement cursor based list apis.
It also changes the first list api (GetOrgMembers).
These api changes are breaking changes, so a related change in the agola
web repository is required and should be merged together.

Some implementation notes:

* Only the gateway list APIs use opaque cursors.
* The cursor is provided as a custom X-Agola-Cursor response header.
* The provided cursor will be for the next batch of result
  using the same query options of the first call (limit excluded).
* When a cursor is provided all the other query options cannot be
  provided with the exception of limit.
* A default limit is forced if not provided.
* The underlying services (configstore, runservice) will continue using
  explicit list options (start, sort etc...) based api instead of an
  opaque cursor.
* The underlying services (configstore, runservice) will continue to not
  force any default limit. If a limit isn't provided then all the output
  results will be provided. This is required since their api must
  sometimes provide an atomicity in the results (i.e. GetSecrets tree).
  So doing multiple calls will break this atomicity since they'll
  execute different db transactions.