### PR TITLE
ci: increase postgres container max connections

### DIFF
--- a/.agola/config.jsonnet
+++ b/.agola/config.jsonnet
@@ -10,6 +10,7 @@ local go_runtime(version, arch) = {
       environment: {
         POSTGRES_PASSWORD: 'password',
       },
+      entrypoint: 'docker-entrypoint.sh -c max_connections=300'
     },
   ],
 };


### PR DESCRIPTION
Test were failing due to exceeding the default max number of connections. Increase the postgres max connections to 300.