### PR TITLE
gateway: add api to get commit status deliveries

### DIFF
--- a/internal/services/gateway/action/commitstatusdelivery.go
+++ b/internal/services/gateway/action/commitstatusdelivery.go
@@ -1,0 +1,84 @@
+// Copyright 2023 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"context"
+
+	"github.com/sorintlab/errors"
+
+	"agola.io/agola/internal/util"
+	"agola.io/agola/services/notification/client"
+	nstypes "agola.io/agola/services/notification/types"
+)
+
+type GetProjectCommitStatusDeliveriesRequest struct {
+	ProjectRef           string
+	DeliveryStatusFilter []string
+
+	Cursor string
+
+	Limit         int
+	SortDirection SortDirection
+}
+
+type GetProjectCommitStatusDeliveriesResponse struct {
+	CommitStatusDeliveries []*nstypes.CommitStatusDelivery
+	Cursor                 string
+}
+
+func (h *ActionHandler) GetProjectCommitStatusDeliveries(ctx context.Context, req *GetProjectCommitStatusDeliveriesRequest) (*GetProjectCommitStatusDeliveriesResponse, error) {
+	project, _, err := h.configstoreClient.GetProject(ctx, req.ProjectRef)
+	if err != nil {
+		return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
+	}
+	isUserOwner, err := h.IsAuthUserProjectOwner(ctx, project.OwnerType, project.OwnerID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to determine permissions")
+	}
+	if !isUserOwner {
+		return nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
+	}
+
+	inCursor := &StartSequenceCursor{}
+	sortDirection := req.SortDirection
+	if req.Cursor != "" {
+		if err := UnmarshalCursor(req.Cursor, inCursor); err != nil {
+			return nil, errors.WithStack(err)
+		}
+		sortDirection = inCursor.SortDirection
+	}
+
+	commitStatusDeliveries, resp, err := h.notificationClient.GetProjectCommitStatusDeliveries(ctx, project.ID, &client.GetProjectCommitStatusDeliveriesOptions{ListOptions: &client.ListOptions{Limit: req.Limit, SortDirection: nstypes.SortDirection(sortDirection)}, StartSequence: inCursor.StartSequence, DeliveryStatusFilter: req.DeliveryStatusFilter})
+	if err != nil {
+		return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
+	}
+
+	var outCursor string
+	if resp.HasMore && len(commitStatusDeliveries) > 0 {
+		lastCommitStatusDeliverySequence := commitStatusDeliveries[len(commitStatusDeliveries)-1].Sequence
+		outCursor, err = MarshalCursor(&StartSequenceCursor{StartSequence: lastCommitStatusDeliverySequence})
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+	}
+
+	res := &GetProjectCommitStatusDeliveriesResponse{
+		CommitStatusDeliveries: commitStatusDeliveries,
+		Cursor:                 outCursor,
+	}
+
+	return res, nil
+}

--- a/internal/services/gateway/api/commitstatusdelivery.go
+++ b/internal/services/gateway/api/commitstatusdelivery.go
@@ -1,0 +1,96 @@
+// Copyright 2023 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/rs/zerolog"
+	"github.com/sorintlab/errors"
+
+	"agola.io/agola/internal/services/gateway/action"
+	util "agola.io/agola/internal/util"
+	gwapitypes "agola.io/agola/services/gateway/api/types"
+	nstypes "agola.io/agola/services/notification/types"
+)
+
+func createCommitStatusDeliveryResponse(r *nstypes.CommitStatusDelivery) *gwapitypes.CommitStatusDeliveryResponse {
+	commitStatusDelivery := &gwapitypes.CommitStatusDeliveryResponse{
+		ID:             r.ID,
+		Sequence:       r.Sequence,
+		DeliveryStatus: gwapitypes.DeliveryStatus(r.DeliveryStatus),
+		DeliveredAt:    r.DeliveredAt,
+	}
+	return commitStatusDelivery
+}
+
+type ProjectCommitStatusDeliveries struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewProjectCommitStatusDeliveriesHandler(log zerolog.Logger, ah *action.ActionHandler) *ProjectCommitStatusDeliveries {
+	return &ProjectCommitStatusDeliveries{log: log, ah: ah}
+}
+
+func (h *ProjectCommitStatusDeliveries) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	res, err := h.do(w, r)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+
+	if err := util.HTTPResponse(w, http.StatusOK, res); err != nil {
+		h.log.Err(err).Send()
+	}
+}
+
+func (h *ProjectCommitStatusDeliveries) do(w http.ResponseWriter, r *http.Request) ([]*gwapitypes.CommitStatusDeliveryResponse, error) {
+	ctx := r.Context()
+	query := r.URL.Query()
+
+	vars := mux.Vars(r)
+	projectRef := vars["projectref"]
+
+	deliveryStatusFilter := query["deliverystatus"]
+
+	ropts, err := parseRequestOptions(r)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	areq := &action.GetProjectCommitStatusDeliveriesRequest{
+		ProjectRef: projectRef,
+
+		DeliveryStatusFilter: deliveryStatusFilter,
+		Cursor:               ropts.Cursor,
+		Limit:                ropts.Limit,
+		SortDirection:        action.SortDirection(ropts.SortDirection),
+	}
+	ares, err := h.ah.GetProjectCommitStatusDeliveries(ctx, areq)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	commitStatusDeliveries := make([]*gwapitypes.CommitStatusDeliveryResponse, len(ares.CommitStatusDeliveries))
+	for i, r := range ares.CommitStatusDeliveries {
+		commitStatusDeliveries[i] = createCommitStatusDeliveryResponse(r)
+	}
+
+	addCursorHeader(w, ares.Cursor)
+
+	return commitStatusDeliveries, nil
+}

