### PR TITLE
gateway: correctly handle org/pg visibility

### DIFF
--- a/internal/services/gateway/action/auth.go
+++ b/internal/services/gateway/action/auth.go
@@ -25,7 +25,7 @@ import (
 	cstypes "agola.io/agola/services/configstore/types"
 )
 
-func (h *ActionHandler) IsOrgOwner(ctx context.Context, orgID string) (bool, error) {
+func (h *ActionHandler) IsAuthUserOrgOwner(ctx context.Context, orgID string) (bool, error) {
 	isAdmin := common.IsUserAdmin(ctx)
 	if isAdmin {
 		return true, nil
@@ -51,7 +51,7 @@ func (h *ActionHandler) IsOrgOwner(ctx context.Context, orgID string) (bool, err
 	return false, nil
 }
 
-func (h *ActionHandler) IsProjectOwner(ctx context.Context, ownerType cstypes.ObjectKind, ownerID string) (bool, error) {
+func (h *ActionHandler) IsAuthUserProjectOwner(ctx context.Context, ownerType cstypes.ObjectKind, ownerID string) (bool, error) {
 	isAdmin := common.IsUserAdmin(ctx)
 	if isAdmin {
 		return true, nil
@@ -85,7 +85,7 @@ func (h *ActionHandler) IsProjectOwner(ctx context.Context, ownerType cstypes.Ob
 	return false, nil
 }
 
-func (h *ActionHandler) IsProjectMember(ctx context.Context, ownerType cstypes.ObjectKind, ownerID string) (bool, error) {
+func (h *ActionHandler) IsAuthUserMember(ctx context.Context, ownerType cstypes.ObjectKind, ownerID string) (bool, error) {
 	isAdmin := common.IsUserAdmin(ctx)
 	if isAdmin {
 		return true, nil
@@ -118,7 +118,7 @@ func (h *ActionHandler) IsProjectMember(ctx context.Context, ownerType cstypes.O
 	return false, nil
 }
 
-func (h *ActionHandler) IsVariableOwner(ctx context.Context, parentType cstypes.ObjectKind, parentRef string) (bool, error) {
+func (h *ActionHandler) IsAuthUserVariableOwner(ctx context.Context, parentType cstypes.ObjectKind, parentRef string) (bool, error) {
 	var ownerType cstypes.ObjectKind
 	var ownerID string
 	switch parentType {
@@ -138,10 +138,10 @@ func (h *ActionHandler) IsVariableOwner(ctx context.Context, parentType cstypes.
 		ownerID = p.OwnerID
 	}
 
-	return h.IsProjectOwner(ctx, ownerType, ownerID)
+	return h.IsAuthUserProjectOwner(ctx, ownerType, ownerID)
 }
 
-func (h *ActionHandler) CanGetRun(ctx context.Context, groupType scommon.GroupType, ref string) (bool, string, error) {
+func (h *ActionHandler) CanAuthUserGetRun(ctx context.Context, groupType scommon.GroupType, ref string) (bool, string, error) {
 	var visibility cstypes.Visibility
 	var ownerType cstypes.ObjectKind
 	var refID string
@@ -172,7 +172,7 @@ func (h *ActionHandler) CanGetRun(ctx context.Context, groupType scommon.GroupTy
 	if visibility == cstypes.VisibilityPublic {
 		return true, refID, nil
 	}
-	isProjectMember, err := h.IsProjectMember(ctx, ownerType, ownerID)
+	isProjectMember, err := h.IsAuthUserMember(ctx, ownerType, ownerID)
 	if err != nil {
 		return false, "", errors.Wrapf(err, "failed to determine ownership")
 	}
@@ -182,7 +182,7 @@ func (h *ActionHandler) CanGetRun(ctx context.Context, groupType scommon.GroupTy
 	return true, refID, nil
 }
 
-func (h *ActionHandler) CanDoRunActions(ctx context.Context, groupType scommon.GroupType, ref string) (bool, string, error) {
+func (h *ActionHandler) CanAuthUserDoRunActions(ctx context.Context, groupType scommon.GroupType, ref string) (bool, string, error) {
 	var ownerType cstypes.ObjectKind
 	var refID string
 	var ownerID string
@@ -207,7 +207,7 @@ func (h *ActionHandler) CanDoRunActions(ctx context.Context, groupType scommon.G
 		ownerID = u.ID
 	}
 
-	isProjectOwner, err := h.IsProjectOwner(ctx, ownerType, ownerID)
+	isProjectOwner, err := h.IsAuthUserProjectOwner(ctx, ownerType, ownerID)
 	if err != nil {
 		return false, "", errors.Wrapf(err, "failed to determine ownership")
 	}
@@ -217,7 +217,7 @@ func (h *ActionHandler) CanDoRunActions(ctx context.Context, groupType scommon.G
 	return true, refID, nil
 }
 
-func (h *ActionHandler) IsOrgMember(ctx context.Context, userRef, orgRef string) (bool, error) {
+func (h *ActionHandler) IsUserOrgMember(ctx context.Context, userRef, orgRef string) (bool, error) {
 	user, err := h.GetUser(ctx, userRef)
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to get user %s:", userRef)

--- a/internal/services/gateway/action/org.go
+++ b/internal/services/gateway/action/org.go
@@ -160,7 +160,7 @@ func (h *ActionHandler) UpdateOrg(ctx context.Context, orgRef string, req *Updat
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
 	}
 
-	isOrgOwner, err := h.IsOrgOwner(ctx, org.ID)
+	isOrgOwner, err := h.IsAuthUserOrgOwner(ctx, org.ID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
@@ -192,7 +192,7 @@ func (h *ActionHandler) DeleteOrg(ctx context.Context, orgRef string) error {
 		return util.NewAPIError(util.KindFromRemoteError(err), err)
 	}
 
-	isOrgOwner, err := h.IsOrgOwner(ctx, org.ID)
+	isOrgOwner, err := h.IsAuthUserOrgOwner(ctx, org.ID)
 	if err != nil {
 		return errors.Wrapf(err, "failed to determine ownership")
 	}
@@ -226,7 +226,7 @@ func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
 	}
 
-	isOrgOwner, err := h.IsOrgOwner(ctx, org.ID)
+	isOrgOwner, err := h.IsAuthUserOrgOwner(ctx, org.ID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
@@ -252,7 +252,7 @@ func (h *ActionHandler) RemoveOrgMember(ctx context.Context, orgRef, userRef str
 		return util.NewAPIError(util.KindFromRemoteError(err), err)
 	}
 
-	isOrgOwner, err := h.IsOrgOwner(ctx, org.ID)
+	isOrgOwner, err := h.IsAuthUserOrgOwner(ctx, org.ID)
 	if err != nil {
 		return errors.Wrapf(err, "failed to determine ownership")
 	}
@@ -282,7 +282,7 @@ func (h *ActionHandler) GetOrgInvitations(ctx context.Context, orgRef string, li
 		return nil, errors.Wrapf(err, "failed to get org %s:", orgRef)
 	}
 
-	isOrgOwner, err := h.IsOrgOwner(ctx, org.ID)
+	isOrgOwner, err := h.IsAuthUserOrgOwner(ctx, org.ID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
@@ -327,7 +327,7 @@ func (h *ActionHandler) CreateOrgInvitation(ctx context.Context, req *CreateOrgI
 		return nil, errors.Wrapf(err, "failed to get org %s:", req.OrganizationRef)
 	}
 
-	isOrgOwner, err := h.IsOrgOwner(ctx, org.ID)
+	isOrgOwner, err := h.IsAuthUserOrgOwner(ctx, org.ID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
@@ -335,7 +335,7 @@ func (h *ActionHandler) CreateOrgInvitation(ctx context.Context, req *CreateOrgI
 		return nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
 	}
 
-	isOrgMember, err := h.IsOrgMember(ctx, req.UserRef, req.OrganizationRef)
+	isOrgMember, err := h.IsUserOrgMember(ctx, req.UserRef, req.OrganizationRef)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine membership")
 	}
@@ -430,7 +430,7 @@ func (h *ActionHandler) DeleteOrgInvitation(ctx context.Context, orgRef string, 
 		return err
 	}
 
-	isOrgOwner, err := h.IsOrgOwner(ctx, org.ID)
+	isOrgOwner, err := h.IsAuthUserOrgOwner(ctx, org.ID)
 	if err != nil {
 		return util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "failed to determine ownership"))
 	}

--- a/internal/services/gateway/action/org.go
+++ b/internal/services/gateway/action/org.go
@@ -31,6 +31,19 @@ func (h *ActionHandler) GetOrg(ctx context.Context, orgRef string) (*cstypes.Org
 	if err != nil {
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
 	}
+
+	if org.Visibility == cstypes.VisibilityPublic {
+		return org, nil
+	}
+
+	isMember, err := h.IsAuthUserMember(ctx, cstypes.ObjectKindOrg, org.ID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to determine ownership")
+	}
+	if !isMember {
+		return nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
+	}
+
 	return org, nil
 }
 

--- a/internal/services/gateway/action/project.go
+++ b/internal/services/gateway/action/project.go
@@ -36,14 +36,14 @@ func (h *ActionHandler) GetProject(ctx context.Context, projectRef string) (*csa
 		return nil, errors.WithStack(err)
 	}
 
-	isProjectMember, err := h.IsProjectMember(ctx, project.OwnerType, project.OwnerID)
+	isMember, err := h.IsAuthUserMember(ctx, project.OwnerType, project.OwnerID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
 	if project.GlobalVisibility == cstypes.VisibilityPublic {
 		return project, nil
 	}
-	if !isProjectMember {
+	if !isMember {
 		return nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
 	}
 
@@ -78,7 +78,7 @@ func (h *ActionHandler) CreateProject(ctx context.Context, req *CreateProjectReq
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project group %q", parentRef))
 	}
 
-	isProjectOwner, err := h.IsProjectOwner(ctx, pg.OwnerType, pg.OwnerID)
+	isProjectOwner, err := h.IsAuthUserProjectOwner(ctx, pg.OwnerType, pg.OwnerID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
@@ -179,7 +179,7 @@ func (h *ActionHandler) UpdateProject(ctx context.Context, projectRef string, re
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project %q", projectRef))
 	}
 
-	isProjectOwner, err := h.IsProjectOwner(ctx, p.OwnerType, p.OwnerID)
+	isProjectOwner, err := h.IsAuthUserProjectOwner(ctx, p.OwnerType, p.OwnerID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
@@ -233,7 +233,7 @@ func (h *ActionHandler) ProjectUpdateRepoLinkedAccount(ctx context.Context, proj
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project %q", projectRef))
 	}
 
-	isProjectOwner, err := h.IsProjectOwner(ctx, p.OwnerType, p.OwnerID)
+	isProjectOwner, err := h.IsAuthUserProjectOwner(ctx, p.OwnerType, p.OwnerID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
@@ -362,7 +362,7 @@ func (h *ActionHandler) ReconfigProject(ctx context.Context, projectRef string) 
 		return util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project %q", projectRef))
 	}
 
-	isProjectOwner, err := h.IsProjectOwner(ctx, p.OwnerType, p.OwnerID)
+	isProjectOwner, err := h.IsAuthUserProjectOwner(ctx, p.OwnerType, p.OwnerID)
 	if err != nil {
 		return errors.Wrapf(err, "failed to determine ownership")
 	}
@@ -386,7 +386,7 @@ func (h *ActionHandler) DeleteProject(ctx context.Context, projectRef string) er
 		return util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project %q", projectRef))
 	}
 
-	isProjectOwner, err := h.IsProjectOwner(ctx, p.OwnerType, p.OwnerID)
+	isProjectOwner, err := h.IsAuthUserProjectOwner(ctx, p.OwnerType, p.OwnerID)
 	if err != nil {
 		return errors.Wrapf(err, "failed to determine ownership")
 	}
@@ -428,7 +428,7 @@ func (h *ActionHandler) ProjectCreateRun(ctx context.Context, projectRef, branch
 		return util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project %q", projectRef))
 	}
 
-	isProjectOwner, err := h.IsProjectOwner(ctx, p.OwnerType, p.OwnerID)
+	isProjectOwner, err := h.IsAuthUserProjectOwner(ctx, p.OwnerType, p.OwnerID)
 	if err != nil {
 		return errors.Wrapf(err, "failed to determine ownership")
 	}
@@ -595,7 +595,7 @@ func (h *ActionHandler) RefreshRemoteRepositoryInfo(ctx context.Context, project
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project %q", projectRef))
 	}
 
-	isProjectOwner, err := h.IsProjectOwner(ctx, p.OwnerType, p.OwnerID)
+	isProjectOwner, err := h.IsAuthUserProjectOwner(ctx, p.OwnerType, p.OwnerID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}

--- a/internal/services/gateway/action/project.go
+++ b/internal/services/gateway/action/project.go
@@ -36,12 +36,13 @@ func (h *ActionHandler) GetProject(ctx context.Context, projectRef string) (*csa
 		return nil, errors.WithStack(err)
 	}
 
+	if project.GlobalVisibility == cstypes.VisibilityPublic {
+		return project, nil
+	}
+
 	isMember, err := h.IsAuthUserMember(ctx, project.OwnerType, project.OwnerID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine ownership")
-	}
-	if project.GlobalVisibility == cstypes.VisibilityPublic {
-		return project, nil
 	}
 	if !isMember {
 		return nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))

--- a/internal/services/gateway/action/projectgroup.go
+++ b/internal/services/gateway/action/projectgroup.go
@@ -66,7 +66,7 @@ func (h *ActionHandler) CreateProjectGroup(ctx context.Context, req *CreateProje
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project group %q", req.ParentRef))
 	}
 
-	isProjectOwner, err := h.IsProjectOwner(ctx, pg.OwnerType, pg.OwnerID)
+	isProjectOwner, err := h.IsAuthUserProjectOwner(ctx, pg.OwnerType, pg.OwnerID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
@@ -117,7 +117,7 @@ func (h *ActionHandler) UpdateProjectGroup(ctx context.Context, projectGroupRef 
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project group %q", projectGroupRef))
 	}
 
-	isProjectOwner, err := h.IsProjectOwner(ctx, pg.OwnerType, pg.OwnerID)
+	isProjectOwner, err := h.IsAuthUserProjectOwner(ctx, pg.OwnerType, pg.OwnerID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
@@ -157,7 +157,7 @@ func (h *ActionHandler) DeleteProjectGroup(ctx context.Context, projectRef strin
 		return util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project %q", projectRef))
 	}
 
-	isProjectOwner, err := h.IsProjectOwner(ctx, p.OwnerType, p.OwnerID)
+	isProjectOwner, err := h.IsAuthUserProjectOwner(ctx, p.OwnerType, p.OwnerID)
 	if err != nil {
 		return errors.Wrapf(err, "failed to determine ownership")
 	}

--- a/internal/services/gateway/action/projectgroup.go
+++ b/internal/services/gateway/action/projectgroup.go
@@ -30,6 +30,19 @@ func (h *ActionHandler) GetProjectGroup(ctx context.Context, projectGroupRef str
 	if err != nil {
 		return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
 	}
+
+	if projectGroup.GlobalVisibility == cstypes.VisibilityPublic {
+		return projectGroup, nil
+	}
+
+	isMember, err := h.IsAuthUserMember(ctx, projectGroup.OwnerType, projectGroup.OwnerID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to determine ownership")
+	}
+	if !isMember {
+		return nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
+	}
+
 	return projectGroup, nil
 }
 

--- a/internal/services/gateway/action/run.go
+++ b/internal/services/gateway/action/run.go
@@ -74,7 +74,7 @@ var (
 )
 
 func (h *ActionHandler) GetRun(ctx context.Context, groupType scommon.GroupType, ref string, runNumber uint64) (*rsapitypes.RunResponse, error) {
-	canGetRun, groupID, err := h.CanGetRun(ctx, groupType, ref)
+	canGetRun, groupID, err := h.CanAuthUserGetRun(ctx, groupType, ref)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine permissions")
 	}
@@ -104,7 +104,7 @@ type GetRunsRequest struct {
 }
 
 func (h *ActionHandler) GetRuns(ctx context.Context, req *GetRunsRequest) (*rsapitypes.GetRunsResponse, error) {
-	canGetRun, groupID, err := h.CanGetRun(ctx, req.GroupType, req.Ref)
+	canGetRun, groupID, err := h.CanAuthUserGetRun(ctx, req.GroupType, req.Ref)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine permissions")
 	}
@@ -134,7 +134,7 @@ type GetLogsRequest struct {
 }
 
 func (h *ActionHandler) GetLogs(ctx context.Context, req *GetLogsRequest) (*http.Response, error) {
-	canGetRun, groupID, err := h.CanGetRun(ctx, req.GroupType, req.Ref)
+	canGetRun, groupID, err := h.CanAuthUserGetRun(ctx, req.GroupType, req.Ref)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine permissions")
 	}
@@ -167,7 +167,7 @@ type DeleteLogsRequest struct {
 }
 
 func (h *ActionHandler) DeleteLogs(ctx context.Context, req *DeleteLogsRequest) error {
-	canDoRunActions, groupID, err := h.CanDoRunActions(ctx, req.GroupType, req.Ref)
+	canDoRunActions, groupID, err := h.CanAuthUserDoRunActions(ctx, req.GroupType, req.Ref)
 	if err != nil {
 		return errors.Wrapf(err, "failed to determine permissions")
 	}
@@ -208,7 +208,7 @@ type RunActionsRequest struct {
 }
 
 func (h *ActionHandler) RunAction(ctx context.Context, req *RunActionsRequest) (*rsapitypes.RunResponse, error) {
-	canDoRunActions, groupID, err := h.CanDoRunActions(ctx, req.GroupType, req.Ref)
+	canDoRunActions, groupID, err := h.CanAuthUserDoRunActions(ctx, req.GroupType, req.Ref)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine permissions")
 	}
@@ -278,7 +278,7 @@ type RunTaskActionsRequest struct {
 }
 
 func (h *ActionHandler) RunTaskAction(ctx context.Context, req *RunTaskActionsRequest) error {
-	canDoRunAction, groupID, err := h.CanDoRunActions(ctx, req.GroupType, req.Ref)
+	canDoRunAction, groupID, err := h.CanAuthUserDoRunActions(ctx, req.GroupType, req.Ref)
 	if err != nil {
 		return errors.Wrapf(err, "failed to determine permissions")
 	}

--- a/internal/services/gateway/action/secret.go
+++ b/internal/services/gateway/action/secret.go
@@ -71,7 +71,7 @@ type CreateSecretRequest struct {
 }
 
 func (h *ActionHandler) CreateSecret(ctx context.Context, req *CreateSecretRequest) (*csapitypes.Secret, error) {
-	isVariableOwner, err := h.IsVariableOwner(ctx, req.ParentType, req.ParentRef)
+	isVariableOwner, err := h.IsAuthUserVariableOwner(ctx, req.ParentType, req.ParentRef)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
@@ -125,7 +125,7 @@ type UpdateSecretRequest struct {
 }
 
 func (h *ActionHandler) UpdateSecret(ctx context.Context, req *UpdateSecretRequest) (*csapitypes.Secret, error) {
-	isVariableOwner, err := h.IsVariableOwner(ctx, req.ParentType, req.ParentRef)
+	isVariableOwner, err := h.IsAuthUserVariableOwner(ctx, req.ParentType, req.ParentRef)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
@@ -161,7 +161,7 @@ func (h *ActionHandler) UpdateSecret(ctx context.Context, req *UpdateSecretReque
 }
 
 func (h *ActionHandler) DeleteSecret(ctx context.Context, parentType cstypes.ObjectKind, parentRef, name string) error {
-	isVariableOwner, err := h.IsVariableOwner(ctx, parentType, parentRef)
+	isVariableOwner, err := h.IsAuthUserVariableOwner(ctx, parentType, parentRef)
 	if err != nil {
 		return errors.Wrapf(err, "failed to determine ownership")
 	}

--- a/internal/services/gateway/action/variable.go
+++ b/internal/services/gateway/action/variable.go
@@ -78,7 +78,7 @@ type CreateVariableRequest struct {
 }
 
 func (h *ActionHandler) CreateVariable(ctx context.Context, req *CreateVariableRequest) (*csapitypes.Variable, []*csapitypes.Secret, error) {
-	isVariableOwner, err := h.IsVariableOwner(ctx, req.ParentType, req.ParentRef)
+	isVariableOwner, err := h.IsAuthUserVariableOwner(ctx, req.ParentType, req.ParentRef)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to determine ownership")
 	}
@@ -145,7 +145,7 @@ type UpdateVariableRequest struct {
 }
 
 func (h *ActionHandler) UpdateVariable(ctx context.Context, req *UpdateVariableRequest) (*csapitypes.Variable, []*csapitypes.Secret, error) {
-	isVariableOwner, err := h.IsVariableOwner(ctx, req.ParentType, req.ParentRef)
+	isVariableOwner, err := h.IsAuthUserVariableOwner(ctx, req.ParentType, req.ParentRef)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to determine ownership")
 	}
@@ -201,7 +201,7 @@ func (h *ActionHandler) UpdateVariable(ctx context.Context, req *UpdateVariableR
 }
 
 func (h *ActionHandler) DeleteVariable(ctx context.Context, parentType cstypes.ObjectKind, parentRef, name string) error {
-	isVariableOwner, err := h.IsVariableOwner(ctx, parentType, parentRef)
+	isVariableOwner, err := h.IsAuthUserVariableOwner(ctx, parentType, parentRef)
 	if err != nil {
 		return errors.Wrapf(err, "failed to determine ownership")
 	}

--- a/services/gateway/client/client.go
+++ b/services/gateway/client/client.go
@@ -167,24 +167,24 @@ func (c *Client) GetProject(ctx context.Context, projectRef string) (*gwapitypes
 	return project, resp, errors.WithStack(err)
 }
 
-func (c *Client) CreateProjectGroup(ctx context.Context, req *gwapitypes.CreateProjectGroupRequest) (*gwapitypes.ProjectResponse, *Response, error) {
+func (c *Client) CreateProjectGroup(ctx context.Context, req *gwapitypes.CreateProjectGroupRequest) (*gwapitypes.ProjectGroupResponse, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
 
-	projectGroup := new(gwapitypes.ProjectResponse)
+	projectGroup := new(gwapitypes.ProjectGroupResponse)
 	resp, err := c.getParsedResponse(ctx, "POST", "/projectgroups", nil, jsonContent, bytes.NewReader(reqj), projectGroup)
 	return projectGroup, resp, errors.WithStack(err)
 }
 
-func (c *Client) UpdateProjectGroup(ctx context.Context, projectGroupRef string, req *gwapitypes.UpdateProjectGroupRequest) (*gwapitypes.ProjectResponse, *Response, error) {
+func (c *Client) UpdateProjectGroup(ctx context.Context, projectGroupRef string, req *gwapitypes.UpdateProjectGroupRequest) (*gwapitypes.ProjectGroupResponse, *Response, error) {
 	reqj, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
 
-	projectGroup := new(gwapitypes.ProjectResponse)
+	projectGroup := new(gwapitypes.ProjectGroupResponse)
 	resp, err := c.getParsedResponse(ctx, "PUT", path.Join("/projectgroups", url.PathEscape(projectGroupRef)), nil, jsonContent, bytes.NewReader(reqj), projectGroup)
 	return projectGroup, resp, errors.WithStack(err)
 }


### PR DESCRIPTION
Like already done for projects, check if user can see the org/pg by
checking the visibility and user membership.

Add various integration tests to check multiple org/pg/project
visibility combinations.