### PR TITLE
testutil: add detailed errors for zerolog output in tests

### DIFF
--- a/internal/testutil/log.go
+++ b/internal/testutil/log.go
@@ -1,34 +1,29 @@
 package testutil
 
 import (
-	"bytes"
+	"os"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/rs/zerolog"
+	"github.com/sorintlab/errors"
 )
 
-// testingWriter is a WriteSyncer that writes to the given testing.TB.
-type testingWriter struct {
-	t *testing.T
-}
-
-func NewTestingWriter(t *testing.T) *testingWriter {
-	return &testingWriter{t: t}
-}
-
-func (w *testingWriter) Write(p []byte) (n int, err error) {
-	n = len(p)
-
-	// Strip trailing newline because t.Log always adds one.
-	p = bytes.TrimRight(p, "\n")
-
-	// Note: t.Log is safe for concurrent use.
-	w.t.Logf("%s", p)
-
-	return n, nil
-}
-
 func NewLogger(t *testing.T) zerolog.Logger {
-	return zerolog.New(zerolog.ConsoleWriter{Out: NewTestingWriter(t), TimeFormat: time.RFC3339Nano}).With().Timestamp().Caller().Logger().Level(zerolog.InfoLevel)
+	detailedErrors, _ := strconv.ParseBool(os.Getenv("DETAILED_ERRORS"))
+
+	if detailedErrors {
+		zerolog.ErrorMarshalFunc = errors.ErrorMarshalFunc
+	}
+
+	cw := zerolog.ConsoleWriter{
+		Out:                 zerolog.TestWriter{T: t, Frame: 6},
+		TimeFormat:          time.RFC3339Nano,
+		FormatErrFieldValue: errors.FormatErrFieldValue,
+	}
+
+	zerolog.TimeFieldFormat = time.RFC3339Nano
+
+	return zerolog.New(cw).With().Timestamp().Stack().Caller().Logger().Level(zerolog.InfoLevel).Output(cw)
 }


### PR DESCRIPTION
Read from the DETAILED_ERRORS env var and if true enable detailed errors for zerolog logging in tests.

Also use zerolog provided TestWriter.