--- a/internal/services/gateway/gateway.go
+++ b/internal/services/gateway/gateway.go
@@ -201,6 +201,7 @@ func (g *Gateway) Run(ctx context.Context) error {
 	refreshRemoteRepositoryInfoHandler := api.NewRefreshRemoteRepositoryInfoHandler(g.log, g.ah)
 	projectRunWebhookDeliveriesHandler := api.NewProjectRunWebhookDeliveriesHandler(g.log, g.ah)
 	projectRunWebhookRedeliveryHandler := api.NewProjectRunWebhookRedeliveryHandler(g.log, g.ah)
+	projectCommitStatusDeliveriesHandler := api.NewProjectCommitStatusDeliveriesHandler(g.log, g.ah)
 
 	secretHandler := api.NewSecretHandler(g.log, g.ah)
 	createSecretHandler := api.NewCreateSecretHandler(g.log, g.ah)
@@ -322,6 +323,7 @@ func (g *Gateway) Run(ctx context.Context) error {
 	apirouter.Handle("/projects/{projectref}/refreshremoterepo", authForcedHandler(refreshRemoteRepositoryInfoHandler)).Methods("POST")
 	apirouter.Handle("/projects/{projectref}/runwebhookdeliveries", authForcedHandler(projectRunWebhookDeliveriesHandler)).Methods("GET")
 	apirouter.Handle("/projects/{projectref}/runwebhookdeliveries/{runwebhookdeliveryid}/redelivery", authForcedHandler(projectRunWebhookRedeliveryHandler)).Methods("PUT")
+	apirouter.Handle("/projects/{projectref}/commitstatusdeliveries", authForcedHandler(projectCommitStatusDeliveriesHandler)).Methods("GET")
 
 	apirouter.Handle("/projectgroups/{projectgroupref}/secrets", authForcedHandler(secretHandler)).Methods("GET")
 	apirouter.Handle("/projects/{projectref}/secrets", authForcedHandler(secretHandler)).Methods("GET")

--- a/internal/services/notification/action/commitstatusdelivery.go
+++ b/internal/services/notification/action/commitstatusdelivery.go
@@ -1,0 +1,74 @@
+// Copyright 2023 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"context"
+
+	"github.com/sorintlab/errors"
+
+	"agola.io/agola/internal/sqlg/sql"
+	"agola.io/agola/services/notification/types"
+)
+
+type GetProjectCommitStatusDeliveriesRequest struct {
+	ProjectID            string
+	DeliveryStatusFilter []types.DeliveryStatus
+
+	StartSequence uint64
+
+	Limit         int
+	SortDirection types.SortDirection
+}
+
+type GetProjectCommitStatusDeliveriesResponse struct {
+	CommitStatusDeliveries []*types.CommitStatusDelivery
+
+	HasMore bool
+}
+
+func (h *ActionHandler) GetProjectCommitStatusDeliveries(ctx context.Context, req *GetProjectCommitStatusDeliveriesRequest) (*GetProjectCommitStatusDeliveriesResponse, error) {
+	limit := req.Limit
+	if limit > 0 {
+		limit += 1
+	}
+
+	var commitStatusDeliveries []*types.CommitStatusDelivery
+	err := h.d.Do(ctx, func(tx *sql.Tx) error {
+		var err error
+		commitStatusDeliveries, err = h.d.GetProjectCommitStatusDeliveriesAfterSequenceByProjectID(tx, req.StartSequence, req.ProjectID, req.DeliveryStatusFilter, limit, req.SortDirection)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	var hasMore bool
+	if req.Limit > 0 {
+		hasMore = len(commitStatusDeliveries) > req.Limit
+		if hasMore {
+			commitStatusDeliveries = commitStatusDeliveries[0:req.Limit]
+		}
+	}
+
+	return &GetProjectCommitStatusDeliveriesResponse{
+		CommitStatusDeliveries: commitStatusDeliveries,
+		HasMore:                hasMore,
+	}, nil
+}

--- a/internal/services/notification/api/commitstatusdelivery.go
+++ b/internal/services/notification/api/commitstatusdelivery.go
@@ -1,0 +1,91 @@
+// Copyright 2023 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+
+	"agola.io/agola/internal/services/notification/action"
+	"agola.io/agola/internal/util"
+	"agola.io/agola/services/notification/types"
+)
+
+const (
+	DefaultCommitStatusDeliveriesLimit = 10
+	MaxCommitStatusDeliveriesLimit     = 20
+)
+
+type CommitStatusDeliveriesHandler struct {
+	log zerolog.Logger
+	ah  *action.ActionHandler
+}
+
+func NewCommitStatusDeliveriesHandler(log zerolog.Logger, ah *action.ActionHandler) *CommitStatusDeliveriesHandler {
+	return &CommitStatusDeliveriesHandler{log: log, ah: ah}
+}
+
+func (h *CommitStatusDeliveriesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	res, err := h.do(w, r)
+	if util.HTTPError(w, err) {
+		h.log.Err(err).Send()
+		return
+	}
+
+	if err := util.HTTPResponse(w, http.StatusOK, res); err != nil {
+		h.log.Err(err).Send()
+	}
+}
+
+func (h *CommitStatusDeliveriesHandler) do(w http.ResponseWriter, r *http.Request) ([]*types.CommitStatusDelivery, error) {
+	ctx := r.Context()
+	query := r.URL.Query()
+
+	vars := mux.Vars(r)
+	projectID := vars["projectid"]
+
+	deliveryStatusFilter, err := types.DeliveryStatusFromStringSlice(query["deliverystatus"])
+	if err != nil {
+		return nil, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "wrong deliverystatus"))
+	}
+
+	startSequenceStr := query.Get("startsequence")
+	var startSequence uint64
+	if startSequenceStr != "" {
+		var err error
+		startSequence, err = strconv.ParseUint(startSequenceStr, 10, 64)
+		if err != nil {
+			return nil, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse startsequence"))
+		}
+	}
+
+	ropts, err := parseRequestOptions(r)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	ares, err := h.ah.GetProjectCommitStatusDeliveries(ctx, &action.GetProjectCommitStatusDeliveriesRequest{ProjectID: projectID, StartSequence: startSequence, DeliveryStatusFilter: deliveryStatusFilter, Limit: ropts.Limit, SortDirection: ropts.SortDirection})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	addHasMoreHeader(w, ares.HasMore)
+
+	return ares.CommitStatusDeliveries, nil
+}

