### PR TITLE
db: defer sqlite foreign keys during migration

### DIFF
--- a/internal/migration/destination/configstore/db/db.go
+++ b/internal/migration/destination/configstore/db/db.go
@@ -33,6 +33,10 @@ func (d *DB) DBType() sql.Type {
 	return d.sdb.Type()
 }
 
+func (d *DB) DB() *sql.DB {
+	return d.sdb
+}
+
 func (d *DB) Do(ctx context.Context, f func(tx *sql.Tx) error) error {
 	return errors.WithStack(d.sdb.Do(ctx, f))
 }

--- a/internal/migration/destination/runservice/db/db.go
+++ b/internal/migration/destination/runservice/db/db.go
@@ -31,6 +31,10 @@ func (d *DB) DBType() sql.Type {
 	return d.sdb.Type()
 }
 
+func (d *DB) DB() *sql.DB {
+	return d.sdb
+}
+
 func (d *DB) Do(ctx context.Context, f func(tx *sql.Tx) error) error {
 	return errors.WithStack(d.sdb.Do(ctx, f))
 }

--- a/internal/services/configstore/db/db.go
+++ b/internal/services/configstore/db/db.go
@@ -35,6 +35,10 @@ func (d *DB) DBType() sql.Type {
 	return d.sdb.Type()
 }
 
+func (d *DB) DB() *sql.DB {
+	return d.sdb
+}
+
 func (d *DB) Do(ctx context.Context, f func(tx *sql.Tx) error) error {
 	return errors.WithStack(d.sdb.Do(ctx, f))
 }

--- a/internal/services/configstore/db/migrate.go
+++ b/internal/services/configstore/db/migrate.go
@@ -71,13 +71,9 @@ func (d *DB) migrateV2(tx *sql.Tx) error {
 		stmts = ddlSqlite3
 	}
 
-	switch d.DBType() {
-	case sql.Postgres:
+	if d.sdb.Type() == sql.Postgres {
+		// defer constraints for postgres
 		if _, err := tx.Exec("SET CONSTRAINTS ALL DEFERRED"); err != nil {
-			return errors.WithStack(err)
-		}
-	case sql.Sqlite3:
-		if _, err := tx.Exec("PRAGMA defer_foreign_keys = ON"); err != nil {
 			return errors.WithStack(err)
 		}
 	}

--- a/internal/services/notification/db/db.go
+++ b/internal/services/notification/db/db.go
@@ -32,6 +32,10 @@ func (d *DB) DBType() sql.Type {
 	return d.sdb.Type()
 }
 
+func (d *DB) DB() *sql.DB {
+	return d.sdb
+}
+
 func (d *DB) Do(ctx context.Context, f func(tx *sql.Tx) error) error {
 	return errors.WithStack(d.sdb.Do(ctx, f))
 }

--- a/internal/services/runservice/db/db.go
+++ b/internal/services/runservice/db/db.go
@@ -33,6 +33,10 @@ func (d *DB) DBType() sql.Type {
 	return d.sdb.Type()
 }
 
+func (d *DB) DB() *sql.DB {
+	return d.sdb
+}
+
 func (d *DB) Do(ctx context.Context, f func(tx *sql.Tx) error) error {
 	return errors.WithStack(d.sdb.Do(ctx, f))
 }

--- a/internal/sqlg/manager/manager.go
+++ b/internal/sqlg/manager/manager.go
@@ -37,6 +37,7 @@ var (
 
 type DB interface {
 	DBType() sql.Type
+	DB() *sql.DB
 	Version() uint
 
 	Do(ctx context.Context, f func(tx *sql.Tx) error) error

--- a/internal/sqlg/manager/migrate.go
+++ b/internal/sqlg/manager/migrate.go
@@ -47,6 +47,16 @@ func (m *DBManager) MigrateToVersion(ctx context.Context, newVersion uint) error
 	migrateFuncs := m.d.MigrateFuncs()
 	for nextVersion := curVersion + 1; nextVersion <= newVersion; nextVersion++ {
 		m.log.Info().Msgf("doing db migration from version %d to version %d", curVersion, nextVersion)
+
+		if m.d.DBType() == sql.Sqlite3 {
+			// disable foreign keys (must be done outside a transaction)
+			// needed for alter table cases. See the 12 steps procedure provided in
+			// https://www.sqlite.org/lang_altertable.html#making_other_kinds_of_table_schema_changes
+			if _, err := m.d.DB().ExecContext(ctx, "PRAGMA foreign_keys = OFF"); err != nil {
+				return errors.WithStack(err)
+			}
+		}
+
 		err := m.d.Do(ctx, func(tx *sql.Tx) error {
 			if err := migrateFuncs[nextVersion](tx); err != nil {
 				return errors.Wrapf(err, "failed to migrate to version %d", nextVersion)
@@ -56,10 +66,32 @@ func (m *DBManager) MigrateToVersion(ctx context.Context, newVersion uint) error
 				return errors.WithStack(err)
 			}
 
+			if m.d.DBType() == sql.Sqlite3 {
+				// check sqlite foreign_keys constraints since they were disabled
+				rows, err := tx.Query("PRAGMA foreign_key_check")
+				if err != nil {
+					return errors.WithStack(err)
+				}
+				if rows.Next() {
+					return errors.Errorf("foreign key constraints violations")
+				}
+				if rows.Err() != nil {
+					return errors.WithStack(err)
+				}
+				rows.Close()
+			}
+
 			return nil
 		})
 		if err != nil {
 			return errors.WithStack(err)
+		}
+
+		if m.d.DBType() == sql.Sqlite3 {
+			// re enable foreign keys (must be done outside a transaction)
+			if _, err := m.d.DB().ExecContext(ctx, "PRAGMA foreign_keys = ON"); err != nil {
+				return errors.WithStack(err)
+			}
 		}
 	}
 

--- a/internal/sqlg/sql/db.go
+++ b/internal/sqlg/sql/db.go
@@ -105,6 +105,11 @@ func (db *DB) Close() error {
 	return errors.WithStack(db.db.Close())
 }
 
+func (db *DB) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	r, err := db.db.ExecContext(ctx, query, db.data.translateArgs(args)...)
+	return r, errors.WithStack(err)
+}
+
 func (db *DB) Conn(ctx context.Context) (*sql.Conn, error) {
 	c, err := db.db.Conn(ctx)
 	return c, errors.WithStack(err)


### PR DESCRIPTION
Sqlite provides only limited alter tables capabilities, complex things must be done by creating a new table and migrating the data. Things becomes more complex when other tables references the table being altered.

For doing this the documentation provides a list of steps https://www.sqlite.org/lang_altertable.html#making_other_kinds_of_table_schema_changes The first stable is disabling foreign keys, but this must be done outside a transaction.

This patch adds this to the migration logic: disable foreign keys outside transaction, check foreign keys before committing the transaction and then re enable them outside the transaction.