--- a/internal/services/notification/commitstatusdelivery.go
+++ b/internal/services/notification/commitstatusdelivery.go
@@ -71,7 +71,7 @@ func (n *NotificationService) commitStatusDeliveriesHandler(ctx context.Context)
 
 		err := n.d.Do(ctx, func(tx *sql.Tx) error {
 			var err error
-			commitStatusDeliveries, err = n.d.GetCommitStatusDeliveriesAfterSequence(tx, curCommitStatusDeliverySequence, types.DeliveryStatusNotDelivered, MaxCommitStatusDeliveriesQueryLimit)
+			commitStatusDeliveries, err = n.d.GetProjectCommitStatusDeliveriesAfterSequenceByProjectID(tx, curCommitStatusDeliverySequence, "", []types.DeliveryStatus{types.DeliveryStatusNotDelivered}, MaxCommitStatusDeliveriesQueryLimit, types.SortDirectionAsc)
 			if err != nil {
 				return errors.WithStack(err)
 			}

--- a/internal/services/notification/notification.go
+++ b/internal/services/notification/notification.go
@@ -122,6 +122,7 @@ func NewNotificationService(ctx context.Context, log zerolog.Logger, gc *config.
 func (n *NotificationService) setupDefaultRouter() http.Handler {
 	runWebhookDeliveriesHandler := api.NewRunWebhookDeliveriesHandler(n.log, n.ah)
 	runWebhookReliveryHandler := api.NewRunWebhookRedeliveryHandler(n.log, n.ah)
+	commitStatusDeliveriesHandler := api.NewCommitStatusDeliveriesHandler(n.log, n.ah)
 
 	authHandler := handlers.NewInternalAuthChecker(n.log, n.c.APIToken)
 
@@ -136,6 +137,8 @@ func (n *NotificationService) setupDefaultRouter() http.Handler {
 	apirouter.Handle("/projects/{projectid}/runwebhookdeliveries", runWebhookDeliveriesHandler).Methods("GET")
 
 	apirouter.Handle("/projects/{projectid}/runwebhookdeliveries/{runwebhookdeliveryid}/redelivery", runWebhookReliveryHandler).Methods("PUT")
+
+	apirouter.Handle("/projects/{projectid}/commitstatusdeliveries", commitStatusDeliveriesHandler).Methods("GET")
 
 	mainrouter := mux.NewRouter().UseEncodedPath().SkipClean(true)
 	mainrouter.PathPrefix("/").Handler(router)

--- a/services/gateway/api/types/commitstatusdelivery.go
+++ b/services/gateway/api/types/commitstatusdelivery.go
@@ -1,0 +1,24 @@
+// Copyright 2023 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "time"
+
+type CommitStatusDeliveryResponse struct {
+	ID             string         `json:"id"`
+	Sequence       uint64         `json:"sequence"`
+	DeliveryStatus DeliveryStatus `json:"delivery_status"`
+	DeliveredAt    *time.Time     `json:"delivered_at"`
+}

--- a/services/gateway/client/client.go
+++ b/services/gateway/client/client.go
@@ -828,3 +828,16 @@ func (c *Client) GetProjectRunWebhookDeliveries(ctx context.Context, projectRef 
 func (c *Client) ProjectRunWebhookRedelivery(ctx context.Context, projectRef string, runWebhookDeliveryID string) (*Response, error) {
 	return c.getResponse(ctx, "PUT", fmt.Sprintf("/projects/%s/runwebhookdeliveries/%s/redelivery", projectRef, runWebhookDeliveryID), nil, jsonContent, nil)
 }
+
+func (c *Client) GetProjectCommitStatusDeliveries(ctx context.Context, projectRef string, deliveryStatusFilter []string, opts *ListOptions) ([]*gwapitypes.CommitStatusDeliveryResponse, *Response, error) {
+	q := url.Values{}
+	opts.Add(q)
+
+	for _, deliveryStatus := range deliveryStatusFilter {
+		q.Add("deliverystatus", deliveryStatus)
+	}
+
+	commitStatusDeliveries := []*gwapitypes.CommitStatusDeliveryResponse{}
+	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/projects/%s/commitstatusdeliveries", url.PathEscape(projectRef)), q, common.JSONContent, nil, &commitStatusDeliveries)
+	return commitStatusDeliveries, resp, errors.WithStack(err)
+}

--- a/services/notification/client/client.go
+++ b/services/notification/client/client.go
@@ -144,3 +144,31 @@ func (c *Client) RunWebhookRedelivery(ctx context.Context, projectID, runWebhook
 	resp, err := c.GetResponse(ctx, "PUT", fmt.Sprintf("/projects/%s/runwebhookdeliveries/%s/redelivery", projectID, runWebhookDeliveryID), nil, -1, common.JSONContent, nil)
 	return resp, errors.WithStack(err)
 }
+
+type GetProjectCommitStatusDeliveriesOptions struct {
+	*ListOptions
+
+	StartSequence        uint64
+	DeliveryStatusFilter []string
+}
+
+func (o *GetProjectCommitStatusDeliveriesOptions) Add(q url.Values) {
+	o.ListOptions.Add(q)
+
+	if o.StartSequence > 0 {
+		q.Add("startsequence", strconv.FormatUint(o.StartSequence, 10))
+	}
+}
+
+func (c *Client) GetProjectCommitStatusDeliveries(ctx context.Context, projectID string, opts *GetProjectCommitStatusDeliveriesOptions) ([]*types.CommitStatusDelivery, *Response, error) {
+	q := url.Values{}
+	opts.Add(q)
+
+	for _, deliveryStatus := range opts.DeliveryStatusFilter {
+		q.Add("deliverystatus", deliveryStatus)
+	}
+
+	commitStatusDeliveries := []*types.CommitStatusDelivery{}
+	resp, err := c.GetParsedResponse(ctx, "GET", fmt.Sprintf("/projects/%s/commitstatusdeliveries", projectID), q, common.JSONContent, nil, &commitStatusDeliveries)
+	return commitStatusDeliveries, resp, errors.WithStack(err)
+}


### PR DESCRIPTION
This patch adds an api to get commit status deliveries by project ref.