### PR TITLE
testutil: Add NilError helper to log detailed test errors

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sorintlab/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"agola.io/agola/internal/testutil"
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/types"
 )
@@ -604,9 +605,8 @@ func TestParseOutput(t *testing.T) {
 			t.Parallel()
 
 			out, err := ParseConfig([]byte(tt.in), ConfigFormatJSON, &ConfigContext{})
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			if diff := cmp.Diff(tt.out, out, cmp.Comparer(func(x, y *resource.Quantity) bool {
 				if x == nil && y == nil {
 					return true

--- a/internal/objectstorage/objectstorage_test.go
+++ b/internal/objectstorage/objectstorage_test.go
@@ -23,6 +23,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"agola.io/agola/internal/testutil"
 )
 
 func setupPosix(t *testing.T, dir string) (*PosixStorage, error) {
@@ -49,17 +51,13 @@ func TestList(t *testing.T) {
 	dir := t.TempDir()
 
 	ps, err := setupPosix(t, dir)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	pfs, err := setupPosixFlat(t, dir)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	s3s, err := setupS3(t, dir)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	type listop struct {
 		prefix    string
@@ -288,7 +286,7 @@ func TestList(t *testing.T) {
 						paths = append(paths, object.Path)
 					}
 					if !reflect.DeepEqual(op.expected, paths) {
-						t.Errorf("%s %d-%d expected paths %v got %v", sname, i, j, op.expected, paths)
+						t.Fatalf("%s %d-%d expected paths %v got %v", sname, i, j, op.expected, paths)
 					}
 				}
 			})
@@ -300,17 +298,13 @@ func TestWriteObject(t *testing.T) {
 	dir := t.TempDir()
 
 	ps, err := setupPosix(t, dir)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	pfs, err := setupPosixFlat(t, dir)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	s3s, err := setupS3(t, dir)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	newBuf := func(n int64) *bytes.Buffer {
 		testBytes := make([]byte, n)
@@ -335,13 +329,12 @@ func TestWriteObject(t *testing.T) {
 			// Test write without size. Should write whole buffer.
 			buf := newBuf(n)
 			objName := "obj01"
-			if err := os.WriteObject(objName, buf, -1, false); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			err := os.WriteObject(objName, buf, -1, false)
+			testutil.NilError(t, err)
+
 			oi, err := os.Stat(objName)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			if oi.Size != n {
 				t.Fatalf("expected object size: %d, got %d", n, oi.Size)
 			}
@@ -349,13 +342,12 @@ func TestWriteObject(t *testing.T) {
 			// Test write with object size equal to buf size.
 			buf = newBuf(n)
 			objName = "obj02"
-			if err := os.WriteObject(objName, buf, n, false); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			err = os.WriteObject(objName, buf, n, false)
+			testutil.NilError(t, err)
+
 			oi, err = os.Stat(objName)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			if oi.Size != n {
 				t.Fatalf("expected object size: %d, got %d", n, oi.Size)
 			}
@@ -364,13 +356,12 @@ func TestWriteObject(t *testing.T) {
 			buf = newBuf(n)
 			objName = "obj03"
 			size := int64(800)
-			if err := os.WriteObject(objName, buf, int64(size), false); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			err = os.WriteObject(objName, buf, int64(size), false)
+			testutil.NilError(t, err)
+
 			oi, err = os.Stat(objName)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			if oi.Size != size {
 				t.Fatalf("expected object size: %d, got %d", size, oi.Size)
 			}

--- a/internal/objectstorage/posix_test.go
+++ b/internal/objectstorage/posix_test.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"agola.io/agola/internal/testutil"
 )
 
 func TestPosixDeleteObject(t *testing.T) {
@@ -27,28 +29,23 @@ func TestPosixDeleteObject(t *testing.T) {
 	dir := t.TempDir()
 
 	ls, err := NewPosix(dir)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	for _, obj := range objects {
-		if err := ls.WriteObject(obj, bytes.NewReader([]byte{}), 0, true); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
-		if err := ls.DeleteObject(obj); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		err := ls.WriteObject(obj, bytes.NewReader([]byte{}), 0, true)
+		testutil.NilError(t, err)
+
+		err = ls.DeleteObject(obj)
+		testutil.NilError(t, err)
 	}
 
 	// no files and directories should be left
 	bd, err := os.Open(filepath.Join(dir, dataDirName))
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	files, err := bd.Readdirnames(0)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if len(files) > 0 {
 		t.Fatalf("expected 0 files got %d files", len(files))
 	}

--- a/internal/objectstorage/posixflat_test.go
+++ b/internal/objectstorage/posixflat_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/sorintlab/errors"
+
+	"agola.io/agola/internal/testutil"
 )
 
 func TestEscapeUnescape(t *testing.T) {
@@ -58,21 +60,21 @@ func TestEscapeUnescape(t *testing.T) {
 	for i, tt := range tests {
 		out := escape(tt.in)
 		if out != tt.expected {
-			t.Errorf("%d: escape: expected %q got %q", i, tt.expected, out)
+			t.Fatalf("%d: escape: expected %q got %q", i, tt.expected, out)
 		}
 
 		unescaped, _, err := unescape(out)
 		if err != nil {
 			if tt.err == nil {
-				t.Errorf("%d: unescape: expected no error got %v", i, err)
+				t.Fatalf("%d: unescape: expected no error got %v", i, err)
 			} else if !errors.Is(tt.err, err) {
-				t.Errorf("%d: unescape: expected error %v got %v", i, tt.err, err)
+				t.Fatalf("%d: unescape: expected error %v got %v", i, tt.err, err)
 			}
 		} else {
 			if tt.err != nil {
-				t.Errorf("%d: unescape: expected error %v got no error", i, tt.err)
+				t.Fatalf("%d: unescape: expected error %v got no error", i, tt.err)
 			} else if unescaped != tt.in {
-				t.Errorf("%d: unescape: expected %q got %q", i, tt.in, unescaped)
+				t.Fatalf("%d: unescape: expected %q got %q", i, tt.in, unescaped)
 			}
 		}
 	}
@@ -84,28 +86,23 @@ func TestPosixFlatDeleteObject(t *testing.T) {
 	dir := t.TempDir()
 
 	ls, err := NewPosixFlat(dir)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	for _, obj := range objects {
-		if err := ls.WriteObject(obj, bytes.NewReader([]byte{}), 0, true); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
-		if err := ls.DeleteObject(obj); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		err := ls.WriteObject(obj, bytes.NewReader([]byte{}), 0, true)
+		testutil.NilError(t, err)
+
+		err = ls.DeleteObject(obj)
+		testutil.NilError(t, err)
 	}
 
 	// no files and directories should be left
 	bd, err := os.Open(filepath.Join(dir, dataDirName))
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	files, err := bd.Readdirnames(0)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if len(files) > 0 {
 		t.Fatalf("expected 0 files got %d files", len(files))
 	}

--- a/internal/services/config/config_test.go
+++ b/internal/services/config/config_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sorintlab/errors"
+
+	"agola.io/agola/internal/testutil"
 )
 
 func TestParseConfig(t *testing.T) {
@@ -823,9 +825,8 @@ gitserver:
 
 			content := []byte(tt.in)
 			err := os.WriteFile(path.Join(dir, "config.yml"), content, 0644)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			c, err := Parse(path.Join(dir, "config.yml"), tt.services)
 			if err != nil {
 				if tt.err == nil {
@@ -840,7 +841,7 @@ gitserver:
 				}
 
 				if diff := cmp.Diff(tt.out, c); diff != "" {
-					t.Errorf("config mismatch (-want +got):\n%s", diff)
+					t.Fatalf("config mismatch (-want +got):\n%s", diff)
 				}
 			}
 		})

--- a/internal/services/configstore/configstore_test.go
+++ b/internal/services/configstore/configstore_test.go
@@ -41,18 +41,13 @@ import (
 
 func setupConfigstore(ctx context.Context, t *testing.T, log zerolog.Logger, dir string) *Configstore {
 	port, err := testutil.GetFreePort("localhost", true, false)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	ostDir, err := os.MkdirTemp(dir, "ost")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	csDir, err := os.MkdirTemp(dir, "cs")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	dbType := testutil.DBType(t)
 	_, _, dbConnString := testutil.CreateDB(t, log, ctx, dir)
@@ -73,9 +68,7 @@ func setupConfigstore(ctx context.Context, t *testing.T, log zerolog.Logger, dir
 	csConfig.Web.ListenAddress = net.JoinHostPort("localhost", port)
 
 	cs, err := NewConfigstore(ctx, log, &csConfig)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	return cs
 }
@@ -181,91 +174,81 @@ func TestExportImport(t *testing.T) {
 	var expectedSecretsCount int
 	var expectedVariablesCount int
 
-	if _, err := cs.ah.CreateRemoteSource(ctx, &action.CreateUpdateRemoteSourceRequest{Name: "rs01", Type: types.RemoteSourceTypeGitea, AuthType: types.RemoteSourceAuthTypePassword, APIURL: "http://example.com"}); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err := cs.ah.CreateRemoteSource(ctx, &action.CreateUpdateRemoteSourceRequest{Name: "rs01", Type: types.RemoteSourceTypeGitea, AuthType: types.RemoteSourceAuthTypePassword, APIURL: "http://example.com"})
+	testutil.NilError(t, err)
+
 	expectedRemoteSourcesCount++
 
 	for i := 0; i < 20; i++ {
-		if _, err := cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: fmt.Sprintf("user%d", i)}); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		_, err := cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: fmt.Sprintf("user%d", i)})
+		testutil.NilError(t, err)
+
 		expectedUsersCount++
 		expectedProjectGroupsCount++
 	}
 
 	user, err := cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: "user01"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	expectedUsersCount++
 	expectedProjectGroupsCount++
 
 	org, err := cs.ah.CreateOrg(ctx, &action.CreateOrgRequest{Name: "org01", Visibility: types.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	expectedOrgsCount++
 	expectedProjectGroupsCount++
 
-	if _, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual}); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
+	testutil.NilError(t, err)
+
 	expectedProjectsCount++
 
-	if _, err := cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "projectgroup01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic}); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "projectgroup01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic})
+	testutil.NilError(t, err)
+
 	expectedProjectGroupsCount++
 
-	if _, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual}); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
+	testutil.NilError(t, err)
+
 	expectedProjectsCount++
 
-	if _, err := cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "projectgroup01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic}); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "projectgroup01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic})
+	testutil.NilError(t, err)
+
 	expectedProjectGroupsCount++
 
-	if _, err := cs.ah.CreateSecret(ctx, &action.CreateUpdateSecretRequest{Name: "secret01", Parent: types.Parent{Kind: types.ObjectKindProject, ID: path.Join("user", user.Name, "projectgroup01", "project01")}, Type: types.SecretTypeInternal, Data: map[string]string{"secret01": "secretvar01"}}); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = cs.ah.CreateSecret(ctx, &action.CreateUpdateSecretRequest{Name: "secret01", Parent: types.Parent{Kind: types.ObjectKindProject, ID: path.Join("user", user.Name, "projectgroup01", "project01")}, Type: types.SecretTypeInternal, Data: map[string]string{"secret01": "secretvar01"}})
+	testutil.NilError(t, err)
+
 	expectedSecretsCount++
 
-	if _, err := cs.ah.CreateVariable(ctx, &action.CreateUpdateVariableRequest{Name: "variable01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name, "projectgroup01")}, Values: []types.VariableValue{{SecretName: "secret01", SecretVar: "secretvar01"}}}); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = cs.ah.CreateVariable(ctx, &action.CreateUpdateVariableRequest{Name: "variable01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name, "projectgroup01")}, Values: []types.VariableValue{{SecretName: "secret01", SecretVar: "secretvar01"}}})
+	testutil.NilError(t, err)
+
 	expectedVariablesCount++
 
 	remoteSources, err := getRemoteSources(ctx, cs)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	users, err := getUsers(ctx, cs)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	orgs, err := getOrgs(ctx, cs)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	projectGroups, err := getProjectGroups(ctx, cs)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	projects, err := getProjects(ctx, cs)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	secrets, err := getSecrets(ctx, cs)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	variables, err := getVariables(ctx, cs)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	if len(remoteSources) != expectedRemoteSourcesCount {
 		t.Logf("remoteSources: %s", util.Dump(remoteSources))
@@ -297,13 +280,11 @@ func TestExportImport(t *testing.T) {
 	}
 
 	var export bytes.Buffer
-	if err := cs.ah.Export(ctx, &export); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	err = cs.ah.Export(ctx, &export)
+	testutil.NilError(t, err)
 
-	if err := cs.ah.SetMaintenanceEnabled(ctx, true); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	err = cs.ah.SetMaintenanceEnabled(ctx, true)
+	testutil.NilError(t, err)
 
 	_ = testutil.Wait(30*time.Second, func() (bool, error) {
 		if !cs.ah.IsMaintenanceMode() {
@@ -313,13 +294,11 @@ func TestExportImport(t *testing.T) {
 		return true, nil
 	})
 
-	if err := cs.ah.Import(ctx, &export); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	err = cs.ah.Import(ctx, &export)
+	testutil.NilError(t, err)
 
-	if err := cs.ah.SetMaintenanceEnabled(ctx, false); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	err = cs.ah.SetMaintenanceEnabled(ctx, false)
+	testutil.NilError(t, err)
 
 	_ = testutil.Wait(30*time.Second, func() (bool, error) {
 		if cs.ah.IsMaintenanceMode() {
@@ -330,33 +309,25 @@ func TestExportImport(t *testing.T) {
 	})
 
 	newRemoteSources, err := getRemoteSources(ctx, cs)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	newUsers, err := getUsers(ctx, cs)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	newOrgs, err := getOrgs(ctx, cs)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	newProjectGroups, err := getProjectGroups(ctx, cs)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	newProjects, err := getProjects(ctx, cs)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	newSecrets, err := getSecrets(ctx, cs)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	newVariables, err := getVariables(ctx, cs)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	if diff := cmpDiffObject(remoteSources, newRemoteSources); diff != "" {
 		t.Fatalf("remoteSources mismatch (-want +got):\n%s", diff)
@@ -397,9 +368,7 @@ func TestUser(t *testing.T) {
 
 	t.Run("create user", func(t *testing.T) {
 		_, err := cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: "user01"})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 	})
 
 	t.Run("create duplicated user", func(t *testing.T) {
@@ -414,9 +383,7 @@ func TestUser(t *testing.T) {
 	})
 	t.Run("concurrent user with same name creation", func(t *testing.T) {
 		prevUsers, err := getUsers(ctx, cs)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		wg := sync.WaitGroup{}
 		for i := 0; i < 10; i++ {
@@ -429,9 +396,7 @@ func TestUser(t *testing.T) {
 		wg.Wait()
 
 		users, err := getUsers(ctx, cs)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		if len(users) != len(prevUsers)+1 {
 			t.Fatalf("expected %d users, got %d", len(prevUsers)+1, len(users))
@@ -440,14 +405,10 @@ func TestUser(t *testing.T) {
 
 	t.Run("delete user", func(t *testing.T) {
 		_, err := cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: "user03"})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		err = cs.ah.DeleteUser(ctx, "user03")
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		var user *types.User
 		err = cs.d.Do(ctx, func(tx *sql.Tx) error {
@@ -455,9 +416,8 @@ func TestUser(t *testing.T) {
 			user, err = cs.d.GetUser(tx, "user03")
 			return errors.WithStack(err)
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if user != nil {
 			t.Fatalf("expected user nil, got: %v", user)
 		}
@@ -479,49 +439,34 @@ func TestProjectGroupsAndProjectsCreate(t *testing.T) {
 	}()
 
 	user, err := cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: "user01"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	org, err := cs.ah.CreateOrg(ctx, &action.CreateOrgRequest{Name: "org01", Visibility: types.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	t.Run("create a project in user root project group", func(t *testing.T) {
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 	})
 	t.Run("create a project in org root project group", func(t *testing.T) {
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 	})
 	t.Run("create a projectgroup in user root project group", func(t *testing.T) {
 		_, err := cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "projectgroup01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 	})
 	t.Run("create a projectgroup in org root project group", func(t *testing.T) {
 		_, err := cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "projectgroup01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 	})
 	t.Run("create a project in user non root project group with same name as a root project", func(t *testing.T) {
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 	})
 	t.Run("create a project in org non root project group with same name as a root project", func(t *testing.T) {
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("org", org.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 	})
 
 	t.Run("create duplicated project in user root project group", func(t *testing.T) {
@@ -575,9 +520,7 @@ func TestProjectGroupsAndProjectsCreate(t *testing.T) {
 
 	t.Run("concurrent project with same name creation", func(t *testing.T) {
 		prevProjects, err := getProjects(ctx, cs)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		wg := sync.WaitGroup{}
 		for i := 0; i < 10; i++ {
@@ -590,9 +533,7 @@ func TestProjectGroupsAndProjectsCreate(t *testing.T) {
 		wg.Wait()
 
 		projects, err := getProjects(ctx, cs)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		if len(projects) != len(prevProjects)+1 {
 			t.Fatalf("expected %d projects, got %d", len(prevProjects)+1, len(projects))
@@ -615,33 +556,28 @@ func TestProjectUpdate(t *testing.T) {
 	}()
 
 	user, err := cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: "user01"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
-	if _, err := cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "projectgroup01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic}); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "projectgroup01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic})
+	testutil.NilError(t, err)
+
 	p01 := &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual}
-	if _, err := cs.ah.CreateProject(ctx, p01); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = cs.ah.CreateProject(ctx, p01)
+	testutil.NilError(t, err)
+
 	p02 := &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual}
-	if _, err := cs.ah.CreateProject(ctx, p02); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = cs.ah.CreateProject(ctx, p02)
+	testutil.NilError(t, err)
+
 	p03 := &action.CreateUpdateProjectRequest{Name: "project02", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual}
-	if _, err := cs.ah.CreateProject(ctx, p03); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = cs.ah.CreateProject(ctx, p03)
+	testutil.NilError(t, err)
 
 	t.Run("rename project keeping same parent", func(t *testing.T) {
 		projectName := "project02"
 		p03.Name = "newproject02"
 		_, err := cs.ah.UpdateProject(ctx, path.Join("user", user.Name, "projectgroup01", projectName), p03)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 	})
 	t.Run("move project to project group having project with same name", func(t *testing.T) {
 		projectName := "project01"
@@ -657,9 +593,7 @@ func TestProjectUpdate(t *testing.T) {
 		p02.Name = "newproject01"
 		p02.Parent.ID = path.Join("user", user.Name)
 		_, err := cs.ah.UpdateProject(ctx, path.Join("user", user.Name, "projectgroup01", projectName), p02)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 	})
 	t.Run("test user project MembersCanPerformRunActions parameter", func(t *testing.T) {
 		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot set MembersCanPerformRunActions on an user project."))
@@ -705,43 +639,36 @@ func TestProjectGroupUpdate(t *testing.T) {
 	}()
 
 	user, err := cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: "user01"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	rootPG, err := cs.ah.GetProjectGroup(ctx, path.Join("user", user.Name))
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	pg01req := &action.CreateUpdateProjectGroupRequest{Name: "pg01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic}
-	if _, err := cs.ah.CreateProjectGroup(ctx, pg01req); err != nil {
-		log.Err(err).Send()
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = cs.ah.CreateProjectGroup(ctx, pg01req)
+	testutil.NilError(t, err)
+
 	pg02req := &action.CreateUpdateProjectGroupRequest{Name: "pg02", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic}
-	if _, err := cs.ah.CreateProjectGroup(ctx, pg02req); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = cs.ah.CreateProjectGroup(ctx, pg02req)
+	testutil.NilError(t, err)
+
 	pg03req := &action.CreateUpdateProjectGroupRequest{Name: "pg03", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic}
-	if _, err := cs.ah.CreateProjectGroup(ctx, pg03req); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = cs.ah.CreateProjectGroup(ctx, pg03req)
+	testutil.NilError(t, err)
+
 	pg04req := &action.CreateUpdateProjectGroupRequest{Name: "pg01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name, "pg01")}, Visibility: types.VisibilityPublic}
-	if _, err := cs.ah.CreateProjectGroup(ctx, pg04req); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = cs.ah.CreateProjectGroup(ctx, pg04req)
+	testutil.NilError(t, err)
+
 	pg05req := &action.CreateUpdateProjectGroupRequest{Name: "pg01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name, "pg02")}, Visibility: types.VisibilityPublic}
-	if _, err := cs.ah.CreateProjectGroup(ctx, pg05req); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = cs.ah.CreateProjectGroup(ctx, pg05req)
+	testutil.NilError(t, err)
 
 	t.Run("rename project group keeping same parent", func(t *testing.T) {
 		projectGroupName := "pg03"
 		pg03req.Name = "newpg03"
-		if _, err := cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name, projectGroupName), pg03req); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		_, err := cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name, projectGroupName), pg03req)
+		testutil.NilError(t, err)
 	})
 	t.Run("move project to project group having project with same name", func(t *testing.T) {
 		projectGroupName := "pg01"
@@ -757,9 +684,8 @@ func TestProjectGroupUpdate(t *testing.T) {
 		pg05req.Name = "newpg01"
 		pg05req.Parent.ID = path.Join("user", user.Name)
 		pg05, err := cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name, "pg02", projectGroupName), pg05req)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if pg05.Parent.ID != rootPG.ID {
 			t.Fatalf("expected project group parent id as root project group id")
 		}
@@ -785,9 +711,8 @@ func TestProjectGroupUpdate(t *testing.T) {
 	t.Run("change root project group parent kind", func(t *testing.T) {
 		var rootPG *types.ProjectGroup
 		rootPG, err := cs.ah.GetProjectGroup(ctx, path.Join("user", user.Name))
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		rootPG.Parent.Kind = types.ObjectKindProjectGroup
 		rootPG.Name = "rootpg"
 
@@ -800,9 +725,8 @@ func TestProjectGroupUpdate(t *testing.T) {
 	t.Run("change root project group parent id", func(t *testing.T) {
 		var rootPG *types.ProjectGroup
 		rootPG, err := cs.ah.GetProjectGroup(ctx, path.Join("user", user.Name))
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		rootPG.Parent.ID = path.Join("user", user.Name, "pg01")
 
 		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot change root project group parent kind or id"))
@@ -814,9 +738,8 @@ func TestProjectGroupUpdate(t *testing.T) {
 	t.Run("change root project group name", func(t *testing.T) {
 		var rootPG *types.ProjectGroup
 		rootPG, err := cs.ah.GetProjectGroup(ctx, path.Join("user", user.Name))
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		rootPG.Name = "rootpgnewname"
 
 		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("project group name for root project group must be empty"))
@@ -828,19 +751,16 @@ func TestProjectGroupUpdate(t *testing.T) {
 	t.Run("change root project group visibility", func(t *testing.T) {
 		var rootPG *types.ProjectGroup
 		rootPG, err := cs.ah.GetProjectGroup(ctx, path.Join("user", user.Name))
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		rootPG.Visibility = types.VisibilityPrivate
 
-		if _, err := cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name), &action.CreateUpdateProjectGroupRequest{Name: rootPG.Name, Parent: rootPG.Parent, Visibility: rootPG.Visibility}); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		_, err = cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name), &action.CreateUpdateProjectGroupRequest{Name: rootPG.Name, Parent: rootPG.Parent, Visibility: rootPG.Visibility})
+		testutil.NilError(t, err)
 
 		rootPG, err = cs.ah.GetProjectGroup(ctx, path.Join("user", user.Name))
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if rootPG.Visibility != types.VisibilityPrivate {
 			t.Fatalf("expected visiblity %q, got visibility: %q", types.VisibilityPublic, rootPG.Visibility)
 		}
@@ -862,20 +782,15 @@ func TestProjectGroupDelete(t *testing.T) {
 	}()
 
 	org, err := cs.ah.CreateOrg(ctx, &action.CreateOrgRequest{Name: "org01", Visibility: types.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create a projectgroup in org root project group
 	pg01, err := cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "projectgroup01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create a child projectgroup in org root project group
-	if _, err := cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "subprojectgroup01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: pg01.ID}, Visibility: types.VisibilityPublic}); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "subprojectgroup01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: pg01.ID}, Visibility: types.VisibilityPublic})
+	testutil.NilError(t, err)
 
 	t.Run("delete root project group", func(t *testing.T) {
 		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot delete root project group"))
@@ -887,9 +802,7 @@ func TestProjectGroupDelete(t *testing.T) {
 
 	t.Run("delete project group", func(t *testing.T) {
 		err := cs.ah.DeleteProjectGroup(ctx, pg01.ID)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 	})
 }
 
@@ -908,110 +821,88 @@ func TestProjectGroupDeleteDontSeeOldChildObjects(t *testing.T) {
 	}()
 
 	org, err := cs.ah.CreateOrg(ctx, &action.CreateOrgRequest{Name: "org01", Visibility: types.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create a projectgroup in org root project group
 	pg01, err := cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "projectgroup01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create a child projectgroup in org root project group
 	spg01, err := cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "subprojectgroup01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: pg01.ID}, Visibility: types.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create a project inside child projectgroup
 	project, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: spg01.ID}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create project secret
-	if _, err := cs.ah.CreateSecret(ctx, &action.CreateUpdateSecretRequest{Name: "secret01", Parent: types.Parent{Kind: types.ObjectKindProject, ID: project.ID}, Type: types.SecretTypeInternal, Data: map[string]string{"secret01": "secretvar01"}}); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = cs.ah.CreateSecret(ctx, &action.CreateUpdateSecretRequest{Name: "secret01", Parent: types.Parent{Kind: types.ObjectKindProject, ID: project.ID}, Type: types.SecretTypeInternal, Data: map[string]string{"secret01": "secretvar01"}})
+	testutil.NilError(t, err)
+
 	// create project variable
-	if _, err = cs.ah.CreateVariable(ctx, &action.CreateUpdateVariableRequest{Name: "variable01", Parent: types.Parent{Kind: types.ObjectKindProject, ID: project.ID}, Values: []types.VariableValue{{SecretName: "secret01", SecretVar: "secretvar01"}}}); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = cs.ah.CreateVariable(ctx, &action.CreateUpdateVariableRequest{Name: "variable01", Parent: types.Parent{Kind: types.ObjectKindProject, ID: project.ID}, Values: []types.VariableValue{{SecretName: "secret01", SecretVar: "secretvar01"}}})
+	testutil.NilError(t, err)
 
 	// delete projectgroup
-	if err := cs.ah.DeleteProjectGroup(ctx, pg01.ID); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	err = cs.ah.DeleteProjectGroup(ctx, pg01.ID)
+	testutil.NilError(t, err)
 
 	// recreate the same hierarchj using the paths
 	pg01, err = cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "projectgroup01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	spg01, err = cs.ah.CreateProjectGroup(ctx, &action.CreateUpdateProjectGroupRequest{Name: "subprojectgroup01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("org", org.Name, pg01.Name)}, Visibility: types.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	project, err = cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("org", org.Name, pg01.Name, spg01.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	secret, err := cs.ah.CreateSecret(ctx, &action.CreateUpdateSecretRequest{Name: "secret01", Parent: types.Parent{Kind: types.ObjectKindProject, ID: path.Join("org", org.Name, pg01.Name, spg01.Name, project.Name)}, Type: types.SecretTypeInternal, Data: map[string]string{"secret01": "secretvar01"}})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	variable, err := cs.ah.CreateVariable(ctx, &action.CreateUpdateVariableRequest{Name: "variable01", Parent: types.Parent{Kind: types.ObjectKindProject, ID: path.Join("org", org.Name, pg01.Name, spg01.Name, project.Name)}, Values: []types.VariableValue{{SecretName: "secret01", SecretVar: "secretvar01"}}})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// Get by projectgroup id
 	projects, err := cs.ah.GetProjectGroupProjects(ctx, spg01.ID)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if diff := cmpDiffObject(projects, []*types.Project{project}); diff != "" {
 		t.Fatalf("mismatch (-want +got):\n%s", diff)
 	}
 
 	// Get by projectgroup path
 	projects, err = cs.ah.GetProjectGroupProjects(ctx, path.Join("org", org.Name, pg01.Name, spg01.Name))
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if diff := cmpDiffObject(projects, []*types.Project{project}); diff != "" {
 		t.Fatalf("mismatch (-want +got):\n%s", diff)
 	}
 
 	secrets, err := cs.ah.GetSecrets(ctx, types.ObjectKindProject, project.ID, false)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if diff := cmpDiffObject(secrets, []*types.Secret{secret}); diff != "" {
 		t.Fatalf("mismatch (-want +got):\n%s", diff)
 	}
 
 	secrets, err = cs.ah.GetSecrets(ctx, types.ObjectKindProject, path.Join("org", org.Name, pg01.Name, spg01.Name, project.Name), false)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if diff := cmpDiffObject(secrets, []*types.Secret{secret}); diff != "" {
 		t.Fatalf("mismatch (-want +got):\n%s", diff)
 	}
 
 	variables, err := cs.ah.GetVariables(ctx, types.ObjectKindProject, project.ID, false)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if diff := cmpDiffObject(variables, []*types.Variable{variable}); diff != "" {
 		t.Fatalf("mismatch (-want +got):\n%s", diff)
 	}
 
 	variables, err = cs.ah.GetVariables(ctx, types.ObjectKindProject, path.Join("org", org.Name, pg01.Name, spg01.Name, project.Name), false)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if diff := cmpDiffObject(variables, []*types.Variable{variable}); diff != "" {
 		t.Fatalf("mismatch (-want +got):\n%s", diff)
 	}
@@ -1030,13 +921,10 @@ func TestOrgMembers(t *testing.T) {
 	go func() { _ = cs.Run(ctx) }()
 
 	user, err := cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: "user01"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	org, err := cs.ah.CreateOrg(ctx, &action.CreateOrgRequest{Name: "org01", Visibility: types.VisibilityPublic, CreatorUserID: user.ID})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	t.Run("test user org creator is org member with owner role", func(t *testing.T) {
 		expectedResponse := &action.GetUserOrgsResponse{
@@ -1048,9 +936,8 @@ func TestOrgMembers(t *testing.T) {
 			},
 		}
 		res, err := cs.ah.GetUserOrgs(ctx, &action.GetUserOrgsRequest{UserRef: user.ID})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if diff := cmpDiffObject(res, expectedResponse); diff != "" {
 			t.Fatalf("mismatch (-want +got):\n%s", diff)
 		}
@@ -1059,16 +946,14 @@ func TestOrgMembers(t *testing.T) {
 	orgs := []*types.Organization{}
 	for i := 0; i < 10; i++ {
 		org, err := cs.ah.CreateOrg(ctx, &action.CreateOrgRequest{Name: fmt.Sprintf("org%d", i), Visibility: types.VisibilityPublic, CreatorUserID: user.ID})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		orgs = append(orgs, org)
 	}
 
 	for i := 0; i < 5; i++ {
-		if err := cs.ah.DeleteOrg(ctx, fmt.Sprintf("org%d", i)); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		err := cs.ah.DeleteOrg(ctx, fmt.Sprintf("org%d", i))
+		testutil.NilError(t, err)
 	}
 
 	// delete some org and check that if also orgmembers aren't yet cleaned only the existing orgs are reported
@@ -1088,9 +973,8 @@ func TestOrgMembers(t *testing.T) {
 			})
 		}
 		res, err := cs.ah.GetUserOrgs(ctx, &action.GetUserOrgsRequest{UserRef: user.ID})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if diff := cmpDiffObject(res, expectedResponse); diff != "" {
 			t.Fatalf("mismatch (-want +got):\n%s", diff)
 		}
@@ -1112,17 +996,15 @@ func TestGetRemoteSources(t *testing.T) {
 	remoteSources := []*types.RemoteSource{}
 	for i := 1; i < 10; i++ {
 		remoteSource, err := cs.ah.CreateRemoteSource(ctx, &action.CreateUpdateRemoteSourceRequest{Name: fmt.Sprintf("rs%d", i), Type: types.RemoteSourceTypeGitea, AuthType: types.RemoteSourceAuthTypePassword, APIURL: "http://example.com"})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		remoteSources = append(remoteSources, remoteSource)
 	}
 
 	t.Run("test get all remote sources", func(t *testing.T) {
 		res, err := cs.ah.GetRemoteSources(ctx, &action.GetRemoteSourcesRequest{SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedRemoteSources := 9
 		if len(res.RemoteSources) != expectedRemoteSources {
 			t.Fatalf("expected %d remote sources, got %d remote sources", expectedRemoteSources, len(res.RemoteSources))
@@ -1134,9 +1016,8 @@ func TestGetRemoteSources(t *testing.T) {
 
 	t.Run("test get remote sources with limit less than remote sources", func(t *testing.T) {
 		res, err := cs.ah.GetRemoteSources(ctx, &action.GetRemoteSourcesRequest{Limit: 5, SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedRemoteSources := 5
 		if len(res.RemoteSources) != expectedRemoteSources {
 			t.Fatalf("expected %d remote sources, got %d remote sources", expectedRemoteSources, len(res.RemoteSources))
@@ -1150,9 +1031,7 @@ func TestGetRemoteSources(t *testing.T) {
 		respAllRemoteSources := []*types.RemoteSource{}
 
 		res, err := cs.ah.GetRemoteSources(ctx, &action.GetRemoteSourcesRequest{Limit: 5, SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		expectedRemoteSources := 5
 		if len(res.RemoteSources) != expectedRemoteSources {
@@ -1168,9 +1047,8 @@ func TestGetRemoteSources(t *testing.T) {
 		// fetch next results
 		for {
 			res, err = cs.ah.GetRemoteSources(ctx, &action.GetRemoteSourcesRequest{StartRemoteSourceName: lastRemoteSource.Name, Limit: 5, SortDirection: types.SortDirectionAsc})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			expectedRemoteSources := 5
 			if res.HasMore && len(res.RemoteSources) != expectedRemoteSources {
 				t.Fatalf("expected %d remote sources, got %d remote sources", expectedRemoteSources, len(res.RemoteSources))
@@ -1211,17 +1089,15 @@ func TestGetUsers(t *testing.T) {
 	users := []*types.User{}
 	for i := 1; i < 10; i++ {
 		user, err := cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: fmt.Sprintf("user%d", i)})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		users = append(users, user)
 	}
 
 	t.Run("test get all users", func(t *testing.T) {
 		res, err := cs.ah.GetUsers(ctx, &action.GetUsersRequest{SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedUsers := 9
 		if len(res.Users) != expectedUsers {
 			t.Fatalf("expected %d users, got %d users", expectedUsers, len(res.Users))
@@ -1233,9 +1109,8 @@ func TestGetUsers(t *testing.T) {
 
 	t.Run("test get users with limit less than users", func(t *testing.T) {
 		res, err := cs.ah.GetUsers(ctx, &action.GetUsersRequest{Limit: 5, SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedUsers := 5
 		if len(res.Users) != expectedUsers {
 			t.Fatalf("expected %d users, got %d users", expectedUsers, len(res.Users))
@@ -1249,9 +1124,7 @@ func TestGetUsers(t *testing.T) {
 		respAllUsers := []*types.User{}
 
 		res, err := cs.ah.GetUsers(ctx, &action.GetUsersRequest{Limit: 5, SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		expectedUsers := 5
 		if len(res.Users) != expectedUsers {
@@ -1267,9 +1140,8 @@ func TestGetUsers(t *testing.T) {
 		// fetch next results
 		for {
 			res, err = cs.ah.GetUsers(ctx, &action.GetUsersRequest{StartUserName: lastUser.Name, Limit: 5, SortDirection: types.SortDirectionAsc})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			expectedUsers := 5
 			if res.HasMore && len(res.Users) != expectedUsers {
 				t.Fatalf("expected %d users, got %d users", expectedUsers, len(res.Users))
@@ -1316,9 +1188,7 @@ func TestGetOrgs(t *testing.T) {
 			visibility = types.VisibilityPrivate
 		}
 		org, err := cs.ah.CreateOrg(ctx, &action.CreateOrgRequest{Name: fmt.Sprintf("org%02d", i), Visibility: visibility})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		allOrgs = append(allOrgs, org)
 		if visibility == types.VisibilityPublic {
@@ -1328,9 +1198,8 @@ func TestGetOrgs(t *testing.T) {
 
 	t.Run("test get all public orgs", func(t *testing.T) {
 		res, err := cs.ah.GetOrgs(ctx, &action.GetOrgsRequest{SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedOrgs := 9
 		if len(res.Orgs) != expectedOrgs {
 			t.Fatalf("expected %d orgs, got %d orgs", expectedOrgs, len(res.Orgs))
@@ -1346,9 +1215,8 @@ func TestGetOrgs(t *testing.T) {
 
 	t.Run("test get all public/private orgs", func(t *testing.T) {
 		res, err := cs.ah.GetOrgs(ctx, &action.GetOrgsRequest{Visibilities: []types.Visibility{types.VisibilityPublic, types.VisibilityPrivate}, SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedOrgs := 18
 		if len(res.Orgs) != expectedOrgs {
 			t.Fatalf("expected %d orgs, got %d orgs", expectedOrgs, len(res.Orgs))
@@ -1364,9 +1232,8 @@ func TestGetOrgs(t *testing.T) {
 
 	t.Run("test get public orgs with limit less than orgs", func(t *testing.T) {
 		res, err := cs.ah.GetOrgs(ctx, &action.GetOrgsRequest{Limit: 5, SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedOrgs := 5
 		if len(res.Orgs) != expectedOrgs {
 			t.Fatalf("expected %d orgs, got %d orgs", expectedOrgs, len(res.Orgs))
@@ -1382,9 +1249,8 @@ func TestGetOrgs(t *testing.T) {
 
 	t.Run("test get public/private orgs with limit less than orgs", func(t *testing.T) {
 		res, err := cs.ah.GetOrgs(ctx, &action.GetOrgsRequest{Limit: 5, Visibilities: []types.Visibility{types.VisibilityPublic, types.VisibilityPrivate}, SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedOrgs := 5
 		if len(res.Orgs) != expectedOrgs {
 			t.Fatalf("expected %d orgs, got %d orgs", expectedOrgs, len(res.Orgs))
@@ -1402,9 +1268,7 @@ func TestGetOrgs(t *testing.T) {
 		respAllOrgs := []*types.Organization{}
 
 		res, err := cs.ah.GetOrgs(ctx, &action.GetOrgsRequest{Limit: 5, SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		expectedOrgs := 5
 		if len(res.Orgs) != expectedOrgs {
@@ -1420,9 +1284,8 @@ func TestGetOrgs(t *testing.T) {
 		// fetch next results
 		for {
 			res, err = cs.ah.GetOrgs(ctx, &action.GetOrgsRequest{StartOrgName: lastOrg.Name, Limit: 5, SortDirection: types.SortDirectionAsc})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			expectedOrgs := 5
 			if res.HasMore && len(res.Orgs) != expectedOrgs {
 				t.Fatalf("expected %d orgs, got %d orgs", expectedOrgs, len(res.Orgs))
@@ -1451,9 +1314,7 @@ func TestGetOrgs(t *testing.T) {
 		respAllOrgs := []*types.Organization{}
 
 		res, err := cs.ah.GetOrgs(ctx, &action.GetOrgsRequest{Limit: 5, Visibilities: []types.Visibility{types.VisibilityPublic, types.VisibilityPrivate}, SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		expectedOrgs := 5
 		if len(res.Orgs) != expectedOrgs {
@@ -1469,9 +1330,8 @@ func TestGetOrgs(t *testing.T) {
 		// fetch next results
 		for {
 			res, err = cs.ah.GetOrgs(ctx, &action.GetOrgsRequest{StartOrgName: lastOrg.Name, Visibilities: []types.Visibility{types.VisibilityPublic, types.VisibilityPrivate}, Limit: 5, SortDirection: types.SortDirectionAsc})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			expectedOrgs := 5
 			if res.HasMore && len(res.Orgs) != expectedOrgs {
 				t.Fatalf("expected %d orgs, got %d orgs", expectedOrgs, len(res.Orgs))
@@ -1512,28 +1372,23 @@ func TestGetOrgMembers(t *testing.T) {
 	users := []*types.User{}
 	for i := 1; i < 10; i++ {
 		user, err := cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: fmt.Sprintf("user%d", i)})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		users = append(users, user)
 	}
 
 	org, err := cs.ah.CreateOrg(ctx, &action.CreateOrgRequest{Name: "org01", Visibility: types.VisibilityPublic, CreatorUserID: users[0].ID})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	for _, user := range users {
-		if _, err := cs.ah.AddOrgMember(ctx, org.ID, user.ID, types.MemberRoleMember); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		_, err := cs.ah.AddOrgMember(ctx, org.ID, user.ID, types.MemberRoleMember)
+		testutil.NilError(t, err)
 	}
 
 	t.Run("test get all org members", func(t *testing.T) {
 		res, err := cs.ah.GetOrgMembers(ctx, &action.GetOrgMembersRequest{OrgRef: org.ID, SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedOrgMembers := 9
 		if len(res.OrgMembers) != expectedOrgMembers {
 			t.Fatalf("expected %d org members, got %d org members", expectedOrgMembers, len(res.OrgMembers))
@@ -1545,9 +1400,8 @@ func TestGetOrgMembers(t *testing.T) {
 
 	t.Run("test get org members with limit less than org members", func(t *testing.T) {
 		res, err := cs.ah.GetOrgMembers(ctx, &action.GetOrgMembersRequest{OrgRef: org.ID, Limit: 5, SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedOrgMembers := 5
 		if len(res.OrgMembers) != expectedOrgMembers {
 			t.Fatalf("expected %d org members, got %d org members", expectedOrgMembers, len(res.OrgMembers))
@@ -1561,9 +1415,7 @@ func TestGetOrgMembers(t *testing.T) {
 		orgMembers := []*action.OrgMember{}
 
 		res, err := cs.ah.GetOrgMembers(ctx, &action.GetOrgMembersRequest{OrgRef: org.ID, Limit: 5, SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		expectedOrgMembers := 5
 		if len(res.OrgMembers) != expectedOrgMembers {
@@ -1579,9 +1431,8 @@ func TestGetOrgMembers(t *testing.T) {
 		// fetch next results
 		for {
 			res, err = cs.ah.GetOrgMembers(ctx, &action.GetOrgMembersRequest{OrgRef: org.ID, StartUserName: lastUser.User.Name, Limit: 5, SortDirection: types.SortDirectionAsc})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			expectedOrgMembers := 5
 			if res.HasMore && len(res.OrgMembers) != expectedOrgMembers {
 				t.Fatalf("expected %d org members, got %d org members", expectedOrgMembers, len(res.OrgMembers))
@@ -1625,30 +1476,25 @@ func TestGetUserOrgs(t *testing.T) {
 	go func() { _ = cs.Run(ctx) }()
 
 	user, err := cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: "orguser01"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	orgs := []*types.Organization{}
 	for i := 1; i < 10; i++ {
 		org, err := cs.ah.CreateOrg(ctx, &action.CreateOrgRequest{Name: fmt.Sprintf("org%d", i), Visibility: types.VisibilityPublic})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		orgs = append(orgs, org)
 	}
 
 	for _, org := range orgs {
-		if _, err := cs.ah.AddOrgMember(ctx, org.ID, user.ID, types.MemberRoleMember); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		_, err := cs.ah.AddOrgMember(ctx, org.ID, user.ID, types.MemberRoleMember)
+		testutil.NilError(t, err)
 	}
 
 	t.Run("test get all user orgs", func(t *testing.T) {
 		res, err := cs.ah.GetUserOrgs(ctx, &action.GetUserOrgsRequest{UserRef: user.ID, SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedUserOrgs := 9
 		if len(res.UserOrgs) != expectedUserOrgs {
 			t.Fatalf("expected %d user orgs, got %d user orgs", expectedUserOrgs, len(res.UserOrgs))
@@ -1660,9 +1506,8 @@ func TestGetUserOrgs(t *testing.T) {
 
 	t.Run("test get user orgs with limit less than user orgs", func(t *testing.T) {
 		res, err := cs.ah.GetUserOrgs(ctx, &action.GetUserOrgsRequest{UserRef: user.ID, Limit: 5, SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedUserOrgs := 5
 		if len(res.UserOrgs) != expectedUserOrgs {
 			t.Fatalf("expected %d user orgs, got %d user orgs", expectedUserOrgs, len(res.UserOrgs))
@@ -1676,9 +1521,7 @@ func TestGetUserOrgs(t *testing.T) {
 		respAllUserOrgs := []*action.UserOrg{}
 
 		respUserOrgs, err := cs.ah.GetUserOrgs(ctx, &action.GetUserOrgsRequest{UserRef: user.ID, Limit: 5, SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		expectedUserOrgs := 5
 		if len(respUserOrgs.UserOrgs) != expectedUserOrgs {
@@ -1694,9 +1537,8 @@ func TestGetUserOrgs(t *testing.T) {
 		// fetch next results
 		for {
 			respUserOrgs, err = cs.ah.GetUserOrgs(ctx, &action.GetUserOrgsRequest{UserRef: user.ID, StartOrgName: lastUserOrg.Organization.Name, Limit: 5, SortDirection: types.SortDirectionAsc})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			expectedUserOrgs := 5
 			if respUserOrgs.HasMore && len(respUserOrgs.UserOrgs) != expectedUserOrgs {
 				t.Fatalf("expected %d user orgs, got %d user orgs", expectedUserOrgs, len(respUserOrgs.UserOrgs))
@@ -1747,9 +1589,8 @@ func TestRemoteSource(t *testing.T) {
 					Oauth2ClientID:     "clientid",
 					Oauth2ClientSecret: "clientsecret",
 				}
-				if _, err := cs.ah.CreateRemoteSource(ctx, rsreq); err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				_, err := cs.ah.CreateRemoteSource(ctx, rsreq)
+				testutil.NilError(t, err)
 			},
 		},
 		{
@@ -1763,12 +1604,11 @@ func TestRemoteSource(t *testing.T) {
 					Oauth2ClientID:     "clientid",
 					Oauth2ClientSecret: "clientsecret",
 				}
-				if _, err := cs.ah.CreateRemoteSource(ctx, rsreq); err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				_, err := cs.ah.CreateRemoteSource(ctx, rsreq)
+				testutil.NilError(t, err)
 
 				expectedError := util.NewAPIError(util.ErrBadRequest, errors.Errorf(`remotesource "rs01" already exists`))
-				_, err := cs.ah.CreateRemoteSource(ctx, rsreq)
+				_, err = cs.ah.CreateRemoteSource(ctx, rsreq)
 				if err.Error() != expectedError.Error() {
 					t.Fatalf("expected err: %v, got err: %v", expectedError.Error(), err.Error())
 				}
@@ -1785,14 +1625,12 @@ func TestRemoteSource(t *testing.T) {
 					Oauth2ClientID:     "clientid",
 					Oauth2ClientSecret: "clientsecret",
 				}
-				if _, err := cs.ah.CreateRemoteSource(ctx, rsreq); err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				_, err := cs.ah.CreateRemoteSource(ctx, rsreq)
+				testutil.NilError(t, err)
 
 				rsreq.Name = "rs02"
-				if _, err := cs.ah.UpdateRemoteSource(ctx, "rs01", rsreq); err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				_, err = cs.ah.UpdateRemoteSource(ctx, "rs01", rsreq)
+				testutil.NilError(t, err)
 			},
 		},
 		{
@@ -1806,14 +1644,12 @@ func TestRemoteSource(t *testing.T) {
 					Oauth2ClientID:     "clientid",
 					Oauth2ClientSecret: "clientsecret",
 				}
-				if _, err := cs.ah.CreateRemoteSource(ctx, rsreq); err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				_, err := cs.ah.CreateRemoteSource(ctx, rsreq)
+				testutil.NilError(t, err)
 
 				rsreq.APIURL = "https://api01.example.com"
-				if _, err := cs.ah.UpdateRemoteSource(ctx, "rs01", rsreq); err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				_, err = cs.ah.UpdateRemoteSource(ctx, "rs01", rsreq)
+				testutil.NilError(t, err)
 			},
 		},
 		{
@@ -1827,9 +1663,8 @@ func TestRemoteSource(t *testing.T) {
 					Oauth2ClientID:     "clientid",
 					Oauth2ClientSecret: "clientsecret",
 				}
-				if _, err := cs.ah.CreateRemoteSource(ctx, rs01req); err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				_, err := cs.ah.CreateRemoteSource(ctx, rs01req)
+				testutil.NilError(t, err)
 
 				rs02req := &action.CreateUpdateRemoteSourceRequest{
 					Name:               "rs02",
@@ -1839,13 +1674,12 @@ func TestRemoteSource(t *testing.T) {
 					Oauth2ClientID:     "clientid",
 					Oauth2ClientSecret: "clientsecret",
 				}
-				if _, err := cs.ah.CreateRemoteSource(ctx, rs02req); err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				_, err = cs.ah.CreateRemoteSource(ctx, rs02req)
+				testutil.NilError(t, err)
 
 				expectedError := util.NewAPIError(util.ErrBadRequest, errors.Errorf(`remotesource "rs02" already exists`))
 				rs01req.Name = "rs02"
-				_, err := cs.ah.UpdateRemoteSource(ctx, "rs01", rs01req)
+				_, err = cs.ah.UpdateRemoteSource(ctx, "rs01", rs01req)
 				if err.Error() != expectedError.Error() {
 					t.Fatalf("expected err: %v, got err: %v", expectedError.Error(), err.Error())
 				}
@@ -1882,27 +1716,20 @@ func TestDeleteUser(t *testing.T) {
 			name: "test delete user by id",
 			f: func(ctx context.Context, t *testing.T, cs *Configstore) {
 				users, err := getUsers(ctx, cs)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
-				if err := cs.ah.DeleteUser(ctx, users[0].ID); err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
-
+				err = cs.ah.DeleteUser(ctx, users[0].ID)
+				testutil.NilError(t, err)
 			},
 		},
 		{
 			name: "test delete user by name",
 			f: func(ctx context.Context, t *testing.T, cs *Configstore) {
 				users, err := getUsers(ctx, cs)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
-				if err := cs.ah.DeleteUser(ctx, users[0].Name); err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				err = cs.ah.DeleteUser(ctx, users[0].Name)
+				testutil.NilError(t, err)
 			},
 		},
 	}
@@ -1917,41 +1744,37 @@ func TestDeleteUser(t *testing.T) {
 
 			t.Logf("starting cs")
 
-			if _, err := cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: "user01"}); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			_, err := cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: "user01"})
+			testutil.NilError(t, err)
 
 			// create related entries
 			// add new entries related to user when needed to properly test
 			// that all will be removed alongside the user
-			if _, err := cs.ah.CreateRemoteSource(ctx, &action.CreateUpdateRemoteSourceRequest{Name: "rs01", Type: types.RemoteSourceTypeGitea, AuthType: types.RemoteSourceAuthTypePassword, APIURL: "http://example.com"}); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
-			if _, err := cs.ah.CreateUserLA(ctx, &action.CreateUserLARequest{UserRef: "user01", RemoteSourceName: "rs01"}); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
-			if _, err := cs.ah.CreateUserToken(ctx, "user01", "token01"); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			_, err = cs.ah.CreateRemoteSource(ctx, &action.CreateUpdateRemoteSourceRequest{Name: "rs01", Type: types.RemoteSourceTypeGitea, AuthType: types.RemoteSourceAuthTypePassword, APIURL: "http://example.com"})
+			testutil.NilError(t, err)
 
-			if _, err := cs.ah.CreateOrg(ctx, &action.CreateOrgRequest{Name: "org01", Visibility: types.VisibilityPublic}); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
-			if _, err := cs.ah.AddOrgMember(ctx, "org01", "user01", types.MemberRoleMember); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
-			if _, err := cs.ah.CreateOrgInvitation(ctx, &action.CreateOrgInvitationRequest{OrganizationRef: "org01", UserRef: "user01", Role: types.MemberRoleMember}); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			_, err = cs.ah.CreateUserLA(ctx, &action.CreateUserLARequest{UserRef: "user01", RemoteSourceName: "rs01"})
+			testutil.NilError(t, err)
+
+			_, err = cs.ah.CreateUserToken(ctx, "user01", "token01")
+			testutil.NilError(t, err)
+
+			_, err = cs.ah.CreateOrg(ctx, &action.CreateOrgRequest{Name: "org01", Visibility: types.VisibilityPublic})
+			testutil.NilError(t, err)
+
+			_, err = cs.ah.AddOrgMember(ctx, "org01", "user01", types.MemberRoleMember)
+			testutil.NilError(t, err)
+
+			_, err = cs.ah.CreateOrgInvitation(ctx, &action.CreateOrgInvitationRequest{OrganizationRef: "org01", UserRef: "user01", Role: types.MemberRoleMember})
+			testutil.NilError(t, err)
 
 			go func() { _ = cs.Run(ctx) }()
 
 			tt.f(ctx, t, cs)
 
 			users, err := getUsers(ctx, cs)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			if len(users) != 0 {
 				t.Fatalf("expected 0 users, got %d users", len(users))
 			}
@@ -1972,26 +1795,20 @@ func TestDeleteOrg(t *testing.T) {
 			name: "test delete org by id",
 			f: func(ctx context.Context, t *testing.T, cs *Configstore) {
 				orgs, err := getOrgs(ctx, cs)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
-				if err := cs.ah.DeleteOrg(ctx, orgs[0].ID); err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				err = cs.ah.DeleteOrg(ctx, orgs[0].ID)
+				testutil.NilError(t, err)
 			},
 		},
 		{
 			name: "test delete org by name",
 			f: func(ctx context.Context, t *testing.T, cs *Configstore) {
 				orgs, err := getOrgs(ctx, cs)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
-				if err := cs.ah.DeleteOrg(ctx, orgs[0].Name); err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				err = cs.ah.DeleteOrg(ctx, orgs[0].Name)
+				testutil.NilError(t, err)
 			},
 		},
 	}
@@ -2007,31 +1824,27 @@ func TestDeleteOrg(t *testing.T) {
 			t.Logf("starting cs")
 
 			_, err := cs.ah.CreateOrg(ctx, &action.CreateOrgRequest{Name: "org01", Visibility: types.VisibilityPublic})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			// create related entries
 			// add new entries related to org when needed to properly test
 			// that all will be removed alongside the org
-			if _, err := cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: "user01"}); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
-			if _, err := cs.ah.AddOrgMember(ctx, "org01", "user01", types.MemberRoleMember); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
-			if _, err := cs.ah.CreateOrgInvitation(ctx, &action.CreateOrgInvitationRequest{OrganizationRef: "org01", UserRef: "user01", Role: types.MemberRoleMember}); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			_, err = cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: "user01"})
+			testutil.NilError(t, err)
+
+			_, err = cs.ah.AddOrgMember(ctx, "org01", "user01", types.MemberRoleMember)
+			testutil.NilError(t, err)
+
+			_, err = cs.ah.CreateOrgInvitation(ctx, &action.CreateOrgInvitationRequest{OrganizationRef: "org01", UserRef: "user01", Role: types.MemberRoleMember})
+			testutil.NilError(t, err)
 
 			go func() { _ = cs.Run(ctx) }()
 
 			tt.f(ctx, t, cs)
 
 			orgs, err := getOrgs(ctx, cs)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			if len(orgs) != 0 {
 				t.Fatalf("expected 0 orgs, got %d orgs", len(orgs))
 			}
@@ -2046,17 +1859,15 @@ func TestOrgInvitation(t *testing.T) {
 
 	setupUsers := func(t *testing.T, ctx context.Context, cs *Configstore) {
 		for i := 1; i < 5; i++ {
-			if _, err := cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: fmt.Sprintf("user%d", i)}); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			_, err := cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: fmt.Sprintf("user%d", i)})
+			testutil.NilError(t, err)
 		}
 	}
 
 	setupOrgs := func(t *testing.T, ctx context.Context, cs *Configstore, creatorUserID string) {
 		for i := 1; i < 5; i++ {
-			if _, err := cs.ah.CreateOrg(ctx, &action.CreateOrgRequest{Name: fmt.Sprintf("org%d", i), Visibility: "public", CreatorUserID: creatorUserID}); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			_, err := cs.ah.CreateOrg(ctx, &action.CreateOrgRequest{Name: fmt.Sprintf("org%d", i), Visibility: "public", CreatorUserID: creatorUserID})
+			testutil.NilError(t, err)
 		}
 	}
 
@@ -2088,9 +1899,8 @@ func TestOrgInvitation(t *testing.T) {
 					Role:            types.MemberRoleMember,
 				}
 				_, err = cs.ah.CreateOrgInvitation(ctx, rs)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				fmt.Println("err:", err)
 			},
 		},
@@ -2122,9 +1932,7 @@ func TestOrgInvitation(t *testing.T) {
 					Role:            types.MemberRoleMember,
 				}
 				_, err = cs.ah.CreateOrgInvitation(ctx, rs)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				expectedError := util.NewAPIError(util.ErrBadRequest, errors.Errorf("invitation already exists"))
 				_, err = cs.ah.CreateOrgInvitation(ctx, rs)
@@ -2157,19 +1965,14 @@ func TestOrgInvitation(t *testing.T) {
 					Role:            types.MemberRoleMember,
 				}
 				_, err = cs.ah.CreateOrgInvitation(ctx, rs)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				err = cs.ah.DeleteOrg(ctx, org.ID)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				orgInvitations, err := cs.ah.GetUserOrgInvitations(ctx, userInvitation.ID)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				if len(orgInvitations) != 0 {
 					t.Fatalf("expected 0 orgInvitations, got %d orgInvitations", len(orgInvitations))
 				}
@@ -2200,19 +2003,14 @@ func TestOrgInvitation(t *testing.T) {
 					Role:            types.MemberRoleMember,
 				}
 				_, err = cs.ah.CreateOrgInvitation(ctx, rs)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				err = cs.ah.DeleteUser(ctx, userInvitation.ID)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				orgInvitations, err := cs.ah.GetOrgInvitations(ctx, org.ID)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				if len(orgInvitations) != 0 {
 					t.Fatalf("expected 0 orgInvitations, got %d orgInvitations", len(orgInvitations))
 				}
@@ -2223,17 +2021,16 @@ func TestOrgInvitation(t *testing.T) {
 			f: func(ctx context.Context, t *testing.T, cs *Configstore) {
 				setupUsers(t, ctx, cs)
 				users, err := getUsers(ctx, cs)
-				if err != nil {
-					t.Fatalf("err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				userOwner := users[0]
 				userInvitation := users[1]
 
 				setupOrgs(t, ctx, cs, userOwner.ID)
+
 				orgs, err := getOrgs(ctx, cs)
-				if err != nil {
-					t.Fatalf("err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				org := orgs[0]
 
 				rs := &action.CreateOrgInvitationRequest{
@@ -2242,19 +2039,14 @@ func TestOrgInvitation(t *testing.T) {
 					Role:            types.MemberRoleMember,
 				}
 				_, err = cs.ah.CreateOrgInvitation(ctx, rs)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_, err = cs.ah.AddOrgMember(ctx, org.ID, userInvitation.ID, types.MemberRoleMember)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				orgInvitations, err := cs.ah.GetOrgInvitations(ctx, org.ID)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				if len(orgInvitations) != 0 {
 					t.Fatalf("expected 0 orgInvitations, got %d orgInvitations", len(orgInvitations))
 				}

--- a/internal/services/configstore/db/tests/migrate_test.go
+++ b/internal/services/configstore/db/tests/migrate_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/rs/zerolog"
-	"gotest.tools/assert"
 
 	"agola.io/agola/internal/services/configstore/db"
 	"agola.io/agola/internal/services/configstore/db/objects"
@@ -20,12 +19,12 @@ func newSetupDBFn(log zerolog.Logger) testutil.SetupDBFn {
 		sdb, lf, dbConnString := testutil.CreateDB(t, log, ctx, dir)
 
 		d, err := db.NewDB(log, sdb)
-		assert.NilError(t, err, "new db error")
+		testutil.NilError(t, err, "new db error")
 
 		dbm := manager.NewDBManager(log, d, lf)
 
 		err = dbm.Setup(ctx)
-		assert.NilError(t, err, "setup db error")
+		testutil.NilError(t, err, "setup db error")
 
 		sc := &testutil.DBContext{D: d, DBM: dbm, LF: lf, DBConnString: dbConnString}
 

--- a/internal/services/executor/driver/docker_test.go
+++ b/internal/services/executor/driver/docker_test.go
@@ -43,15 +43,11 @@ func TestDockerPod(t *testing.T) {
 	initImage := "busybox:stable"
 
 	d, err := NewDockerDriver(log, "executorid01", toolboxPath, initImage, nil)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	ctx := context.Background()
-
-	if err := d.Setup(ctx); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	err = d.Setup(ctx)
+	testutil.NilError(t, err)
 
 	t.Run("create a pod with one container", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
@@ -65,9 +61,8 @@ func TestDockerPod(t *testing.T) {
 			},
 			InitVolumeDir: "/tmp/agola",
 		}, io.Discard)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		defer func() { _ = pod.Remove(ctx) }()
 	})
 
@@ -83,22 +78,18 @@ func TestDockerPod(t *testing.T) {
 			},
 			InitVolumeDir: "/tmp/agola",
 		}, io.Discard)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		defer func() { _ = pod.Remove(ctx) }()
 
 		ce, err := pod.Exec(ctx, &ExecConfig{
 			Cmd: []string{"ls"},
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		code, err := ce.Wait(ctx)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if code != 0 {
 			t.Fatalf("unexpected exit code: %d", code)
 		}
@@ -122,9 +113,8 @@ func TestDockerPod(t *testing.T) {
 			},
 			InitVolumeDir: "/tmp/agola",
 		}, io.Discard)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		defer func() { _ = pod.Remove(ctx) }()
 
 		var buf bytes.Buffer
@@ -133,22 +123,17 @@ func TestDockerPod(t *testing.T) {
 			Stdout: &buf,
 			Stderr: &buf,
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		code, err := ce.Wait(ctx)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if code != 0 {
 			t.Fatalf("unexpected exit code: %d", code)
 		}
 
 		curEnv, err := testutil.ParseEnvs(bytes.NewReader(buf.Bytes()))
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		for n, e := range env {
 			if ce, ok := curEnv[n]; !ok {
@@ -176,9 +161,8 @@ func TestDockerPod(t *testing.T) {
 			},
 			InitVolumeDir: "/tmp/agola",
 		}, io.Discard)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		defer func() { _ = pod.Remove(ctx) }()
 	})
 
@@ -197,9 +181,8 @@ func TestDockerPod(t *testing.T) {
 			},
 			InitVolumeDir: "/tmp/agola",
 		}, io.Discard)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		defer func() { _ = pod.Remove(ctx) }()
 
 		// wait for nginx up
@@ -208,14 +191,11 @@ func TestDockerPod(t *testing.T) {
 		ce, err := pod.Exec(ctx, &ExecConfig{
 			Cmd: []string{"nc", "-z", "localhost", "80"},
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		code, err := ce.Wait(ctx)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if code != 0 {
 			t.Fatalf("unexpected exit code: %d", code)
 		}
@@ -233,15 +213,12 @@ func TestDockerPod(t *testing.T) {
 			},
 			InitVolumeDir: "/tmp/agola",
 		}, io.Discard)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		defer func() { _ = pod.Remove(ctx) }()
 
 		pods, err := d.GetPods(ctx, true)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		ok := false
 		for _, p := range pods {
@@ -279,15 +256,12 @@ func TestDockerPod(t *testing.T) {
 			},
 			InitVolumeDir: "/tmp/agola",
 		}, io.Discard)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		defer func() { _ = pod.Remove(ctx) }()
 
 		pods, err := d.GetPods(ctx, true)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		ok := false
 		for _, p := range pods {
@@ -325,21 +299,17 @@ func TestDockerPod(t *testing.T) {
 			},
 			InitVolumeDir: "/tmp/agola",
 		}, io.Discard)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		defer func() { _ = pod.Remove(ctx) }()
 
 		// delete the first container
 		dp := pod.(*DockerPod)
-		if err := dp.client.ContainerRemove(ctx, dp.containers[0].ID, types.ContainerRemoveOptions{Force: true}); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		err = dp.client.ContainerRemove(ctx, dp.containers[0].ID, types.ContainerRemoveOptions{Force: true})
+		testutil.NilError(t, err)
 
 		pods, err := d.GetPods(ctx, true)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		ok := false
 		for _, p := range pods {
@@ -383,22 +353,18 @@ func TestDockerPod(t *testing.T) {
 			},
 			InitVolumeDir: "/tmp/agola",
 		}, io.Discard)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		defer func() { _ = pod.Remove(ctx) }()
 
 		ce, err := pod.Exec(ctx, &ExecConfig{
 			Cmd: []string{"sh", "-c", "if [ $(grep /mnt/tmpfs /proc/mounts | grep -c size=1024k) -ne 1 ]; then exit 1; fi"},
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		code, err := ce.Wait(ctx)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if code != 0 {
 			t.Fatalf("unexpected exit code: %d", code)
 		}
@@ -422,22 +388,18 @@ func TestDockerPod(t *testing.T) {
 			},
 			InitVolumeDir: "/tmp/agola",
 		}, io.Discard)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		defer func() { _ = pod.Remove(ctx) }()
 
 		ce, err := pod.Exec(ctx, &ExecConfig{
 			Cmd: []string{"sh", "-c", "if [ $(grep -c /mnt/tmpfs /proc/mounts) -ne 1 ]; then exit 1; fi"},
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		code, err := ce.Wait(ctx)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if code != 0 {
 			t.Fatalf("unexpected exit code: %d", code)
 		}
@@ -469,22 +431,18 @@ func TestDockerPod(t *testing.T) {
 			},
 			InitVolumeDir: "/tmp/agola",
 		}, io.Discard)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		defer func() { _ = pod.Remove(ctx) }()
 
 		ce, err := pod.Exec(ctx, &ExecConfig{
 			Cmd: []string{"sh", "-c", "if [ $(grep /mnt/vol1 /proc/mounts | grep -c size=1024k) -ne 1 -o $(grep /mnt/vol2 /proc/mounts | grep -c size=1024k) -ne 1 ]; then exit 1; fi"},
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		code, err := ce.Wait(ctx)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if code != 0 {
 			t.Fatalf("unexpected exit code: %d", code)
 		}
@@ -514,22 +472,18 @@ func TestDockerPod(t *testing.T) {
 			},
 			InitVolumeDir: "/tmp/agola",
 		}, io.Discard)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		defer func() { _ = pod.Remove(ctx) }()
 
 		ce, err := pod.Exec(ctx, &ExecConfig{
 			Cmd: []string{"sh", "-c", "if [ $(grep /mnt/vol1 /proc/mounts | grep -c size=1024k) -ne 1 -o $(grep -c /mnt/vol2 /proc/mounts) -ne 1 ]; then exit 1; fi"},
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		code, err := ce.Wait(ctx)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if code != 0 {
 			t.Fatalf("unexpected exit code: %d", code)
 		}

--- a/internal/services/executor/driver/k8s_test.go
+++ b/internal/services/executor/driver/k8s_test.go
@@ -42,15 +42,11 @@ func TestK8sPod(t *testing.T) {
 	initImage := "busybox:stable"
 
 	d, err := NewK8sDriver(log, "executorid01", toolboxPath, initImage, nil)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	ctx := context.Background()
-
-	if err := d.Setup(ctx); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	err = d.Setup(ctx)
+	testutil.NilError(t, err)
 
 	t.Run("create a pod with one container", func(t *testing.T) {
 		pod, err := d.NewPod(ctx, &PodConfig{
@@ -64,9 +60,8 @@ func TestK8sPod(t *testing.T) {
 			},
 			InitVolumeDir: "/tmp/agola",
 		}, io.Discard)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		defer func() { _ = pod.Remove(ctx) }()
 	})
 
@@ -82,9 +77,8 @@ func TestK8sPod(t *testing.T) {
 			},
 			InitVolumeDir: "/tmp/agola",
 		}, io.Discard)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		defer func() { _ = pod.Remove(ctx) }()
 
 		var buf bytes.Buffer
@@ -92,14 +86,11 @@ func TestK8sPod(t *testing.T) {
 			Cmd:    []string{"ls"},
 			Stdout: &buf,
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		code, err := ce.Wait(ctx)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if code != 0 {
 			t.Fatalf("unexpected exit code: %d", code)
 		}
@@ -123,9 +114,8 @@ func TestK8sPod(t *testing.T) {
 			},
 			InitVolumeDir: "/tmp/agola",
 		}, io.Discard)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		defer func() { _ = pod.Remove(ctx) }()
 
 		var buf bytes.Buffer
@@ -134,22 +124,17 @@ func TestK8sPod(t *testing.T) {
 			Stdout: &buf,
 			Stderr: os.Stdout,
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		code, err := ce.Wait(ctx)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if code != 0 {
 			t.Fatalf("unexpected exit code: %d", code)
 		}
 
 		curEnv, err := testutil.ParseEnvs(bytes.NewReader(buf.Bytes()))
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		for n, e := range env {
 			if ce, ok := curEnv[n]; !ok {
@@ -177,9 +162,8 @@ func TestK8sPod(t *testing.T) {
 			},
 			InitVolumeDir: "/tmp/agola",
 		}, io.Discard)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		defer func() { _ = pod.Remove(ctx) }()
 	})
 
@@ -198,9 +182,8 @@ func TestK8sPod(t *testing.T) {
 			},
 			InitVolumeDir: "/tmp/agola",
 		}, io.Discard)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		defer func() { _ = pod.Remove(ctx) }()
 
 		// wait for nginx up
@@ -211,14 +194,11 @@ func TestK8sPod(t *testing.T) {
 			Cmd:    []string{"nc", "-z", "localhost", "80"},
 			Stdout: &buf,
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		code, err := ce.Wait(ctx)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if code != 0 {
 			t.Fatalf("unexpected exit code: %d", code)
 		}
@@ -236,15 +216,12 @@ func TestK8sPod(t *testing.T) {
 			},
 			InitVolumeDir: "/tmp/agola",
 		}, io.Discard)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		defer func() { _ = pod.Remove(ctx) }()
 
 		pods, err := d.GetPods(ctx, true)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		ok := false
 		for _, p := range pods {
@@ -277,9 +254,8 @@ func TestK8sPod(t *testing.T) {
 			},
 			InitVolumeDir: "/tmp/agola",
 		}, io.Discard)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		defer func() { _ = pod.Remove(ctx) }()
 
 		var buf bytes.Buffer
@@ -288,14 +264,11 @@ func TestK8sPod(t *testing.T) {
 			Cmd:    []string{"sh", "-c", "if [ $(grep -c /mnt/tmpfs /proc/mounts) -ne 1 ]; then exit 1; fi"},
 			Stdout: &buf,
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		code, err := ce.Wait(ctx)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if code != 0 {
 			t.Fatalf("unexpected exit code: %d", code)
 		}
@@ -327,9 +300,8 @@ func TestK8sPod(t *testing.T) {
 			},
 			InitVolumeDir: "/tmp/agola",
 		}, io.Discard)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		defer func() { _ = pod.Remove(ctx) }()
 
 		var buf bytes.Buffer
@@ -338,14 +310,11 @@ func TestK8sPod(t *testing.T) {
 			Cmd:    []string{"sh", "-c", "if [ $(grep -c /mnt/vol1 /proc/mounts) -ne 1 -o $(grep -c /mnt/vol2 /proc/mounts) -ne 1 ]; then exit 1; fi"},
 			Stdout: &buf,
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		code, err := ce.Wait(ctx)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if code != 0 {
 			t.Fatalf("unexpected exit code: %d", code)
 		}
@@ -383,18 +352,18 @@ func TestParseGitVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
 			sv, err := parseGitVersion(tt.gitVersion)
-			if tt.err {
-				if err == nil {
-					t.Errorf("expected error, got nil error")
-				}
-				return
-			}
 			if err != nil {
-				t.Errorf("unexpected err: %v", err)
-				return
+				if !tt.err {
+					t.Fatalf("got error, want no error")
+				}
+			} else {
+				if tt.err {
+					t.Fatalf("got no error, want error")
+				}
 			}
+
 			if !reflect.DeepEqual(sv, tt.out) {
-				t.Errorf("expected %v, got %v", tt.out, sv)
+				t.Fatalf("expected %v, got %v", tt.out, sv)
 			}
 		})
 	}

--- a/internal/services/gitserver/gitserver_test.go
+++ b/internal/services/gitserver/gitserver_test.go
@@ -34,29 +34,24 @@ const (
 )
 
 func createTag(t *testing.T, ctx context.Context, git *util.Git, committerTime time.Time) {
-	if _, err := git.Output(ctx, nil, "branch", "test"); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err := git.Output(ctx, nil, "branch", "test")
+	testutil.NilError(t, err)
 
-	if _, err := git.Output(ctx, nil, "checkout", "test"); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = git.Output(ctx, nil, "checkout", "test")
+	testutil.NilError(t, err)
 
 	git.Env = append(git.Env, "GIT_COMMITTER_DATE="+committerTime.Format(time.RFC3339))
-	if _, err := git.Output(ctx, nil, "commit", "--allow-empty", "-m", "root commit"); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = git.Output(ctx, nil, "commit", "--allow-empty", "-m", "root commit")
+	testutil.NilError(t, err)
 
-	if _, err := git.Output(ctx, nil, "tag", tagName, "-m", "tag test"); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = git.Output(ctx, nil, "tag", tagName, "-m", "tag test")
+	testutil.NilError(t, err)
 }
 
 func createBranch(t *testing.T, ctx context.Context, git *util.Git, committerTime time.Time) {
 	git.Env = append(git.Env, "GIT_COMMITTER_DATE="+committerTime.Format(time.RFC3339))
-	if _, err := git.Output(ctx, nil, "commit", "--allow-empty", "-m", "'root commit'"); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err := git.Output(ctx, nil, "commit", "--allow-empty", "-m", "'root commit'")
+	testutil.NilError(t, err)
 }
 
 func TestRepoCleaner(t *testing.T) {
@@ -101,30 +96,24 @@ func TestRepoCleaner(t *testing.T) {
 			}
 
 			gs, err := NewGitserver(ctx, log, config)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			userDirRepo := filepath.Join(gitDataDir, "user01", "repo01")
 			err = os.MkdirAll(userDirRepo, os.ModePerm)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			git := &util.Git{GitDir: userDirRepo}
+			_, err = git.Output(ctx, nil, "init")
+			testutil.NilError(t, err)
 
-			if _, err := git.Output(ctx, nil, "init"); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
-			if _, err := git.Output(ctx, nil, "config", "--unset", "core.bare"); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
-			if _, err := git.Output(ctx, nil, "config", "user.email", "user01@example.com"); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
-			if _, err := git.Output(ctx, nil, "config", "user.name", "user01"); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			_, err = git.Output(ctx, nil, "config", "--unset", "core.bare")
+			testutil.NilError(t, err)
+
+			_, err = git.Output(ctx, nil, "config", "user.email", "user01@example.com")
+			testutil.NilError(t, err)
+
+			_, err = git.Output(ctx, nil, "config", "user.name", "user01")
+			testutil.NilError(t, err)
 
 			var committerTime time.Time
 			if tt.branchOldTime {
@@ -140,14 +129,11 @@ func TestRepoCleaner(t *testing.T) {
 				committerTime = time.Now()
 			}
 			createTag(t, ctx, git, committerTime)
+			_, err = git.Output(ctx, nil, "config", "--bool", "core.bare", "true")
+			testutil.NilError(t, err)
 
-			if _, err := git.Output(ctx, nil, "config", "--bool", "core.bare", "true"); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
-
-			if err := gs.scanRepos(ctx); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			err = gs.scanRepos(ctx)
+			testutil.NilError(t, err)
 
 			if tt.branchOldTime && tt.tagOldTime {
 				_, err = os.Open(userDirRepo)
@@ -159,9 +145,7 @@ func TestRepoCleaner(t *testing.T) {
 			}
 
 			branches, err := gs.getBranches(git, ctx)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			found := false
 			for _, b := range branches {
@@ -178,9 +162,8 @@ func TestRepoCleaner(t *testing.T) {
 			}
 
 			tags, err := gs.getTags(git, ctx)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			found = false
 			for _, b := range tags {
 				if b == tagName {

--- a/internal/services/notification/db/tests/migrate_test.go
+++ b/internal/services/notification/db/tests/migrate_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/rs/zerolog"
-	"gotest.tools/assert"
 
 	"agola.io/agola/internal/services/notification/db"
 	"agola.io/agola/internal/services/notification/db/objects"
@@ -20,12 +19,12 @@ func newSetupDBFn(log zerolog.Logger) testutil.SetupDBFn {
 		sdb, lf, dbConnString := testutil.CreateDB(t, log, ctx, dir)
 
 		d, err := db.NewDB(log, sdb)
-		assert.NilError(t, err, "new db error")
+		testutil.NilError(t, err, "new db error")
 
 		dbm := manager.NewDBManager(log, d, lf)
 
 		err = dbm.Setup(ctx)
-		assert.NilError(t, err, "setup db error")
+		testutil.NilError(t, err, "setup db error")
 
 		sc := &testutil.DBContext{D: d, DBM: dbm, LF: lf, DBConnString: dbConnString}
 

--- a/internal/services/notification/notification_test.go
+++ b/internal/services/notification/notification_test.go
@@ -65,9 +65,7 @@ func setupNotificationService(ctx context.Context, t *testing.T, log zerolog.Log
 	}
 
 	ns, err := NewNotificationService(ctx, log, &c)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	return ns
 }
@@ -97,10 +95,8 @@ func TestRunWebhookDelivery(t *testing.T) {
 			runWebhooks[i] = createRunWebhook(t, ctx, ns, project01)
 			createRunWebhookDelivery(t, ctx, ns, runWebhooks[i].ID, types.DeliveryStatusNotDelivered)
 		}
-
-		if err := ns.runWebhookDeliveriesHandler(ctx); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		err := ns.runWebhookDeliveriesHandler(ctx)
+		testutil.NilError(t, err)
 
 		runWebhookDeliveries := getRunWebhookDeliveries(t, ctx, ns)
 		if len(runWebhookDeliveries) != len(runWebhooks) {
@@ -113,9 +109,8 @@ func TestRunWebhookDelivery(t *testing.T) {
 		}
 
 		webhooks, err := wr.webhooks.getWebhooks()
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(webhooks) != len(runWebhooks) {
 			t.Fatalf("expected %d run webhook got: %d", len(runWebhooks), len(webhooks))
 		}
@@ -125,9 +120,9 @@ func TestRunWebhookDelivery(t *testing.T) {
 			}
 
 			h256 := hmac.New(sha256.New, []byte(webhookSecret))
-			if _, err = h256.Write([]byte(runWebhooks[i].Payload)); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			_, err = h256.Write([]byte(runWebhooks[i].Payload))
+			testutil.NilError(t, err)
+
 			expectedsignature := hex.EncodeToString(h256.Sum(nil))
 
 			if webhooks[i].Signature != expectedsignature {
@@ -139,14 +134,12 @@ func TestRunWebhookDelivery(t *testing.T) {
 
 		wr.webhooks.resetWebhooks()
 
-		if err := ns.runWebhookDeliveriesHandler(ctx); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		err = ns.runWebhookDeliveriesHandler(ctx)
+		testutil.NilError(t, err)
 
 		webhooks, err = wr.webhooks.getWebhooks()
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(webhooks) != 0 {
 			t.Fatalf("expected %d run webhook got: %d", 0, len(webhooks))
 		}
@@ -163,10 +156,8 @@ func TestRunWebhookDelivery(t *testing.T) {
 
 		runWebhook := createRunWebhook(t, ctx, ns, project01)
 		createRunWebhookDelivery(t, ctx, ns, runWebhook.ID, types.DeliveryStatusNotDelivered)
-
-		if err := ns.runWebhookDeliveriesHandler(ctx); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		err := ns.runWebhookDeliveriesHandler(ctx)
+		testutil.NilError(t, err)
 
 		runWebhookDeliveries := getRunWebhookDeliveries(t, ctx, ns)
 		if len(runWebhookDeliveries) != 1 {
@@ -214,9 +205,7 @@ func TestLastRunEventSequence(t *testing.T) {
 	expectedLastRunEventSequenceValue := uint64(2)
 
 	err := ns.runEventsHandler(ctx)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	lastRunEventSequenceValue = getLastRunEventSequenceValue(t, ctx, ns)
 	if lastRunEventSequenceValue != expectedLastRunEventSequenceValue {
@@ -231,9 +220,7 @@ func TestLastRunEventSequence(t *testing.T) {
 	runEventsSender.runEvents.addRunEvent(runEvents[3])
 
 	err = ns.runEventsHandler(ctx)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	runWebhooks := getRunWebhooks(t, ctx, ns)
 	if len(runWebhooks) != len(runEvents) {
@@ -243,9 +230,7 @@ func TestLastRunEventSequence(t *testing.T) {
 	for i := range runEvents {
 		runWebhook := ns.generatewebhook(ctx, runEvents[i])
 		webhookPayload, err := json.Marshal(runWebhook)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		if !bytes.Equal(runWebhooks[i].Payload, webhookPayload) {
 			t.Fatalf("expected %s run webhook payload got: %s", runWebhooks[i].Payload, webhookPayload)
@@ -282,9 +267,7 @@ func getLastRunEventSequenceValue(t *testing.T, ctx context.Context, ns *Notific
 
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	return lastRunEventSequence
 }
@@ -301,9 +284,7 @@ func getRunWebhookDeliveries(t *testing.T, ctx context.Context, ns *Notification
 
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	return wd
 }
@@ -322,9 +303,7 @@ func createRunWebhook(t *testing.T, ctx context.Context, ns *NotificationService
 
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	return wh
 }
@@ -341,9 +320,7 @@ func getRunWebhooks(t *testing.T, ctx context.Context, ns *NotificationService) 
 
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	return runWebhooks
 }
@@ -362,9 +339,7 @@ func createRunWebhookDelivery(t *testing.T, ctx context.Context, ns *Notificatio
 
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	return wd
 }
@@ -384,9 +359,7 @@ func updateRunWebhookCreationDate(t *testing.T, ctx context.Context, ns *Notific
 
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 }
 
 func TestCommitStatusDelivery(t *testing.T) {
@@ -411,10 +384,8 @@ func TestCommitStatusDelivery(t *testing.T) {
 			commitStatuses[i] = createCommitStatus(t, ctx, ns, i, fmt.Sprintf("projectID-%d", i))
 			createCommitStatusDelivery(t, ctx, ns, commitStatuses[i].ID, types.DeliveryStatusNotDelivered)
 		}
-
-		if err := ns.commitStatusDeliveriesHandler(ctx); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		err := ns.commitStatusDeliveriesHandler(ctx)
+		testutil.NilError(t, err)
 
 		commitStatusDeliveries := getCommitStatusDeliveries(t, ctx, ns)
 		if len(commitStatusDeliveries) != len(commitStatuses) {
@@ -427,9 +398,8 @@ func TestCommitStatusDelivery(t *testing.T) {
 		}
 
 		commitStatusesReceived, err := cs.commitStatuses.getCommitStatuses()
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(commitStatusesReceived) != len(commitStatuses) {
 			t.Fatalf("expected %d run commitStatus got: %d", len(commitStatuses), len(commitStatusesReceived))
 		}
@@ -451,14 +421,12 @@ func TestCommitStatusDelivery(t *testing.T) {
 
 		cs.commitStatuses.resetCommitStatuses()
 
-		if err := ns.commitStatusDeliveriesHandler(ctx); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		err = ns.commitStatusDeliveriesHandler(ctx)
+		testutil.NilError(t, err)
 
 		commitStatusesReceived, err = cs.commitStatuses.getCommitStatuses()
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(commitStatusesReceived) != 0 {
 			t.Fatalf("expected %d commit status got: %d", 0, len(commitStatusesReceived))
 		}
@@ -481,10 +449,8 @@ func TestCommitStatusDelivery(t *testing.T) {
 
 		commitStatus := createCommitStatus(t, ctx, ns, 1, project01)
 		createCommitStatusDelivery(t, ctx, ns, commitStatus.ID, types.DeliveryStatusNotDelivered)
-
-		if err := ns.commitStatusDeliveriesHandler(ctx); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		err := ns.commitStatusDeliveriesHandler(ctx)
+		testutil.NilError(t, err)
 
 		commitStatusDeliveries := getCommitStatusDeliveries(t, ctx, ns)
 		if len(commitStatusDeliveries) != 1 {
@@ -515,9 +481,7 @@ func createCommitStatus(t *testing.T, ctx context.Context, ns *NotificationServi
 
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	return cs
 }
@@ -537,9 +501,7 @@ func updateCommitStatusCreationDate(t *testing.T, ctx context.Context, ns *Notif
 
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 }
 
 func getCommitStatuses(t *testing.T, ctx context.Context, ns *NotificationService) []*types.CommitStatus {
@@ -554,9 +516,7 @@ func getCommitStatuses(t *testing.T, ctx context.Context, ns *NotificationServic
 
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	return commitStatuses
 }
@@ -573,9 +533,7 @@ func getCommitStatusDeliveries(t *testing.T, ctx context.Context, ns *Notificati
 
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	return wd
 }
@@ -594,9 +552,7 @@ func createCommitStatusDelivery(t *testing.T, ctx context.Context, ns *Notificat
 
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	return delivery
 }
@@ -628,9 +584,8 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 
 	t.Run("test get run webhook deliveries with limit = 0", func(t *testing.T) {
 		res, err := ns.ah.GetProjectRunWebhookDeliveries(ctx, &action.GetProjectRunWebhookDeliveriesRequest{ProjectID: project01, Limit: 0})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if res.HasMore != false {
 			t.Fatalf("unexpected HasMore true")
 		}
@@ -641,9 +596,8 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 
 	t.Run("test get run webhook deliveries with limit = 10", func(t *testing.T) {
 		res, err := ns.ah.GetProjectRunWebhookDeliveries(ctx, &action.GetProjectRunWebhookDeliveriesRequest{ProjectID: project01, Limit: 10})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if res.HasMore != true {
 			t.Fatalf("unexpected HasMore false")
 		}
@@ -654,9 +608,8 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 
 	t.Run("test get run webhook deliveries with deliverystatusfilter = delivered", func(t *testing.T) {
 		res, err := ns.ah.GetProjectRunWebhookDeliveries(ctx, &action.GetProjectRunWebhookDeliveriesRequest{ProjectID: project01, DeliveryStatusFilter: []types.DeliveryStatus{types.DeliveryStatusDelivered}, Limit: 0})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if res.HasMore != false {
 			t.Fatalf("unexpected HasMore true")
 		}
@@ -667,9 +620,8 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 
 	t.Run("test get run webhook deliveries with deliverystatusfilter = delivered and limit less than run webhook deliveries", func(t *testing.T) {
 		res, err := ns.ah.GetProjectRunWebhookDeliveries(ctx, &action.GetProjectRunWebhookDeliveriesRequest{ProjectID: project01, DeliveryStatusFilter: []types.DeliveryStatus{types.DeliveryStatusDelivered}, Limit: 5})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if res.HasMore != true {
 			t.Fatalf("unexpected HasMore false")
 		}
@@ -682,9 +634,7 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 		respAllProjectRunWebhookDeliveries := []*types.RunWebhookDelivery{}
 
 		res, err := ns.ah.GetProjectRunWebhookDeliveries(ctx, &action.GetProjectRunWebhookDeliveriesRequest{ProjectID: project01, Limit: 5, SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		expectedProjectRunWebhookDeliveries := 5
 		if len(res.RunWebhookDeliveries) != expectedProjectRunWebhookDeliveries {
@@ -700,9 +650,7 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 		// fetch next results
 		for {
 			res, err = ns.ah.GetProjectRunWebhookDeliveries(ctx, &action.GetProjectRunWebhookDeliveriesRequest{ProjectID: project01, StartSequence: lastProjectRunWebhookDelivery.Sequence, Limit: 5, SortDirection: types.SortDirectionAsc})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			if res.HasMore && len(res.RunWebhookDeliveries) != expectedProjectRunWebhookDeliveries {
 				t.Fatalf("expected %d project run webhook deliveries, got %d project run webhook deliveries", expectedProjectRunWebhookDeliveries, len(res.RunWebhookDeliveries))
@@ -739,9 +687,8 @@ func TestDeliveryStatusFromStringSlice(t *testing.T) {
 	}
 
 	result, err := types.DeliveryStatusFromStringSlice(deliverystatus)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if diff := cmp.Diff(result, expectedDeliveryStatus); diff != "" {
 		t.Fatalf("mismatch (-want +got):\n%s", diff)
 	}
@@ -801,9 +748,7 @@ func TestRunWebhooksCleaner(t *testing.T) {
 	}
 
 	err := ns.runWebhooksCleaner(ctx, 30*time.Minute)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	runWebhooks := getRunWebhooks(t, ctx, ns)
 	if len(runWebhooks) != len(expectedRunWebhooks) {
@@ -814,9 +759,8 @@ func TestRunWebhooksCleaner(t *testing.T) {
 	}
 
 	runWebhookDeliveries := getRunWebhookDeliveries(t, ctx, ns)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if len(runWebhookDeliveries) != len(expectedRunWebhookDeliveries) {
 		t.Fatalf("expected %d run webhooks got: %d", len(expectedRunWebhookDeliveries), len(runWebhookDeliveries))
 	}
@@ -854,18 +798,14 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		ns.c.WebhookURL = fmt.Sprintf("%s/%s", wr.exposedURL, "webhooks")
 
 		err := ns.ah.RunWebhookRedelivery(ctx, runWebhook.ProjectID, runWebhookDelivery.ID)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
-		if err := ns.runWebhookDeliveriesHandler(ctx); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		err = ns.runWebhookDeliveriesHandler(ctx)
+		testutil.NilError(t, err)
 
 		res, err := ns.ah.GetProjectRunWebhookDeliveries(ctx, &action.GetProjectRunWebhookDeliveriesRequest{ProjectID: project01, SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(res.RunWebhookDeliveries) != 2 {
 			t.Fatalf("expected 2 RunWebhookDeliveries got: %d", len(res.RunWebhookDeliveries))
 		}
@@ -898,18 +838,14 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		ns.c.WebhookURL = fmt.Sprintf("%s/%s", wr.exposedURL, "webhooks")
 
 		err := ns.ah.RunWebhookRedelivery(ctx, runWebhook.ProjectID, runWebhookDelivery.ID)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
-		if err := ns.runWebhookDeliveriesHandler(ctx); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		err = ns.runWebhookDeliveriesHandler(ctx)
+		testutil.NilError(t, err)
 
 		res, err := ns.ah.GetProjectRunWebhookDeliveries(ctx, &action.GetProjectRunWebhookDeliveriesRequest{ProjectID: project01, SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(res.RunWebhookDeliveries) != 2 {
 			t.Fatalf("expected 2 RunWebhookDeliveries got: %d", len(res.RunWebhookDeliveries))
 		}
@@ -998,14 +934,12 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 			t.Fatalf("expected err %v, got err: %v", expectedErr, err)
 		}
 
-		if err := ns.runWebhookDeliveriesHandler(ctx); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		err = ns.runWebhookDeliveriesHandler(ctx)
+		testutil.NilError(t, err)
 
 		res, err := ns.ah.GetProjectRunWebhookDeliveries(ctx, &action.GetProjectRunWebhookDeliveriesRequest{ProjectID: project01, SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(res.RunWebhookDeliveries) != 1 {
 			t.Fatalf("expected 1 RunWebhookDeliveries got: %d", len(res.RunWebhookDeliveries))
 		}
@@ -1049,9 +983,7 @@ func TestCommitStatusesCleaner(t *testing.T) {
 	}
 
 	err := ns.commitStatusesCleaner(ctx, 30*time.Minute)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	commitStatuses := getCommitStatuses(t, ctx, ns)
 	if len(commitStatuses) != len(expectedCommitStatuses) {
@@ -1062,9 +994,8 @@ func TestCommitStatusesCleaner(t *testing.T) {
 	}
 
 	commitStatusDeliveries := getCommitStatusDeliveries(t, ctx, ns)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if len(commitStatusDeliveries) != len(expectedCommitStatusDeliveries) {
 		t.Fatalf("expected %d run commitStatusDeliveries got: %d", len(expectedCommitStatusDeliveries), len(commitStatusDeliveries))
 	}
@@ -1100,9 +1031,8 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 
 	t.Run("test get commit status deliveries with limit = 0", func(t *testing.T) {
 		res, err := ns.ah.GetProjectCommitStatusDeliveries(ctx, &action.GetProjectCommitStatusDeliveriesRequest{ProjectID: project01, Limit: 0})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if res.HasMore != false {
 			t.Fatalf("unexpected HasMore true")
 		}
@@ -1113,9 +1043,8 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 
 	t.Run("test get commit status deliveries with limit = 10", func(t *testing.T) {
 		res, err := ns.ah.GetProjectCommitStatusDeliveries(ctx, &action.GetProjectCommitStatusDeliveriesRequest{ProjectID: project01, Limit: 10})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if res.HasMore != true {
 			t.Fatalf("unexpected HasMore false")
 		}
@@ -1126,9 +1055,8 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 
 	t.Run("test get commit status deliveries with deliverystatusfilter = delivered", func(t *testing.T) {
 		res, err := ns.ah.GetProjectCommitStatusDeliveries(ctx, &action.GetProjectCommitStatusDeliveriesRequest{ProjectID: project01, DeliveryStatusFilter: []types.DeliveryStatus{types.DeliveryStatusDelivered}, Limit: 0})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if res.HasMore != false {
 			t.Fatalf("unexpected HasMore true")
 		}
@@ -1139,9 +1067,8 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 
 	t.Run("test get commit status deliveries with deliverystatusfilter = delivered and limit less than commit status deliveries", func(t *testing.T) {
 		res, err := ns.ah.GetProjectCommitStatusDeliveries(ctx, &action.GetProjectCommitStatusDeliveriesRequest{ProjectID: project01, DeliveryStatusFilter: []types.DeliveryStatus{types.DeliveryStatusDelivered}, Limit: 5})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if res.HasMore != true {
 			t.Fatalf("unexpected HasMore false")
 		}
@@ -1154,9 +1081,7 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 		respAllProjectCommitStatusDeliveries := []*types.CommitStatusDelivery{}
 
 		res, err := ns.ah.GetProjectCommitStatusDeliveries(ctx, &action.GetProjectCommitStatusDeliveriesRequest{ProjectID: project01, Limit: 5, SortDirection: types.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		expectedProjectCommitStatusDeliveries := 5
 		if len(res.CommitStatusDeliveries) != expectedProjectCommitStatusDeliveries {
@@ -1172,9 +1097,7 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 		// fetch next results
 		for {
 			res, err = ns.ah.GetProjectCommitStatusDeliveries(ctx, &action.GetProjectCommitStatusDeliveriesRequest{ProjectID: project01, StartSequence: lastProjectCommitStatusDelivery.Sequence, Limit: 5, SortDirection: types.SortDirectionAsc})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			if res.HasMore && len(res.CommitStatusDeliveries) != expectedProjectCommitStatusDeliveries {
 				t.Fatalf("expected %d project commit status deliveries, got %d project commit status deliveries", expectedProjectCommitStatusDeliveries, len(res.CommitStatusDeliveries))

--- a/internal/services/notification/runeventssender_test.go
+++ b/internal/services/notification/runeventssender_test.go
@@ -71,16 +71,12 @@ func setupRunEventsSender(pctx context.Context, t *testing.T) *runEventsSender {
 	es := &runEventsSender{ctx: ctx, t: t, log: log, cancel: cancel, runEvents: r}
 
 	port, err := testutil.GetFreePort("localhost", true, false)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	es.listenAddress = net.JoinHostPort("localhost", port)
 	es.exposedURL = fmt.Sprintf("http://%s", net.JoinHostPort("localhost", port))
-
-	if err := es.start(); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	err = es.start()
+	testutil.NilError(t, err)
 
 	go func() {
 		<-ctx.Done()

--- a/internal/services/notification/webhooksreceiver_test.go
+++ b/internal/services/notification/webhooksreceiver_test.go
@@ -99,16 +99,12 @@ func setupWebhooksReceiver(pctx context.Context, t *testing.T) *webhooksReceiver
 	wr := &webhooksReceiver{ctx: ctx, t: t, log: log, cancel: cancel, webhooks: ws}
 
 	port, err := testutil.GetFreePort("localhost", true, false)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	wr.listenAddress = net.JoinHostPort("localhost", port)
 	wr.exposedURL = fmt.Sprintf("http://%s", net.JoinHostPort("localhost", port))
-
-	if err := wr.start(); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	err = wr.start()
+	testutil.NilError(t, err)
 
 	go func() {
 		<-ctx.Done()

--- a/internal/services/runservice/db/tests/migrate_test.go
+++ b/internal/services/runservice/db/tests/migrate_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/rs/zerolog"
-	"gotest.tools/assert"
 
 	"agola.io/agola/internal/services/runservice/db"
 	"agola.io/agola/internal/services/runservice/db/objects"
@@ -20,12 +19,12 @@ func newSetupDBFn(log zerolog.Logger) testutil.SetupDBFn {
 		sdb, lf, dbConnString := testutil.CreateDB(t, log, ctx, dir)
 
 		d, err := db.NewDB(log, sdb)
-		assert.NilError(t, err, "new db error")
+		testutil.NilError(t, err, "new db error")
 
 		dbm := manager.NewDBManager(log, d, lf)
 
 		err = dbm.Setup(ctx)
-		assert.NilError(t, err, "setup db error")
+		testutil.NilError(t, err, "setup db error")
 
 		sc := &testutil.DBContext{D: d, DBM: dbm, LF: lf, DBConnString: dbConnString}
 

--- a/internal/services/runservice/scheduler_test.go
+++ b/internal/services/runservice/scheduler_test.go
@@ -405,9 +405,8 @@ func TestAdvanceRunTasks(t *testing.T) {
 			t.Parallel()
 
 			r, err := advanceRunTasks(log, tt.r, tt.rc, tt.scheduledExecutorTasks)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			if diff := cmp.Diff(tt.out, r); diff != "" {
 				t.Error(diff)
 			}
@@ -572,9 +571,8 @@ func TestGetTasksToRun(t *testing.T) {
 			t.Parallel()
 
 			tasks, err := getTasksToRun(log, tt.r, tt.rc)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			outTasks := []string{}
 			for _, t := range tasks {
 				outTasks = append(outTasks, t.ID)

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -71,23 +71,23 @@ func CreateDBWithType(t *testing.T, log zerolog.Logger, ctx context.Context, dir
 		connString = filepath.Join(dir, dbName)
 
 		sdb, err = sql.NewDB("sqlite3", connString)
-		assert.NilError(t, err)
+		NilError(t, err)
 
 	case sql.Postgres:
 		dbName := "testdb" + strconv.FormatUint(uint64(rand.Uint32()), 10)
 		connString = fmt.Sprintf(pgConnString, dbName)
 
 		pgdb, err := stdsql.Open("postgres", fmt.Sprintf(pgConnString, "postgres"))
-		assert.NilError(t, err)
+		NilError(t, err)
 
 		_, err = pgdb.Exec(fmt.Sprintf("drop database if exists %s", dbName))
-		assert.NilError(t, err)
+		NilError(t, err)
 
 		_, err = pgdb.Exec(fmt.Sprintf("create database %s", dbName))
-		assert.NilError(t, err)
+		NilError(t, err)
 
 		sdb, err = sql.NewDB("postgres", connString)
-		assert.NilError(t, err)
+		NilError(t, err)
 
 	default:
 		t.Fatalf("unknown db type")
@@ -538,16 +538,16 @@ func TestCreate(t *testing.T, lastVersion uint, dataFixtures DataFixtures, setup
 				t.Fatalf("missing fixture for db version %d", createVersion)
 			}
 			dataFixture, err := os.ReadFile(filepath.Join("fixtures", "migrate", dataFixtureFile))
-			assert.NilError(t, err)
+			NilError(t, err)
 			dataFixture = jsonc.ToJSON(dataFixture)
 
 			createFixtureFile := fmt.Sprintf("v%d.json", createVersion)
 			createFixture, err := os.ReadFile(filepath.Join("fixtures", "create", createFixtureFile))
-			assert.NilError(t, err)
+			NilError(t, err)
 
 			var createData *CreateData
 			err = json.Unmarshal(createFixture, &createData)
-			assert.NilError(t, err)
+			NilError(t, err)
 
 			dc.Schema = createData.Tables
 			ddl := createData.DDL
@@ -561,13 +561,13 @@ func TestCreate(t *testing.T, lastVersion uint, dataFixtures DataFixtures, setup
 			}
 
 			err = dc.DBM.Setup(ctx)
-			assert.NilError(t, err, "setup db error")
+			NilError(t, err, "setup db error")
 
 			err = dc.DBM.Create(ctx, stmts, createVersion)
-			assert.NilError(t, err)
+			NilError(t, err)
 
 			err = dc.Import(ctx, bytes.NewBuffer(dataFixture), createData)
-			assert.NilError(t, err)
+			NilError(t, err)
 		})
 	}
 }
@@ -596,16 +596,16 @@ func TestMigrate(t *testing.T, lastVersion uint, dataFixtures DataFixtures, setu
 					t.Fatalf("missing data fixture for db version %d", migrateVersion)
 				}
 				dataFixtureCreate, err := os.ReadFile(filepath.Join("fixtures", "migrate", dataFixtureFileCreate))
-				assert.NilError(t, err)
+				NilError(t, err)
 				dataFixtureCreate = jsonc.ToJSON(dataFixtureCreate)
 
 				createFixtureFileCreate := fmt.Sprintf("v%d.json", migrateVersion)
 				createFixtureCreate, err := os.ReadFile(filepath.Join("fixtures", "create", createFixtureFileCreate))
-				assert.NilError(t, err)
+				NilError(t, err)
 
 				var createDataCreate *CreateData
 				err = json.Unmarshal(createFixtureCreate, &createDataCreate)
-				assert.NilError(t, err)
+				NilError(t, err)
 
 				createDC.Schema = createDataCreate.Tables
 				createDDL := createDataCreate.DDL
@@ -619,13 +619,13 @@ func TestMigrate(t *testing.T, lastVersion uint, dataFixtures DataFixtures, setu
 				}
 
 				err = createDC.DBM.Setup(ctx)
-				assert.NilError(t, err, "setup db error")
+				NilError(t, err, "setup db error")
 
 				err = createDC.DBM.Create(ctx, createStmts, migrateVersion)
-				assert.NilError(t, err)
+				NilError(t, err)
 
 				err = createDC.Import(ctx, bytes.NewBuffer(dataFixtureCreate), createDataCreate)
-				assert.NilError(t, err)
+				NilError(t, err)
 
 				// create db at create version to be migrated.
 				dc := setupDBFn(ctx, t, dir)
@@ -634,16 +634,16 @@ func TestMigrate(t *testing.T, lastVersion uint, dataFixtures DataFixtures, setu
 					t.Fatalf("missing fixture for db version %d", createVersion)
 				}
 				dataFixture, err := os.ReadFile(filepath.Join("fixtures", "migrate", dataFixtureFile))
-				assert.NilError(t, err)
+				NilError(t, err)
 				dataFixture = jsonc.ToJSON(dataFixture)
 
 				createFixtureFile := fmt.Sprintf("v%d.json", createVersion)
 				createFixture, err := os.ReadFile(filepath.Join("fixtures", "create", createFixtureFile))
-				assert.NilError(t, err)
+				NilError(t, err)
 
 				var createData *CreateData
 				err = json.Unmarshal(createFixture, &createData)
-				assert.NilError(t, err)
+				NilError(t, err)
 
 				dc.Schema = createData.Tables
 				ddl := createData.DDL
@@ -657,32 +657,32 @@ func TestMigrate(t *testing.T, lastVersion uint, dataFixtures DataFixtures, setu
 				}
 
 				err = dc.DBM.Setup(ctx)
-				assert.NilError(t, err, "setup db error")
+				NilError(t, err, "setup db error")
 
 				err = dc.DBM.Create(ctx, stmts, createVersion)
-				assert.NilError(t, err)
+				NilError(t, err)
 
 				err = dc.Import(ctx, bytes.NewBuffer(dataFixture), createData)
-				assert.NilError(t, err)
+				NilError(t, err)
 
 				err = dc.DBM.MigrateToVersion(ctx, migrateVersion)
-				assert.NilError(t, err)
+				NilError(t, err)
 
 				// Diff created and migrated schema
 				createAtlasClient, err := atlassqlclient.Open(ctx, createDC.AtlasConnString())
-				assert.NilError(t, err)
+				NilError(t, err)
 
 				atlasClient, err := atlassqlclient.Open(ctx, dc.AtlasConnString())
-				assert.NilError(t, err)
+				NilError(t, err)
 
 				createSchema, err := createAtlasClient.InspectSchema(ctx, "", nil)
-				assert.NilError(t, err)
+				NilError(t, err)
 
 				schema, err := atlasClient.InspectSchema(ctx, "", nil)
-				assert.NilError(t, err)
+				NilError(t, err)
 
 				diff, err := atlasClient.SchemaDiff(createSchema, schema)
-				assert.NilError(t, err)
+				NilError(t, err)
 
 				assert.Assert(t, len(diff) == 0, "schema of db created at version %d and db migrated from version %d to version %d is different:\n %s", migrateVersion, createVersion, migrateVersion, diff)
 
@@ -707,10 +707,10 @@ func TestMigrate(t *testing.T, lastVersion uint, dataFixtures DataFixtures, setu
 				}
 
 				err = createDC.Export(ctx, tableNames(createSchema), createExport)
-				assert.NilError(t, err)
+				NilError(t, err)
 
 				err = dc.Export(ctx, tableNames(schema), export)
-				assert.NilError(t, err)
+				NilError(t, err)
 
 				// Diff database data
 
@@ -733,10 +733,10 @@ func decodeExport(t *testing.T, d manager.DB, export []byte) []any {
 		if errors.Is(err, io.EOF) {
 			break
 		}
-		assert.NilError(t, err)
+		NilError(t, err)
 
 		obj, err := d.UnmarshalExportObject(jobj)
-		assert.NilError(t, err)
+		NilError(t, err)
 
 		objs = append(objs, obj)
 	}
@@ -759,15 +759,15 @@ func TestImportExport(t *testing.T, importFixtureFile string, setupDBFn SetupDBF
 	dc := setupDBFn(ctx, t, dir)
 
 	fixture, err := os.ReadFile(filepath.Join("fixtures", "import", importFixtureFile))
-	assert.NilError(t, err)
+	NilError(t, err)
 
 	stmts := dc.D.DDL()
 
 	err = dc.DBM.Create(ctx, stmts, dc.D.Version())
-	assert.NilError(t, err)
+	NilError(t, err)
 
 	err = dc.DBM.Import(ctx, bytes.NewBuffer(fixture))
-	assert.NilError(t, err)
+	NilError(t, err)
 
 	// check sequences
 	curSeqs := map[string]uint64{}
@@ -786,14 +786,14 @@ func TestImportExport(t *testing.T, importFixtureFile string, setupDBFn SetupDBF
 
 		return nil
 	})
-	assert.NilError(t, err)
+	NilError(t, err)
 
 	assert.DeepEqual(t, curSeqs, seqs)
 
 	export := &bytes.Buffer{}
 
 	err = dc.DBM.Export(ctx, sqlg.ObjectNames(dc.D.ObjectsInfo()), export)
-	assert.NilError(t, err)
+	NilError(t, err)
 
 	exportMap := decodeExport(t, dc.D, export.Bytes())
 	fixturesMap := decodeExport(t, dc.D, fixture)

--- a/internal/testutil/log.go
+++ b/internal/testutil/log.go
@@ -1,13 +1,16 @@
 package testutil
 
 import (
+	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/sorintlab/errors"
+	"gotest.tools/assert"
 )
 
 func NewLogger(t *testing.T) zerolog.Logger {
@@ -26,4 +29,32 @@ func NewLogger(t *testing.T) zerolog.Logger {
 	zerolog.TimeFieldFormat = time.RFC3339Nano
 
 	return zerolog.New(cw).With().Timestamp().Stack().Caller().Logger().Level(zerolog.InfoLevel).Output(cw)
+}
+
+type helperT interface {
+	Helper()
+}
+
+func NilError(t assert.TestingT, err error, msgAndArgs ...interface{}) {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
+
+	detailedErrors, _ := strconv.ParseBool(os.Getenv("DETAILED_ERRORS"))
+
+	if !assert.Check(t, err, msgAndArgs...) {
+		if detailedErrors {
+			var sb strings.Builder
+			errDetails := errors.PrintErrorDetails(err)
+			if len(errDetails) > 0 {
+				sb.WriteString("error details:\n")
+				for _, l := range errDetails {
+					sb.WriteString(fmt.Sprintf("%s\n", l))
+				}
+			}
+			t.Log(sb.String())
+		}
+
+		t.FailNow()
+	}
 }

--- a/internal/testutil/utils.go
+++ b/internal/testutil/utils.go
@@ -268,23 +268,17 @@ func NewTestGitea(t *testing.T, dir, dockerBridgeAddress string, a ...string) (*
     name = TestGitea
     email = testgitea@example.com
 `
-	if err := os.WriteFile(filepath.Join(giteaDir, ".gitconfig"), []byte(gitConfigData), 0644); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	err := os.WriteFile(filepath.Join(giteaDir, ".gitconfig"), []byte(gitConfigData), 0644)
+	NilError(t, err)
 
 	curUser, err := user.Current()
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	NilError(t, err)
 
 	httpPort, err := GetFreePort(dockerBridgeAddress, true, false)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	NilError(t, err)
+
 	sshPort, err := GetFreePort(dockerBridgeAddress, true, false)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	NilError(t, err)
 
 	giteaConfig := &GiteaConfig{
 		Data:              giteaDir,

--- a/internal/util/path_test.go
+++ b/internal/util/path_test.go
@@ -42,7 +42,7 @@ func TestPathList(t *testing.T) {
 		t.Run("test is parent path", func(t *testing.T) {
 			out := PathList(tt.in)
 			if !reflect.DeepEqual(out, tt.out) {
-				t.Errorf("got %q but wanted: %q", out, tt.out)
+				t.Fatalf("got %q but wanted: %q", out, tt.out)
 			}
 		})
 	}
@@ -66,7 +66,7 @@ func TestIsParentPath(t *testing.T) {
 		t.Run("test is parent path", func(t *testing.T) {
 			ok := IsParentPath(tt.parent, tt.p)
 			if ok != tt.ok {
-				t.Errorf("got %t but wanted: %t a: %v, b: %v", ok, tt.ok, tt.parent, tt.p)
+				t.Fatalf("got %t but wanted: %t a: %v, b: %v", ok, tt.ok, tt.parent, tt.p)
 			}
 		})
 	}
@@ -93,7 +93,7 @@ func TestIsSameOrParentPath(t *testing.T) {
 		t.Run("test is parent path", func(t *testing.T) {
 			ok := IsSameOrParentPath(tt.parent, tt.p)
 			if ok != tt.ok {
-				t.Errorf("got %t but wanted: %t a: %v, b: %v", ok, tt.ok, tt.parent, tt.p)
+				t.Fatalf("got %t but wanted: %t a: %v, b: %v", ok, tt.ok, tt.parent, tt.p)
 			}
 		})
 	}

--- a/internal/util/slice_test.go
+++ b/internal/util/slice_test.go
@@ -37,7 +37,7 @@ func TestCompareStringSlice(t *testing.T) {
 	for i, tt := range tests {
 		ok := CompareStringSlice(tt.a, tt.b)
 		if ok != tt.ok {
-			t.Errorf("%d: got %t but wanted: %t a: %v, b: %v", i, ok, tt.ok, tt.a, tt.b)
+			t.Fatalf("%d: got %t but wanted: %t a: %v, b: %v", i, ok, tt.ok, tt.a, tt.b)
 		}
 	}
 }
@@ -63,7 +63,7 @@ func TestCompareStringSliceNoOrder(t *testing.T) {
 	for i, tt := range tests {
 		ok := CompareStringSliceNoOrder(tt.a, tt.b)
 		if ok != tt.ok {
-			t.Errorf("%d: got %t but wanted: %t a: %v, b: %v", i, ok, tt.ok, tt.a, tt.b)
+			t.Fatalf("%d: got %t but wanted: %t a: %v, b: %v", i, ok, tt.ok, tt.a, tt.b)
 		}
 	}
 }
@@ -93,7 +93,7 @@ func TestDifference(t *testing.T) {
 	for i, tt := range tests {
 		r := Difference(tt.a, tt.b)
 		if !CompareStringSliceNoOrder(r, tt.r) {
-			t.Errorf("%d: got %v but wanted: %v a: %v, b: %v", i, r, tt.r, tt.a, tt.b)
+			t.Fatalf("%d: got %v but wanted: %v a: %v, b: %v", i, r, tt.r, tt.a, tt.b)
 		}
 	}
 }

--- a/internal/util/validation_test.go
+++ b/internal/util/validation_test.go
@@ -55,13 +55,13 @@ func TestValidateName(t *testing.T) {
 	for _, name := range goodNames {
 		ok := ValidateName(name)
 		if !ok {
-			t.Errorf("expect valid name for %q", name)
+			t.Fatalf("expect valid name for %q", name)
 		}
 	}
 	for _, name := range badNames {
 		ok := ValidateName(name)
 		if ok {
-			t.Errorf("expect invalid name for %q", name)
+			t.Fatalf("expect invalid name for %q", name)
 		}
 	}
 }

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -111,12 +111,9 @@ const (
 
 func setupGitea(t *testing.T, dir, dockerBridgeAddress string) *testutil.TestGitea {
 	tgitea, err := testutil.NewTestGitea(t, dir, dockerBridgeAddress)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	if err := tgitea.Start(); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+	err = tgitea.Start()
+	testutil.NilError(t, err)
 
 	giteaAPIURL := fmt.Sprintf("http://%s:%s", tgitea.HTTPListenAddress, tgitea.HTTPPort)
 
@@ -127,9 +124,7 @@ func setupGitea(t *testing.T, dir, dockerBridgeAddress string) *testutil.TestGit
 		}
 		return true, nil
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	err = testutil.Wait(30*time.Second, func() (bool, error) {
 		cmd := exec.Command(tgitea.GiteaPath, "admin", "user", "create", "--name", giteaUser01, "--email", giteaUser01+"@example.com", "--password", giteaUser01Password, "--admin", "--config", tgitea.ConfigPath)
@@ -139,14 +134,10 @@ func setupGitea(t *testing.T, dir, dockerBridgeAddress string) *testutil.TestGit
 		}
 		return true, nil
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	giteaClient, err := gitea.NewClient(giteaAPIURL)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// Wait for gitea api to be ready using gitea client
 	err = testutil.Wait(30*time.Second, func() (bool, error) {
@@ -156,9 +147,7 @@ func setupGitea(t *testing.T, dir, dockerBridgeAddress string) *testutil.TestGit
 		}
 		return true, nil
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	return tgitea
 }
@@ -453,29 +442,22 @@ func setup(ctx context.Context, t *testing.T, dir string, opts ...setupOption) *
 	}
 
 	gwPort, err := testutil.GetFreePort(dockerBridgeAddress, true, false)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	csPort, err := testutil.GetFreePort(dockerBridgeAddress, true, false)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	rsPort, err := testutil.GetFreePort(dockerBridgeAddress, true, false)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	exPort, err := testutil.GetFreePort(dockerBridgeAddress, true, false)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	nsPort, err := testutil.GetFreePort(dockerBridgeAddress, true, false)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	gitServerPort, err := testutil.GetFreePort(dockerBridgeAddress, true, false)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	gwURL := fmt.Sprintf("http://%s:%s", dockerBridgeAddress, gwPort)
 	csURL := fmt.Sprintf("http://%s:%s", dockerBridgeAddress, csPort)
@@ -505,10 +487,8 @@ func setup(ctx context.Context, t *testing.T, dir string, opts ...setupOption) *
 	sc.config.Notification.ConfigstoreURL = csURL
 
 	sc.config.Executor.RunserviceURL = rsURL
-
-	if err := sc.startAgola(); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	err = sc.startAgola()
+	testutil.NilError(t, err)
 
 	go func() {
 		<-ctx.Done()
@@ -607,9 +587,8 @@ func TestPasswordRegisterUser(t *testing.T) {
 		AuthType:            "password",
 		SkipSSHHostKeyCheck: true,
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	t.Logf("created agola remote source: %s", rs.Name)
 
 	loginGWClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, "")
@@ -624,9 +603,8 @@ func TestPasswordRegisterUser(t *testing.T) {
 			RemoteSourceLoginPassword: giteaUser01Password,
 		},
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	t.Logf("created agola user")
 
 	loginUserResponse, _, err := loginGWClient.Login(ctx, &gwapitypes.LoginUserRequest{
@@ -634,9 +612,7 @@ func TestPasswordRegisterUser(t *testing.T) {
 		LoginName:        giteaUser01,
 		LoginPassword:    giteaUser01Password,
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// Register again. Should fail.
 	_, _, err = loginGWClient.RegisterUser(ctx, &gwapitypes.RegisterUserRequest{
@@ -658,9 +634,8 @@ func TestPasswordRegisterUser(t *testing.T) {
 	}
 
 	// Remove user
-	if _, err := adminGWClient.DeleteUser(ctx, loginUserResponse.User.ID); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, err = adminGWClient.DeleteUser(ctx, loginUserResponse.User.ID)
+	testutil.NilError(t, err)
 
 	// Register again. Should work and recreate remote gitea user access token.
 	_, _, err = loginGWClient.RegisterUser(ctx, &gwapitypes.RegisterUserRequest{
@@ -673,18 +648,15 @@ func TestPasswordRegisterUser(t *testing.T) {
 			RemoteSourceLoginPassword: giteaUser01Password,
 		},
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	token := createAgolaUserToken(ctx, t, sc.config)
 	tokenGWClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, token)
 
 	// Do an agola call that will use the linkedAccount userAccessToken to call gitea api
 	// should work
-	if _, _, err := tokenGWClient.GetUserRemoteRepos(ctx, rs.ID); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, _, err = tokenGWClient.GetUserRemoteRepos(ctx, rs.ID)
+	testutil.NilError(t, err)
 }
 
 func TestPasswordLogin(t *testing.T) {
@@ -709,9 +681,8 @@ func TestPasswordLogin(t *testing.T) {
 		AuthType:            "password",
 		SkipSSHHostKeyCheck: true,
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	t.Logf("created agola remote source: %s", rs.Name)
 
 	loginGWClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, "")
@@ -726,9 +697,8 @@ func TestPasswordLogin(t *testing.T) {
 			RemoteSourceLoginPassword: giteaUser01Password,
 		},
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	t.Logf("created agola user")
 
 	_, _, err = loginGWClient.Login(ctx, &gwapitypes.LoginUserRequest{
@@ -736,28 +706,21 @@ func TestPasswordLogin(t *testing.T) {
 		LoginName:        giteaUser01,
 		LoginPassword:    giteaUser01Password,
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	token := createAgolaUserToken(ctx, t, sc.config)
 	tokenGWClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, token)
 
 	// Test userAccessToken recreation on login
 	giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetBasicAuth(giteaUser01, giteaUser01Password))
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	giteaTokens, _, err := giteaClient.ListAccessTokens(gitea.ListAccessTokensOptions{})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	for _, giteaToken := range giteaTokens {
-		if _, err := giteaClient.DeleteAccessToken(giteaToken.Name); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		_, err := giteaClient.DeleteAccessToken(giteaToken.Name)
+		testutil.NilError(t, err)
 	}
 
 	// Do an agola call that will use the linkedAccount userAccessToken to call gitea api
@@ -777,15 +740,12 @@ func TestPasswordLogin(t *testing.T) {
 		LoginName:        giteaUser01,
 		LoginPassword:    giteaUser01Password,
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// Do an agola call that will use the linkedAccount userAccessToken to call gitea api
 	// should work
-	if _, _, err := tokenGWClient.GetUserRemoteRepos(ctx, rs.ID); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, _, err = tokenGWClient.GetUserRemoteRepos(ctx, rs.ID)
+	testutil.NilError(t, err)
 }
 
 func TestCookieAuth(t *testing.T) {
@@ -808,18 +768,14 @@ func TestCookieAuth(t *testing.T) {
 		LoginName:        giteaUser01,
 		LoginPassword:    giteaUser01Password,
 	}, nil)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// Test auth passing recevied login response cookies
 	authCookieName := common.AuthCookieName(false)
 	secondaryAuthCookieName := common.SecondaryAuthCookieName()
 	cookies := resp.Cookies()
 	_, _, err = gwCookieClient.GetCurrentUser(ctx, cookies)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// Don't send  authcookie
 	cookies = []*http.Cookie{}
@@ -878,17 +834,13 @@ func TestCSRF(t *testing.T) {
 		LoginName:        giteaUser01,
 		LoginPassword:    giteaUser01Password,
 	}, nil)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	loginCookies := resp.Cookies()
 
 	// Do an initial request to fetch the csrf cookies and token
 	_, resp, err = gwCookieClient.GetCurrentUser(ctx, loginCookies)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	t.Logf("resp.Header: %v", resp.Header)
 	cookies := append(loginCookies, resp.Cookies()...)
@@ -897,9 +849,8 @@ func TestCSRF(t *testing.T) {
 	header.Set("X-Csrf-Token", csrfToken)
 
 	// Create an org. Should work
-	if _, _, err := gwCookieClient.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: agolaOrg01, Visibility: gwapitypes.VisibilityPublic}, header, cookies); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	_, _, err = gwCookieClient.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: agolaOrg01, Visibility: gwapitypes.VisibilityPublic}, header, cookies)
+	testutil.NilError(t, err)
 
 	// Don't send csrf token in request headers. Should return 403 (forbidden)
 	_, _, err = gwCookieClient.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: agolaOrg02, Visibility: gwapitypes.VisibilityPublic}, http.Header{}, cookies)
@@ -964,9 +915,8 @@ func TestCreateLinkedAccount(t *testing.T) {
 func createAgolaUserToken(ctx context.Context, t *testing.T, c *config.Config) string {
 	gwClient := gwclient.NewClient(c.Gateway.APIExposedURL, "admintoken")
 	token, _, err := gwClient.CreateUserToken(ctx, agolaUser01, &gwapitypes.CreateUserTokenRequest{TokenName: "token01"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	t.Logf("created agola user token: %s", token.Token)
 
 	return token.Token
@@ -975,22 +925,18 @@ func createAgolaUserToken(ctx context.Context, t *testing.T, c *config.Config) s
 func createLinkedAccount(ctx context.Context, t *testing.T, tgitea *testutil.TestGitea, c *config.Config) (string, string) {
 	giteaAPIURL := fmt.Sprintf("http://%s:%s", tgitea.HTTPListenAddress, tgitea.HTTPPort)
 	giteaClient, err := gitea.NewClient(giteaAPIURL)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	giteaClient.SetBasicAuth(giteaUser01, giteaUser01Password)
 	giteaToken, _, err := giteaClient.CreateAccessToken(gitea.CreateAccessTokenOption{Name: "token01"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	t.Logf("created gitea user token: %s", giteaToken.Token)
 
 	adminGWClient := gwclient.NewClient(c.Gateway.APIExposedURL, "admintoken")
 	user, _, err := adminGWClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser01})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	t.Logf("created agola user: %s", user.UserName)
 
 	token := createAgolaUserToken(ctx, t, c)
@@ -1002,9 +948,8 @@ func createLinkedAccount(ctx context.Context, t *testing.T, tgitea *testutil.Tes
 		AuthType:            "password",
 		SkipSSHHostKeyCheck: true,
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	t.Logf("created agola remote source: %s", rs.Name)
 
 	tokenGWClient := gwclient.NewClient(c.Gateway.APIExposedURL, token)
@@ -1014,9 +959,8 @@ func createLinkedAccount(ctx context.Context, t *testing.T, tgitea *testutil.Tes
 		RemoteSourceLoginName:     giteaUser01,
 		RemoteSourceLoginPassword: giteaUser01Password,
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	t.Logf("created user linked account: %s", util.Dump(la))
 
 	return giteaToken.Token, token
@@ -1038,9 +982,7 @@ func TestCreateProject(t *testing.T) {
 	giteaToken, token := createLinkedAccount(ctx, t, sc.gitea, sc.config)
 
 	giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, token)
 
@@ -1064,9 +1006,7 @@ func TestUpdateProject(t *testing.T) {
 		giteaToken, token := createLinkedAccount(ctx, t, sc.gitea, sc.config)
 
 		giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, token)
 
@@ -1078,9 +1018,8 @@ func TestUpdateProject(t *testing.T) {
 		project, _, err = gwClient.UpdateProject(ctx, project.ID, &gwapitypes.UpdateProjectRequest{
 			PassVarsToForkedPR: util.BoolP(false),
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if project.PassVarsToForkedPR != false {
 			t.Fatalf("expected PassVarsToForkedPR false, got %v", project.PassVarsToForkedPR)
 		}
@@ -1088,9 +1027,8 @@ func TestUpdateProject(t *testing.T) {
 		project, _, err = gwClient.UpdateProject(ctx, project.ID, &gwapitypes.UpdateProjectRequest{
 			PassVarsToForkedPR: util.BoolP(true),
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if project.PassVarsToForkedPR != true {
 			t.Fatalf("expected PassVarsToForkedPR false, got %v", project.PassVarsToForkedPR)
 		}
@@ -1110,9 +1048,7 @@ func TestUpdateProject(t *testing.T) {
 		giteaToken, token := createLinkedAccount(ctx, t, sc.gitea, sc.config)
 
 		giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, token)
 
@@ -1120,9 +1056,8 @@ func TestUpdateProject(t *testing.T) {
 			Name:    "repo01",
 			Private: false,
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		t.Logf("created gitea repo: %s", giteaRepo.Name)
 
 		req := &gwapitypes.CreateProjectRequest{
@@ -1156,9 +1091,7 @@ func TestUpdateProject(t *testing.T) {
 		giteaToken, token := createLinkedAccount(ctx, t, sc.gitea, sc.config)
 
 		giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, token)
 
@@ -1193,16 +1126,12 @@ func TestUpdateProject(t *testing.T) {
 		giteaToken, token := createLinkedAccount(ctx, t, sc.gitea, sc.config)
 
 		giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, token)
 
 		_, _, err = gwClient.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: agolaOrg01, Visibility: gwapitypes.VisibilityPublic})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		// test create org project with MembersCanPerformRunActions false
 		_, project := createProject(ctx, t, giteaClient, gwClient, withParentRef(path.Join("org", agolaOrg01)))
@@ -1215,9 +1144,8 @@ func TestUpdateProject(t *testing.T) {
 			Name:                        &project.Name,
 			MembersCanPerformRunActions: util.BoolP(true),
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if project.MembersCanPerformRunActions != true {
 			t.Fatalf("expected MembersCanPerformRunActions true, got %v", project.MembersCanPerformRunActions)
 		}
@@ -1231,9 +1159,8 @@ func TestUpdateProject(t *testing.T) {
 			ParentRef:                   path.Join("org", agolaOrg01),
 			MembersCanPerformRunActions: true,
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if project.MembersCanPerformRunActions != true {
 			t.Fatalf("expected MembersCanPerformRunActions true, got %v", project.MembersCanPerformRunActions)
 		}
@@ -1243,9 +1170,8 @@ func TestUpdateProject(t *testing.T) {
 			Name:                        &project.Name,
 			MembersCanPerformRunActions: util.BoolP(false),
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if project.MembersCanPerformRunActions != false {
 			t.Fatalf("expected MembersCanPerformRunActions false, got %v", project.MembersCanPerformRunActions)
 		}
@@ -1277,9 +1203,8 @@ func createProject(ctx context.Context, t *testing.T, giteaClient *gitea.Client,
 		Name:    "repo01",
 		Private: false,
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	t.Logf("created gitea repo: %s", giteaRepo.Name)
 
 	// TODO currently RepoPath is always fixed and related to giteaUser01. Add withRepoPath function to make it configurable
@@ -1296,9 +1221,7 @@ func createProject(ctx context.Context, t *testing.T, giteaClient *gitea.Client,
 	}
 
 	project, _, err := gwClient.CreateProject(ctx, req)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	return giteaRepo, project
 }
@@ -1307,9 +1230,7 @@ func updateProject(ctx context.Context, t *testing.T, giteaClient *gitea.Client,
 	project, _, err := gwClient.UpdateProject(ctx, projectRef, &gwapitypes.UpdateProjectRequest{
 		PassVarsToForkedPR: util.BoolP(passVarsToForkedPR),
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	return project
 }
@@ -1317,32 +1238,24 @@ func updateProject(ctx context.Context, t *testing.T, giteaClient *gitea.Client,
 func push(t *testing.T, config, cloneURL, remoteToken, message string, pushNewBranch bool) {
 	gitfs := memfs.New()
 	f, err := gitfs.Create(".agola/config.jsonnet")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	if _, err = f.Write([]byte(config)); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+	_, err = f.Write([]byte(config))
+	testutil.NilError(t, err)
 
 	r, err := git.Init(memory.NewStorage(), gitfs)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
-	if _, err := r.CreateRemote(&gitconfig.RemoteConfig{
+	_, err = r.CreateRemote(&gitconfig.RemoteConfig{
 		Name: "origin",
 		URLs: []string{cloneURL},
-	}); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	})
+	testutil.NilError(t, err)
 
 	wt, err := r.Worktree()
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	if _, err := wt.Add(".agola/config.jsonnet"); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+	_, err = wt.Add(".agola/config.jsonnet")
+	testutil.NilError(t, err)
+
 	_, err = wt.Commit(message, &git.CommitOptions{
 		Author: &object.Signature{
 			Name:  giteaUser01,
@@ -1350,44 +1263,36 @@ func push(t *testing.T, config, cloneURL, remoteToken, message string, pushNewBr
 			When:  time.Now(),
 		},
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	t.Logf("sshurl: %s", cloneURL)
-	if err := r.Push(&git.PushOptions{
+	err = r.Push(&git.PushOptions{
 		RemoteName: "origin",
 		Auth: &githttp.BasicAuth{
 			Username: giteaUser01,
 			Password: remoteToken,
 		},
 		Force: true,
-	}); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	})
+	testutil.NilError(t, err)
 
 	if pushNewBranch {
 		// change worktree and push to a new branch
 		headRef, err := r.Head()
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		ref := plumbing.NewHashReference("refs/heads/new-branch", headRef.Hash())
 		err = r.Storer.SetReference(ref)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		f, err = gitfs.Create("file1")
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
-		if _, err = f.Write([]byte("my file content")); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
-		if _, err := wt.Add("file1"); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+		_, err = f.Write([]byte("my file content"))
+		testutil.NilError(t, err)
+
+		_, err = wt.Add("file1")
+		testutil.NilError(t, err)
+
 		_, err = wt.Commit("add file1", &git.CommitOptions{
 			Author: &object.Signature{
 				Name:  giteaUser01,
@@ -1395,11 +1300,9 @@ func push(t *testing.T, config, cloneURL, remoteToken, message string, pushNewBr
 				When:  time.Now(),
 			},
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
-		if err := r.Push(&git.PushOptions{
+		err = r.Push(&git.PushOptions{
 			RemoteName: "origin",
 			RefSpecs: []gitconfig.RefSpec{
 				gitconfig.RefSpec("refs/heads/new-branch:refs/heads/new-branch"),
@@ -1408,9 +1311,8 @@ func push(t *testing.T, config, cloneURL, remoteToken, message string, pushNewBr
 				Username: giteaUser01,
 				Password: remoteToken,
 			},
-		}); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		})
+		testutil.NilError(t, err)
 	}
 }
 
@@ -1572,9 +1474,7 @@ func TestPush(t *testing.T) {
 			giteaToken, token := createLinkedAccount(ctx, t, sc.gitea, sc.config)
 
 			giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, token)
 
@@ -1600,9 +1500,7 @@ func TestPush(t *testing.T) {
 			})
 
 			runs, _, err := gwClient.GetProjectRuns(ctx, project.ID, nil, nil, 0, 0, false)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			t.Logf("runs: %s", util.Dump(runs))
 
@@ -1635,14 +1533,10 @@ func directRun(t *testing.T, dir, config string, configFormat ConfigFormat, gate
 		t.Fatalf("env var AGOLA_BIN_DIR is undefined")
 	}
 	agolaBinDir, err := filepath.Abs(agolaBinDir)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	repoDir, err := os.MkdirTemp(dir, "repo")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	gitfs := osfs.New(repoDir)
 	dot, _ := gitfs.Chroot(".git")
@@ -1656,17 +1550,12 @@ func directRun(t *testing.T, dir, config string, configFormat ConfigFormat, gate
 	}
 
 	f, err := gitfs.Create(configPath)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	if _, err = f.Write([]byte(config)); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+	_, err = f.Write([]byte(config))
+	testutil.NilError(t, err)
 
 	_, err = git.Init(filesystem.NewStorage(dot, cache.NewObjectLRUDefault()), gitfs)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// override default gitconfig file to make it unique for test instance.
 	// We have to override the HOME env var since GIT_CONFIG env is ignored.
@@ -1681,18 +1570,16 @@ func directRun(t *testing.T, dir, config string, configFormat ConfigFormat, gate
     name = TestGitea
     email = testgitea@example.com
 `
-	if err := os.WriteFile(filepath.Join(dir, ".gitconfig"), []byte(gitConfigData), 0644); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	err = os.WriteFile(filepath.Join(dir, ".gitconfig"), []byte(gitConfigData), 0644)
+	testutil.NilError(t, err)
 
 	args = append([]string{"--gateway-url", gatewayURL, "--token", token, "directrun", "start", "--untracked", "false"}, args...)
 	cmd := exec.Command(filepath.Join(agolaBinDir, "agola"), args...)
 	cmd.Dir = repoDir
 	cmd.Env = env
 	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("unexpected err: %v, out: %s", err, out)
-	}
+	testutil.NilError(t, err, "out: %s", out)
+
 	t.Logf("directrun start out: %s", out)
 }
 
@@ -1790,9 +1677,8 @@ func testDirectRun(t *testing.T, internalServicesAuth bool) {
 
 			gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, "admintoken")
 			user, _, err := gwClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser01})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			t.Logf("created agola user: %s", user.UserName)
 
 			token := createAgolaUserToken(ctx, t, sc.config)
@@ -1821,9 +1707,7 @@ func testDirectRun(t *testing.T, internalServicesAuth bool) {
 			})
 
 			runs, _, err := gwClient.GetUserRuns(ctx, user.ID, nil, nil, 0, 0, false)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			t.Logf("runs: %s", util.Dump(runs))
 
@@ -1930,10 +1814,8 @@ func TestDirectRunVariables(t *testing.T) {
 			t.Parallel()
 
 			dir := t.TempDir()
-
-			if err := os.WriteFile(filepath.Join(dir, "varfile01.yml"), []byte(varfile01), 0644); err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			err := os.WriteFile(filepath.Join(dir, "varfile01.yml"), []byte(varfile01), 0644)
+			testutil.NilError(t, err)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -1943,9 +1825,8 @@ func TestDirectRunVariables(t *testing.T) {
 
 			gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, "admintoken")
 			user, _, err := gwClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser01})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			t.Logf("created agola user: %s", user.UserName)
 
 			token := createAgolaUserToken(ctx, t, sc.config)
@@ -1975,9 +1856,7 @@ func TestDirectRunVariables(t *testing.T) {
 			})
 
 			runs, _, err := gwClient.GetUserRuns(ctx, user.ID, nil, nil, 0, 0, false)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			t.Logf("runs: %s", util.Dump(runs))
 
@@ -1986,9 +1865,8 @@ func TestDirectRunVariables(t *testing.T) {
 			}
 
 			run, _, err := gwClient.GetUserRun(ctx, user.ID, runs[0].Number)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			if run.Phase != rstypes.RunPhaseFinished {
 				t.Fatalf("expected run phase %q, got %q", rstypes.RunPhaseFinished, run.Phase)
 			}
@@ -2005,19 +1883,15 @@ func TestDirectRunVariables(t *testing.T) {
 			}
 
 			resp, err := gwClient.GetUserLogs(ctx, user.ID, run.Number, task.ID, false, 1, false)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			defer resp.Body.Close()
 
 			logs, err := io.ReadAll(resp.Body)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			curEnv, err := testutil.ParseEnvs(bytes.NewReader(logs))
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			for n, e := range tt.env {
 				if ce, ok := curEnv[n]; !ok {
@@ -2114,9 +1988,8 @@ func TestDirectRunLogs(t *testing.T) {
 
 			gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, "admintoken")
 			user, _, err := gwClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser01})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			t.Logf("created agola user: %s", user.UserName)
 
 			token := createAgolaUserToken(ctx, t, sc.config)
@@ -2145,9 +2018,7 @@ func TestDirectRunLogs(t *testing.T) {
 			})
 
 			runs, _, err := gwClient.GetUserRuns(ctx, user.ID, nil, nil, 0, 0, false)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			t.Logf("runs: %s", util.Dump(runs))
 
@@ -2156,9 +2027,7 @@ func TestDirectRunLogs(t *testing.T) {
 			}
 
 			run, _, err := gwClient.GetUserRun(ctx, user.ID, runs[0].Number)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			if run.Phase != rstypes.RunPhaseFinished {
 				t.Fatalf("expected run phase %q, got %q", rstypes.RunPhaseFinished, run.Phase)
@@ -2296,9 +2165,7 @@ func TestPullRequest(t *testing.T) {
 			giteaToken, token := createLinkedAccount(ctx, t, sc.gitea, sc.config)
 
 			giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, token)
 
@@ -2385,9 +2252,8 @@ func TestPullRequest(t *testing.T) {
 				}
 
 				giteaUser02Client, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaUser02Token.Token))
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				giteaForkedRepo, _, err := giteaUser02Client.CreateFork(giteaUser01, "repo01", gitea.CreateForkOption{})
 				if err != nil {
 					t.Fatalf("failed to fork repo01: %v", err)
@@ -2406,19 +2272,16 @@ func TestPullRequest(t *testing.T) {
 				}
 
 				wt, err := r.Worktree()
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				f, err := gitfs.Create("file2")
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
-				if _, err = f.Write([]byte("file2 content")); err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
-				if _, err := wt.Add("file2"); err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+				_, err = f.Write([]byte("file2 content"))
+				testutil.NilError(t, err)
+
+				_, err = wt.Add("file2")
+				testutil.NilError(t, err)
+
 				_, err = wt.Commit("commit from user02", &git.CommitOptions{
 					Author: &object.Signature{
 						Name:  giteaUser02,
@@ -2426,11 +2289,9 @@ func TestPullRequest(t *testing.T) {
 						When:  time.Now(),
 					},
 				})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
-				if err := r.Push(&git.PushOptions{
+				err = r.Push(&git.PushOptions{
 					RemoteName: "origin",
 					RefSpecs: []gitconfig.RefSpec{
 						gitconfig.RefSpec("refs/heads/master:refs/heads/master"),
@@ -2439,9 +2300,8 @@ func TestPullRequest(t *testing.T) {
 						Username: giteaUser02,
 						Password: giteaUser02Token.Token,
 					},
-				}); err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				})
+				testutil.NilError(t, err)
 
 				prOpts := gitea.CreatePullRequestOption{
 					Head:  "user02:master",
@@ -2471,16 +2331,12 @@ func TestPullRequest(t *testing.T) {
 			})
 
 			runs, _, err := gwClient.GetProjectRuns(ctx, project.ID, nil, nil, 0, 0, false)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			t.Logf("runs: %s", util.Dump(runs))
 
 			run, _, err := gwClient.GetProjectRun(ctx, project.ID, runs[0].Number)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			var task *gwapitypes.RunResponseTask
 			for _, t := range run.Tasks {
@@ -2655,9 +2511,8 @@ def main(ctx):
 
 				gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, "admintoken")
 				user, _, err := gwClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser01})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				t.Logf("created agola user: %s", user.UserName)
 
 				token := createAgolaUserToken(ctx, t, sc.config)
@@ -2687,9 +2542,7 @@ def main(ctx):
 				})
 
 				runs, _, err := gwClient.GetUserRuns(ctx, user.ID, nil, nil, 0, 0, false)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				t.Logf("runs: %s", util.Dump(runs))
 
@@ -2698,9 +2551,8 @@ def main(ctx):
 				}
 
 				run, _, err := gwClient.GetUserRun(ctx, user.ID, runs[0].Number)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				if run.Phase != rstypes.RunPhaseFinished {
 					t.Fatalf("expected run phase %q, got %q", rstypes.RunPhaseFinished, run.Phase)
 				}
@@ -2717,19 +2569,15 @@ def main(ctx):
 				}
 
 				resp, err := gwClient.GetUserLogs(ctx, user.ID, run.Number, task.ID, false, 1, false)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				defer resp.Body.Close()
 
 				logs, err := io.ReadAll(resp.Body)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				curEnv, err := testutil.ParseEnvs(bytes.NewReader(logs))
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				// update commit sha from annotations since it will change at every test
 				tt.env["COMMIT_SHA"] = run.Annotations["commit_sha"]
@@ -2762,35 +2610,26 @@ func TestUserOrgs(t *testing.T) {
 	gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, "admintoken")
 
 	org01, _, err := gwClient.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: agolaOrg01, Visibility: gwapitypes.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	org02, _, err := gwClient.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: agolaOrg02, Visibility: gwapitypes.VisibilityPrivate})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	_, _, err = gwClient.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: agolaOrg03, Visibility: gwapitypes.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	_, token := createLinkedAccount(ctx, t, sc.gitea, sc.config)
 
 	_, _, err = gwClient.AddOrgMember(ctx, agolaOrg01, giteaUser01, gwapitypes.MemberRoleMember)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	_, _, err = gwClient.AddOrgMember(ctx, agolaOrg02, giteaUser01, gwapitypes.MemberRoleOwner)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	gwClientNew := gwclient.NewClient(sc.config.Gateway.APIExposedURL, token)
 
 	orgs, _, err := gwClientNew.GetUserOrgs(ctx, nil)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	expectedOrgs := []*gwapitypes.UserOrgResponse{
 		{
@@ -3028,9 +2867,8 @@ func TestTaskTimeout(t *testing.T) {
 
 			gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, "admintoken")
 			user, _, err := gwClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser01})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			t.Logf("created agola user: %s", user.UserName)
 
 			token := createAgolaUserToken(ctx, t, sc.config)
@@ -3060,9 +2898,7 @@ func TestTaskTimeout(t *testing.T) {
 			})
 
 			run, _, err := gwClient.GetUserRun(ctx, user.ID, 1)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			t.Logf("runs: %s", util.Dump(run))
 
@@ -3106,9 +2942,7 @@ func TestRefreshRemoteRepositoryInfo(t *testing.T) {
 	giteaToken, token := createLinkedAccount(ctx, t, sc.gitea, sc.config)
 
 	giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, token)
 
@@ -3119,22 +2953,18 @@ func TestRefreshRemoteRepositoryInfo(t *testing.T) {
 	}
 
 	_, _, err = giteaClient.EditRepo(giteaRepo.Owner.UserName, giteaRepo.Name, gitea.EditRepoOption{DefaultBranch: util.StringP("testbranch")})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	project, _, err = gwClient.RefreshRemoteRepo(ctx, project.ID)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if project.DefaultBranch != "testbranch" {
 		t.Fatalf("expected DefaultBranch testbranch got: %s", project.DefaultBranch)
 	}
 
 	p, _, err := gwClient.GetProject(ctx, project.ID)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if diff := cmp.Diff(project, p); diff != "" {
 		t.Fatalf("projects mismatch (-expected +got):\n%s", diff)
 	}
@@ -3154,20 +2984,14 @@ func TestAddUpdateOrgUserMembers(t *testing.T) {
 	gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, sc.config.Gateway.AdminToken)
 
 	user, _, err := gwClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser01})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	_, _, err = gwClient.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: agolaOrg01, Visibility: gwapitypes.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	//test add org member role member
 	_, _, err = gwClient.AddOrgMember(ctx, agolaOrg01, agolaUser01, gwapitypes.MemberRoleMember)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	expectedOrgMember := gwapitypes.OrgMemberResponse{
 		User: &gwapitypes.UserResponse{ID: user.ID, UserName: user.UserName},
@@ -3175,9 +2999,8 @@ func TestAddUpdateOrgUserMembers(t *testing.T) {
 	}
 
 	orgMembers, _, err := gwClient.GetOrgMembers(ctx, agolaOrg01, nil)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if orgMembers == nil {
 		t.Fatal("unexpected members nil")
 	}
@@ -3190,16 +3013,13 @@ func TestAddUpdateOrgUserMembers(t *testing.T) {
 
 	//test update org member role owner
 	_, _, err = gwClient.AddOrgMember(ctx, agolaOrg01, agolaUser01, gwapitypes.MemberRoleOwner)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	expectedOrgMember.Role = gwapitypes.MemberRoleOwner
 
 	orgMembers, _, err = gwClient.GetOrgMembers(ctx, agolaOrg01, nil)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if orgMembers == nil {
 		t.Fatal("unexpected members nil")
 	}
@@ -3226,52 +3046,40 @@ func TestGetOrg(t *testing.T) {
 
 	// create users
 	_, _, err := gwAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser01})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	tokenUser01, _, err := gwAdminClient.CreateUserToken(ctx, agolaUser01, &gwapitypes.CreateUserTokenRequest{TokenName: "test"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	gwClientUser01 := gwclient.NewClient(sc.config.Gateway.APIExposedURL, tokenUser01.Token)
 
 	_, _, err = gwAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser02})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	tokenUser02, _, err := gwAdminClient.CreateUserToken(ctx, agolaUser02, &gwapitypes.CreateUserTokenRequest{TokenName: "test"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	gwClientUser02 := gwclient.NewClient(sc.config.Gateway.APIExposedURL, tokenUser02.Token)
 
 	_, _, err = gwAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser03})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	tokenUser03, _, err := gwAdminClient.CreateUserToken(ctx, agolaUser03, &gwapitypes.CreateUserTokenRequest{TokenName: "test"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	gwClientUser03 := gwclient.NewClient(sc.config.Gateway.APIExposedURL, tokenUser03.Token)
 
 	// create public org
 	pubOrg, _, err := gwClientUser01.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: agolaOrg01, Visibility: gwapitypes.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create private org
 	privOrg, _, err := gwClientUser01.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: agolaOrg02, Visibility: gwapitypes.VisibilityPrivate})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// add user02 as member of priv org
 	_, _, err = gwClientUser01.AddOrgMember(ctx, privOrg.ID, agolaUser02, gwapitypes.MemberRoleMember)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	tests := []struct {
 		name   string
@@ -3325,9 +3133,8 @@ func TestGetOrg(t *testing.T) {
 					t.Fatalf("expected err %v, got err: %v", tt.err, err)
 				}
 			} else {
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				if diff := cmp.Diff(tt.org, org); diff != "" {
 					t.Fatalf("org mismatch (-want +got):\n%s", diff)
 				}
@@ -3351,82 +3158,60 @@ func TestGetProjectGroup(t *testing.T) {
 
 	// create users
 	_, _, err := gwAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser01})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	tokenUser01, _, err := gwAdminClient.CreateUserToken(ctx, agolaUser01, &gwapitypes.CreateUserTokenRequest{TokenName: "test"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	gwClientUser01 := gwclient.NewClient(sc.config.Gateway.APIExposedURL, tokenUser01.Token)
 
 	_, _, err = gwAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser02})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	tokenUser02, _, err := gwAdminClient.CreateUserToken(ctx, agolaUser02, &gwapitypes.CreateUserTokenRequest{TokenName: "test"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	gwClientUser02 := gwclient.NewClient(sc.config.Gateway.APIExposedURL, tokenUser02.Token)
 
 	_, _, err = gwAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser03})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	tokenUser03, _, err := gwAdminClient.CreateUserToken(ctx, agolaUser03, &gwapitypes.CreateUserTokenRequest{TokenName: "test"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	gwClientUser03 := gwclient.NewClient(sc.config.Gateway.APIExposedURL, tokenUser03.Token)
 
 	// create public org
 	pubOrg, _, err := gwClientUser01.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: agolaOrg01, Visibility: gwapitypes.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create public org pub project group
 	pubOrgPubPG, _, err := gwClientUser01.CreateProjectGroup(ctx, &gwapitypes.CreateProjectGroupRequest{Name: "puborg-pubpg", ParentRef: path.Join("org", pubOrg.Name), Visibility: gwapitypes.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create public org priv project group
 	pubOrgPrivPG, _, err := gwClientUser01.CreateProjectGroup(ctx, &gwapitypes.CreateProjectGroupRequest{Name: "puborg-privpg", ParentRef: path.Join("org", pubOrg.Name), Visibility: gwapitypes.VisibilityPrivate})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create private org
 	privOrg, _, err := gwClientUser01.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: agolaOrg02, Visibility: gwapitypes.VisibilityPrivate})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create priv org pub project group
 	privOrgPubPG, _, err := gwClientUser01.CreateProjectGroup(ctx, &gwapitypes.CreateProjectGroupRequest{Name: "privorg-pubpg", ParentRef: path.Join("org", privOrg.Name), Visibility: gwapitypes.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create priv org priv project group
 	privOrgPrivPG, _, err := gwClientUser01.CreateProjectGroup(ctx, &gwapitypes.CreateProjectGroupRequest{Name: "privorg-privpg", ParentRef: path.Join("org", privOrg.Name), Visibility: gwapitypes.VisibilityPrivate})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// add user02 as member of pub org
 	_, _, err = gwClientUser01.AddOrgMember(ctx, pubOrg.ID, agolaUser02, gwapitypes.MemberRoleMember)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// add user02 as member of priv org
 	_, _, err = gwClientUser01.AddOrgMember(ctx, privOrg.ID, agolaUser02, gwapitypes.MemberRoleMember)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	tests := []struct {
 		name   string
@@ -3512,9 +3297,8 @@ func TestGetProjectGroup(t *testing.T) {
 					t.Fatalf("expected err %v, got err: %v", tt.err, err)
 				}
 			} else {
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				if diff := cmp.Diff(tt.pg, pg); diff != "" {
 					t.Fatalf("pg mismatch (-want +got):\n%s", diff)
 				}
@@ -3541,9 +3325,7 @@ func TestGetProject(t *testing.T) {
 	giteaAPIURL := fmt.Sprintf("http://%s:%s", sc.gitea.HTTPListenAddress, sc.gitea.HTTPPort)
 
 	giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	gwClientUser01 := gwclient.NewClient(sc.config.Gateway.APIExposedURL, tokenUser01)
 
@@ -3551,120 +3333,84 @@ func TestGetProject(t *testing.T) {
 
 	// create other users
 	_, _, err = gwAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser02})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	tokenUser02, _, err := gwAdminClient.CreateUserToken(ctx, agolaUser02, &gwapitypes.CreateUserTokenRequest{TokenName: "test"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	gwClientUser02 := gwclient.NewClient(sc.config.Gateway.APIExposedURL, tokenUser02.Token)
 
 	_, _, err = gwAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser03})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	tokenUser03, _, err := gwAdminClient.CreateUserToken(ctx, agolaUser03, &gwapitypes.CreateUserTokenRequest{TokenName: "test"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	gwClientUser03 := gwclient.NewClient(sc.config.Gateway.APIExposedURL, tokenUser03.Token)
 
 	// create public org
 	pubOrg, _, err := gwClientUser01.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: agolaOrg01, Visibility: gwapitypes.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create public org pub project group
 	pubOrgPubPG, _, err := gwClientUser01.CreateProjectGroup(ctx, &gwapitypes.CreateProjectGroupRequest{Name: "puborg-pubpg", ParentRef: path.Join("org", pubOrg.Name), Visibility: gwapitypes.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create public org pub project group pub project
 	pubOrgPubPGPubProj, _, err := gwClientUser01.CreateProject(ctx, &gwapitypes.CreateProjectRequest{Name: "puborg-pubpg-pugproj", ParentRef: pubOrgPubPG.ID, Visibility: gwapitypes.VisibilityPublic, RemoteSourceName: "gitea", RepoPath: path.Join(giteaUser01, "repo01")})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create public org pub project group priv project
 	pubOrgPubPGPrivProj, _, err := gwClientUser01.CreateProject(ctx, &gwapitypes.CreateProjectRequest{Name: "puborg-pubpg-privproj", ParentRef: pubOrgPubPG.ID, Visibility: gwapitypes.VisibilityPrivate, RemoteSourceName: "gitea", RepoPath: path.Join(giteaUser01, "repo01")})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create public org priv project group
 	pubOrgPrivPG, _, err := gwClientUser01.CreateProjectGroup(ctx, &gwapitypes.CreateProjectGroupRequest{Name: "puborg-privpg", ParentRef: path.Join("org", pubOrg.Name), Visibility: gwapitypes.VisibilityPrivate})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create public org priv project group pub project
 	pubOrgPrivPGPubProj, _, err := gwClientUser01.CreateProject(ctx, &gwapitypes.CreateProjectRequest{Name: "pubvorg-privpg-pugproj", ParentRef: pubOrgPrivPG.ID, Visibility: gwapitypes.VisibilityPublic, RemoteSourceName: "gitea", RepoPath: path.Join(giteaUser01, "repo01")})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create public org priv project group priv project
 	pubOrgPrivPGPrivProj, _, err := gwClientUser01.CreateProject(ctx, &gwapitypes.CreateProjectRequest{Name: "pubvorg-privpg-privproj", ParentRef: pubOrgPrivPG.ID, Visibility: gwapitypes.VisibilityPrivate, RemoteSourceName: "gitea", RepoPath: path.Join(giteaUser01, "repo01")})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create private org
 	privOrg, _, err := gwClientUser01.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: agolaOrg02, Visibility: gwapitypes.VisibilityPrivate})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create priv org pub project group
 	privOrgPubPG, _, err := gwClientUser01.CreateProjectGroup(ctx, &gwapitypes.CreateProjectGroupRequest{Name: "privorg-pubpg", ParentRef: path.Join("org", privOrg.Name), Visibility: gwapitypes.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create priv org pub project group pub project
 	privOrgPubPGPubProj, _, err := gwClientUser01.CreateProject(ctx, &gwapitypes.CreateProjectRequest{Name: "privorg-pubpg-pugproj", ParentRef: privOrgPubPG.ID, Visibility: gwapitypes.VisibilityPublic, RemoteSourceName: "gitea", RepoPath: path.Join(giteaUser01, "repo01")})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create priv org pub project group priv project
 	privOrgPubPGPrivProj, _, err := gwClientUser01.CreateProject(ctx, &gwapitypes.CreateProjectRequest{Name: "privorg-pubpg-privproj", ParentRef: privOrgPubPG.ID, Visibility: gwapitypes.VisibilityPrivate, RemoteSourceName: "gitea", RepoPath: path.Join(giteaUser01, "repo01")})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create priv org priv project group
 	privOrgPrivPG, _, err := gwClientUser01.CreateProjectGroup(ctx, &gwapitypes.CreateProjectGroupRequest{Name: "privorg-privpg", ParentRef: path.Join("org", privOrg.Name), Visibility: gwapitypes.VisibilityPrivate})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create priv org priv project group pub project
 	privOrgPrivPGPubProj, _, err := gwClientUser01.CreateProject(ctx, &gwapitypes.CreateProjectRequest{Name: "privorg-privpg-pubproj", ParentRef: privOrgPrivPG.ID, Visibility: gwapitypes.VisibilityPublic, RemoteSourceName: "gitea", RepoPath: path.Join(giteaUser01, "repo01")})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// create priv org priv project group priv project
 	privOrgPrivPGPrivProj, _, err := gwClientUser01.CreateProject(ctx, &gwapitypes.CreateProjectRequest{Name: "privorg-privpg-privproj", ParentRef: privOrgPrivPG.ID, Visibility: gwapitypes.VisibilityPrivate, RemoteSourceName: "gitea", RepoPath: path.Join(giteaUser01, "repo01")})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// add user02 as member of pub org
 	_, _, err = gwClientUser01.AddOrgMember(ctx, pubOrg.ID, agolaUser02, gwapitypes.MemberRoleMember)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	// add user02 as member of priv org
 	_, _, err = gwClientUser01.AddOrgMember(ctx, privOrg.ID, agolaUser02, gwapitypes.MemberRoleMember)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	tests := []struct {
 		name   string
@@ -3814,9 +3560,8 @@ func TestGetProject(t *testing.T) {
 					t.Fatalf("expected err %v, got err: %v", tt.err, err)
 				}
 			} else {
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				if diff := cmp.Diff(tt.proj, pg); diff != "" {
 					t.Fatalf("project mismatch (-want +got):\n%s", diff)
 				}
@@ -3840,47 +3585,39 @@ func TestUpdateOrganization(t *testing.T) {
 
 	//create user01 and user02
 	_, _, err := gwAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser01})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	tokenUser01, _, err := gwAdminClient.CreateUserToken(ctx, agolaUser01, &gwapitypes.CreateUserTokenRequest{TokenName: "test"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	gwClientUser01 := gwclient.NewClient(sc.config.Gateway.APIExposedURL, tokenUser01.Token)
 
 	_, _, err = gwAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser02})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	tokenUser02, _, err := gwAdminClient.CreateUserToken(ctx, agolaUser02, &gwapitypes.CreateUserTokenRequest{TokenName: "test"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	gwClientUser02 := gwclient.NewClient(sc.config.Gateway.APIExposedURL, tokenUser02.Token)
 
 	//create org
 	org, _, err := gwClientUser01.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: agolaOrg01, Visibility: gwapitypes.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	//user owner update org
 	expectedOrgResponse := &gwapitypes.OrgResponse{ID: org.ID, Name: agolaOrg01, Visibility: gwapitypes.VisibilityPrivate}
 
 	visibility := gwapitypes.VisibilityPrivate
 	updatedOrg, _, err := gwClientUser01.UpdateOrg(ctx, agolaOrg01, &gwapitypes.UpdateOrgRequest{Visibility: &visibility})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if diff := cmp.Diff(updatedOrg, expectedOrgResponse); diff != "" {
 		t.Fatalf("org mismatch (-want +got):\n%s", diff)
 	}
 
 	org, _, err = gwClientUser01.GetOrg(ctx, agolaOrg01)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if diff := cmp.Diff(expectedOrgResponse, org); diff != "" {
 		t.Fatalf("org mismatch (-want +got):\n%s", diff)
 	}
@@ -3897,9 +3634,8 @@ func TestUpdateOrganization(t *testing.T) {
 	}
 
 	org, _, err = gwClientUser01.GetOrg(ctx, agolaOrg01)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if diff := cmp.Diff(expectedOrgResponse, org); diff != "" {
 		t.Fatalf("org mismatch (-want +got):\n%s", diff)
 	}
@@ -3927,14 +3663,11 @@ func TestOrgInvitation(t *testing.T) {
 			orgInvitationEnabled: true,
 			f: func(ctx context.Context, t *testing.T, tc *testOrgInvitationConfig) {
 				invitation, _, err := tc.gwClientUser01.CreateOrgInvitation(ctx, agolaOrg01, &gwapitypes.CreateOrgInvitationRequest{UserRef: agolaUser02, Role: cstypes.MemberRoleMember})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				i, _, err := tc.gwClientUser01.GetOrgInvitation(ctx, agolaOrg01, agolaUser02)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				if diff := cmp.Diff(i, invitation); diff != "" {
 					t.Fatalf("invitation mismatch (-want +got):\n%s", diff)
 				}
@@ -3945,9 +3678,7 @@ func TestOrgInvitation(t *testing.T) {
 			orgInvitationEnabled: true,
 			f: func(ctx context.Context, t *testing.T, tc *testOrgInvitationConfig) {
 				_, _, err := tc.gwClientUser01.CreateOrgInvitation(ctx, agolaOrg01, &gwapitypes.CreateOrgInvitationRequest{UserRef: agolaUser02, Role: cstypes.MemberRoleMember})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_, _, err = tc.gwClientUser01.CreateOrgInvitation(ctx, agolaOrg01, &gwapitypes.CreateOrgInvitationRequest{UserRef: agolaUser02, Role: cstypes.MemberRoleMember})
 				expectedErr := "remote error internal"
@@ -3964,25 +3695,18 @@ func TestOrgInvitation(t *testing.T) {
 			orgInvitationEnabled: true,
 			f: func(ctx context.Context, t *testing.T, tc *testOrgInvitationConfig) {
 				invitation, _, err := tc.gwClientUser01.CreateOrgInvitation(ctx, agolaOrg01, &gwapitypes.CreateOrgInvitationRequest{UserRef: agolaUser02, Role: cstypes.MemberRoleMember})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_, _, err = tc.gwAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser03})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_, _, err = tc.gwClientUser01.CreateOrgInvitation(ctx, agolaOrg01, &gwapitypes.CreateOrgInvitationRequest{UserRef: agolaUser03, Role: cstypes.MemberRoleMember})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				userInvitations, _, err := tc.gwClientUser02.GetUserOrgInvitations(ctx)
 				expectedUserInvitations := []*gwapitypes.OrgInvitationResponse{invitation}
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				if len(userInvitations) != 1 {
 					t.Fatalf("expected 1 invitation got: %d", len(userInvitations))
 				}
@@ -4010,14 +3734,10 @@ func TestOrgInvitation(t *testing.T) {
 			orgInvitationEnabled: true,
 			f: func(ctx context.Context, t *testing.T, tc *testOrgInvitationConfig) {
 				_, _, err := tc.gwClientUser01.CreateOrgInvitation(ctx, agolaOrg01, &gwapitypes.CreateOrgInvitationRequest{UserRef: agolaUser02, Role: cstypes.MemberRoleMember})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_, err = tc.gwClientUser02.UserOrgInvitationAction(ctx, agolaOrg01, &gwapitypes.OrgInvitationActionRequest{Action: csapitypes.Reject})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_, _, err = tc.gwClientUser02.GetOrgInvitation(ctx, agolaOrg01, agolaUser02)
 				expectedErr := remoteErrorNotExist
@@ -4034,14 +3754,10 @@ func TestOrgInvitation(t *testing.T) {
 			orgInvitationEnabled: true,
 			f: func(ctx context.Context, t *testing.T, tc *testOrgInvitationConfig) {
 				_, _, err := tc.gwClientUser01.CreateOrgInvitation(ctx, agolaOrg01, &gwapitypes.CreateOrgInvitationRequest{UserRef: agolaUser02, Role: cstypes.MemberRoleMember})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_, err = tc.gwClientUser01.DeleteOrgInvitation(ctx, agolaOrg01, agolaUser02)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_, _, err = tc.gwClientUser01.GetOrgInvitation(ctx, agolaOrg01, agolaUser02)
 				expectedErr := remoteErrorNotExist
@@ -4058,14 +3774,10 @@ func TestOrgInvitation(t *testing.T) {
 			orgInvitationEnabled: true,
 			f: func(ctx context.Context, t *testing.T, tc *testOrgInvitationConfig) {
 				_, _, err := tc.gwClientUser01.CreateOrgInvitation(ctx, agolaOrg01, &gwapitypes.CreateOrgInvitationRequest{UserRef: agolaUser02, Role: cstypes.MemberRoleMember})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_, err = tc.gwClientUser02.UserOrgInvitationAction(ctx, agolaOrg01, &gwapitypes.OrgInvitationActionRequest{Action: csapitypes.Accept})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_, _, err = tc.gwClientUser02.GetOrgInvitation(ctx, agolaOrg01, agolaUser02)
 				expectedErr := remoteErrorNotExist
@@ -4077,9 +3789,8 @@ func TestOrgInvitation(t *testing.T) {
 				}
 
 				org01Members, _, err := tc.gwClientUser01.GetOrgMembers(ctx, agolaOrg01, nil)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				if len(org01Members.Members) != 2 {
 					t.Fatalf("expected 2 members got: %d", len(org01Members.Members))
 				}
@@ -4104,14 +3815,10 @@ func TestOrgInvitation(t *testing.T) {
 			orgInvitationEnabled: true,
 			f: func(ctx context.Context, t *testing.T, tc *testOrgInvitationConfig) {
 				_, _, err := tc.gwClientUser01.CreateOrgInvitation(ctx, agolaOrg01, &gwapitypes.CreateOrgInvitationRequest{UserRef: agolaUser02, Role: cstypes.MemberRoleMember})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_, err = tc.gwClientUser02.UserOrgInvitationAction(ctx, agolaOrg01, &gwapitypes.OrgInvitationActionRequest{Action: csapitypes.Accept})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_, _, err = tc.gwClientUser01.CreateOrgInvitation(ctx, agolaOrg01, &gwapitypes.CreateOrgInvitationRequest{UserRef: agolaUser02, Role: cstypes.MemberRoleMember})
 				expectedErr := "remote error internal"
@@ -4142,19 +3849,14 @@ func TestOrgInvitation(t *testing.T) {
 			orgInvitationEnabled: true,
 			f: func(ctx context.Context, t *testing.T, tc *testOrgInvitationConfig) {
 				_, _, err := tc.gwClientUser01.CreateOrgInvitation(ctx, agolaOrg01, &gwapitypes.CreateOrgInvitationRequest{UserRef: agolaUser02, Role: cstypes.MemberRoleMember})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_, err = tc.gwAdminClient.DeleteUser(ctx, agolaUser02)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				org01Invitations, _, err := tc.gwClientUser01.GetOrgInvitations(ctx, agolaOrg01)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				if len(org01Invitations) != 0 {
 					t.Fatalf("expected org01 invitations len 0, found: %d", len(org01Invitations))
 				}
@@ -4165,14 +3867,10 @@ func TestOrgInvitation(t *testing.T) {
 			orgInvitationEnabled: true,
 			f: func(ctx context.Context, t *testing.T, tc *testOrgInvitationConfig) {
 				_, _, err := tc.gwClientUser01.CreateOrgInvitation(ctx, agolaOrg01, &gwapitypes.CreateOrgInvitationRequest{UserRef: agolaUser02, Role: cstypes.MemberRoleMember})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_, err = tc.gwClientUser01.DeleteOrg(ctx, agolaOrg01)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				orgInvitations, _, err := tc.gwClientUser01.GetOrgInvitations(ctx, agolaOrg01)
 				expectedErr := "remote error internal"
@@ -4189,24 +3887,18 @@ func TestOrgInvitation(t *testing.T) {
 			orgInvitationEnabled: true,
 			f: func(ctx context.Context, t *testing.T, tc *testOrgInvitationConfig) {
 				_, _, err := tc.gwClientUser01.CreateOrgInvitation(ctx, agolaOrg01, &gwapitypes.CreateOrgInvitationRequest{UserRef: agolaUser02, Role: cstypes.MemberRoleMember})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				// disable invitations in agola config
 				tc.sc.config.Gateway.OrganizationMemberAddingMode = config.OrganizationMemberAddingModeInvitation
 				err = tc.sc.restartAgola()
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				gwClientUser01 := gwclient.NewClient(tc.sc.config.Gateway.APIExposedURL, tc.tokenUser01)
 				gwClientUser02 := gwclient.NewClient(tc.sc.config.Gateway.APIExposedURL, tc.tokenUser02)
 
 				_, err = gwClientUser02.UserOrgInvitationAction(ctx, agolaOrg01, &gwapitypes.OrgInvitationActionRequest{Action: csapitypes.Accept})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_, _, err = gwClientUser01.GetOrgInvitation(ctx, agolaOrg01, agolaUser02)
 				expectedErr := remoteErrorNotExist
@@ -4218,9 +3910,8 @@ func TestOrgInvitation(t *testing.T) {
 				}
 
 				orgMembers, _, err := gwClientUser01.GetOrgMembers(ctx, agolaOrg01, nil)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				if len(orgMembers.Members) != 2 {
 					t.Fatalf("expected 2 members got: %d", len(orgMembers.Members))
 				}
@@ -4259,28 +3950,21 @@ func TestOrgInvitation(t *testing.T) {
 			orgInvitationEnabled: true,
 			f: func(ctx context.Context, t *testing.T, tc *testOrgInvitationConfig) {
 				_, _, err := tc.gwClientUser01.CreateOrgInvitation(ctx, agolaOrg01, &gwapitypes.CreateOrgInvitationRequest{UserRef: agolaUser02, Role: cstypes.MemberRoleMember})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				// disable invitations in agola config
 				tc.sc.config.Gateway.OrganizationMemberAddingMode = config.OrganizationMemberAddingModeDirect
 				err = tc.sc.restartAgola()
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				gwClientUser01 := gwclient.NewClient(tc.sc.config.Gateway.APIExposedURL, tc.tokenUser01)
 
 				_, _, err = gwClientUser01.AddOrgMember(ctx, agolaOrg01, agolaUser02, gwapitypes.MemberRoleMember)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				orgInvitations, _, err := gwClientUser01.GetOrgInvitations(ctx, agolaOrg01)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				if len(orgInvitations) != 0 {
 					t.Fatalf("expected org invitations len 0, found: %d", len(orgInvitations))
 				}
@@ -4291,19 +3975,14 @@ func TestOrgInvitation(t *testing.T) {
 			orgInvitationEnabled: true,
 			f: func(ctx context.Context, t *testing.T, tc *testOrgInvitationConfig) {
 				_, _, err := tc.gwClientUser01.CreateOrgInvitation(ctx, agolaOrg01, &gwapitypes.CreateOrgInvitationRequest{UserRef: agolaUser02, Role: cstypes.MemberRoleMember})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_, _, err = tc.gwAdminClient.AddOrgMember(ctx, agolaOrg01, agolaUser02, gwapitypes.MemberRoleMember)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				orgInvitations, _, err := tc.gwClientUser01.GetOrgInvitations(ctx, agolaOrg01)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				if len(orgInvitations) != 0 {
 					t.Fatalf("expected org invitations len 0, found: %d", len(orgInvitations))
 				}
@@ -4314,24 +3993,17 @@ func TestOrgInvitation(t *testing.T) {
 			orgInvitationEnabled: true,
 			f: func(ctx context.Context, t *testing.T, tc *testOrgInvitationConfig) {
 				_, _, err := tc.gwAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser03})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_, _, err = tc.gwClientUser01.CreateOrgInvitation(ctx, agolaOrg01, &gwapitypes.CreateOrgInvitationRequest{UserRef: agolaUser02, Role: cstypes.MemberRoleMember})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_, _, err = tc.gwClientUser01.CreateOrgInvitation(ctx, agolaOrg01, &gwapitypes.CreateOrgInvitationRequest{UserRef: agolaUser03, Role: cstypes.MemberRoleMember})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				orgInvitations, _, err := tc.gwClientUser01.GetOrgInvitations(ctx, agolaOrg01)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				if len(orgInvitations) != 2 {
 					t.Fatalf("expected org invitations len 1, found: %d", len(orgInvitations))
 				}
@@ -4368,31 +4040,22 @@ func TestOrgInvitation(t *testing.T) {
 			gwAdminClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, sc.config.Gateway.AdminToken)
 
 			_, _, err := gwAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser01})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			tokenUser01, _, err := gwAdminClient.CreateUserToken(ctx, agolaUser01, &gwapitypes.CreateUserTokenRequest{TokenName: "test"})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			_, _, err = gwAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser02})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			tokenUser02, _, err := gwAdminClient.CreateUserToken(ctx, agolaUser02, &gwapitypes.CreateUserTokenRequest{TokenName: "test"})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			_, _, err = gwAdminClient.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: agolaOrg01, Visibility: gwapitypes.VisibilityPublic})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			_, _, err = gwAdminClient.AddOrgMember(ctx, agolaOrg01, agolaUser01, gwapitypes.MemberRoleOwner)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			gwClientUser01 := gwclient.NewClient(sc.config.Gateway.APIExposedURL, tokenUser01.Token)
 			gwClientUser02 := gwclient.NewClient(sc.config.Gateway.APIExposedURL, tokenUser02.Token)
@@ -4426,9 +4089,8 @@ func TestGetUsersPermissions(t *testing.T) {
 				gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, sc.config.Gateway.AdminToken)
 
 				user, _, err := gwClient.GetUserByLinkedAccountRemoteUserAndSource(ctx, "1", "gitea")
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				if user.UserName != giteaUser01 {
 					t.Fatalf("expected username %s, got %s", giteaUser01, user.UserName)
 				}
@@ -4457,23 +4119,18 @@ func TestGetUsersPermissions(t *testing.T) {
 				gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, sc.config.Gateway.AdminToken)
 
 				user01, _, err := gwClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser01})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				user02, _, err := gwClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser02})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				expectedUsers := []*gwapitypes.PrivateUserResponse{
 					{ID: user01.ID, UserName: user01.UserName, Tokens: []string{}, LinkedAccounts: []*gwapitypes.LinkedAccountResponse{}},
 					{ID: user02.ID, UserName: user02.UserName, Tokens: []string{}, LinkedAccounts: []*gwapitypes.LinkedAccountResponse{}},
 				}
 				users, _, err := gwClient.GetUsers(ctx, nil)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				if diff := cmp.Diff(expectedUsers, users); diff != "" {
 					t.Fatalf("users mismatch (-want +got):\n%s", diff)
 				}
@@ -4537,17 +4194,15 @@ func TestGetRemoteSources(t *testing.T) {
 			AuthType:            "password",
 			SkipSSHHostKeyCheck: true,
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		remoteSources = append(remoteSources, remoteSource)
 	}
 
 	t.Run("test get remote sources with default limit greater than remote sources", func(t *testing.T) {
 		remoteSources, resp, err := gwClient.GetRemoteSources(ctx, &gwclient.ListOptions{SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedRemoteSources := 9
 		if len(remoteSources) != expectedRemoteSources {
 			t.Fatalf("expected %d members, got %d members", expectedRemoteSources, len(remoteSources))
@@ -4559,9 +4214,8 @@ func TestGetRemoteSources(t *testing.T) {
 
 	t.Run("test get remote sources with limit less than remote sources", func(t *testing.T) {
 		remoteSources, resp, err := gwClient.GetRemoteSources(ctx, &gwclient.ListOptions{Limit: 5, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedRemoteSources := 5
 		if len(remoteSources) != expectedRemoteSources {
 			t.Fatalf("expected %d remote sources, got %d remote sources", expectedRemoteSources, len(remoteSources))
@@ -4575,9 +4229,7 @@ func TestGetRemoteSources(t *testing.T) {
 		respAllRemoteSources := []*gwapitypes.RemoteSourceResponse{}
 
 		respRemoteSources, resp, err := gwClient.GetRemoteSources(ctx, &gwclient.ListOptions{Limit: 5, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		expectedRemoteSources := 5
 		if len(respRemoteSources) != expectedRemoteSources {
@@ -4592,9 +4244,8 @@ func TestGetRemoteSources(t *testing.T) {
 		// fetch next results
 		for {
 			respRemoteSources, resp, err = gwClient.GetRemoteSources(ctx, &gwclient.ListOptions{Cursor: resp.Cursor, Limit: 5})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			expectedRemoteSources := 5
 			if resp.Cursor != "" && len(respRemoteSources) != expectedRemoteSources {
 				t.Fatalf("expected %d remote sources, got %d remote sources", expectedRemoteSources, len(respRemoteSources))
@@ -4634,17 +4285,15 @@ func TestGetUsers(t *testing.T) {
 	users := []*gwapitypes.UserResponse{}
 	for i := 1; i < 10; i++ {
 		user, _, err := gwClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: fmt.Sprintf("orguser%d", i)})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		users = append(users, user)
 	}
 
 	t.Run("test get users with default limit greater than users", func(t *testing.T) {
 		users, resp, err := gwClient.GetUsers(ctx, &gwclient.ListOptions{SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedUsers := 9
 		if len(users) != expectedUsers {
 			t.Fatalf("expected %d members, got %d members", expectedUsers, len(users))
@@ -4656,9 +4305,8 @@ func TestGetUsers(t *testing.T) {
 
 	t.Run("test get users with limit less than users", func(t *testing.T) {
 		users, resp, err := gwClient.GetUsers(ctx, &gwclient.ListOptions{Limit: 5, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedUsers := 5
 		if len(users) != expectedUsers {
 			t.Fatalf("expected %d users, got %d users", expectedUsers, len(users))
@@ -4672,9 +4320,7 @@ func TestGetUsers(t *testing.T) {
 		respAllUsers := []*gwapitypes.UserResponse{}
 
 		respUsers, resp, err := gwClient.GetUsers(ctx, &gwclient.ListOptions{Limit: 5, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		expectedUsers := 5
 		if len(respUsers) != expectedUsers {
@@ -4691,9 +4337,8 @@ func TestGetUsers(t *testing.T) {
 		// fetch next results
 		for {
 			respUsers, resp, err = gwClient.GetUsers(ctx, &gwclient.ListOptions{Cursor: resp.Cursor, Limit: 5})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			expectedUsers := 5
 			if resp.Cursor != "" && len(respUsers) != expectedUsers {
 				t.Fatalf("expected %d users, got %d users", expectedUsers, len(respUsers))
@@ -4734,13 +4379,11 @@ func TestGetOrgs(t *testing.T) {
 
 	// create users
 	_, _, err := gwAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser01})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	tokenUser01, _, err := gwAdminClient.CreateUserToken(ctx, agolaUser01, &gwapitypes.CreateUserTokenRequest{TokenName: "test"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	gwClientUser01 := gwclient.NewClient(sc.config.Gateway.APIExposedURL, tokenUser01.Token)
 
 	allOrgs := []*gwapitypes.OrgResponse{}
@@ -4752,9 +4395,8 @@ func TestGetOrgs(t *testing.T) {
 			visibility = gwapitypes.VisibilityPrivate
 		}
 		org, _, err := gwAdminClient.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: fmt.Sprintf("org%02d", i), Visibility: visibility})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		allOrgs = append(allOrgs, org)
 		if visibility == gwapitypes.VisibilityPublic {
 			publicOrgs = append(publicOrgs, org)
@@ -4763,9 +4405,8 @@ func TestGetOrgs(t *testing.T) {
 
 	t.Run("test get public orgs with default limit greater than orgs", func(t *testing.T) {
 		orgs, resp, err := gwClientUser01.GetOrgs(ctx, &gwclient.ListOptions{SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedOrgs := 9
 		if len(orgs) != expectedOrgs {
 			t.Fatalf("expected %d members, got %d members", expectedOrgs, len(orgs))
@@ -4781,9 +4422,8 @@ func TestGetOrgs(t *testing.T) {
 
 	t.Run("test get public/private orgs with default limit greater than orgs", func(t *testing.T) {
 		orgs, resp, err := gwAdminClient.GetOrgs(ctx, &gwclient.ListOptions{SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedOrgs := 18
 		if len(orgs) != expectedOrgs {
 			t.Fatalf("expected %d members, got %d members", expectedOrgs, len(orgs))
@@ -4795,9 +4435,8 @@ func TestGetOrgs(t *testing.T) {
 
 	t.Run("test get public orgs with limit less than orgs", func(t *testing.T) {
 		orgs, resp, err := gwClientUser01.GetOrgs(ctx, &gwclient.ListOptions{Limit: 5, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedOrgs := 5
 		if len(orgs) != expectedOrgs {
 			t.Fatalf("expected %d orgs, got %d orgs", expectedOrgs, len(orgs))
@@ -4809,9 +4448,8 @@ func TestGetOrgs(t *testing.T) {
 
 	t.Run("test get public/private orgs with limit less than orgs", func(t *testing.T) {
 		orgs, resp, err := gwAdminClient.GetOrgs(ctx, &gwclient.ListOptions{Limit: 5, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedOrgs := 5
 		if len(orgs) != expectedOrgs {
 			t.Fatalf("expected %d orgs, got %d orgs", expectedOrgs, len(orgs))
@@ -4825,9 +4463,7 @@ func TestGetOrgs(t *testing.T) {
 		respAllOrgs := []*gwapitypes.OrgResponse{}
 
 		respOrgs, resp, err := gwClientUser01.GetOrgs(ctx, &gwclient.ListOptions{Limit: 5, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		expectedOrgs := 5
 		if len(respOrgs) != expectedOrgs {
@@ -4842,9 +4478,8 @@ func TestGetOrgs(t *testing.T) {
 		// fetch next results
 		for {
 			respOrgs, resp, err = gwClientUser01.GetOrgs(ctx, &gwclient.ListOptions{Cursor: resp.Cursor, Limit: 5})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			expectedOrgs := 5
 			if resp.Cursor != "" && len(respOrgs) != expectedOrgs {
 				t.Fatalf("expected %d orgs, got %d orgs", expectedOrgs, len(respOrgs))
@@ -4871,9 +4506,7 @@ func TestGetOrgs(t *testing.T) {
 		respAllOrgs := []*gwapitypes.OrgResponse{}
 
 		respOrgs, resp, err := gwAdminClient.GetOrgs(ctx, &gwclient.ListOptions{Limit: 5, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		expectedOrgs := 5
 		if len(respOrgs) != expectedOrgs {
@@ -4888,9 +4521,8 @@ func TestGetOrgs(t *testing.T) {
 		// fetch next results
 		for {
 			respOrgs, resp, err = gwAdminClient.GetOrgs(ctx, &gwclient.ListOptions{Cursor: resp.Cursor, Limit: 5})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			expectedOrgs := 5
 			if resp.Cursor != "" && len(respOrgs) != expectedOrgs {
 				t.Fatalf("expected %d orgs, got %d orgs", expectedOrgs, len(respOrgs))
@@ -4931,28 +4563,23 @@ func TestGetOrgMembers(t *testing.T) {
 	users := []*gwapitypes.UserResponse{}
 	for i := 1; i < 10; i++ {
 		user, _, err := gwClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: fmt.Sprintf("orguser%d", i)})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		users = append(users, user)
 	}
 
 	org, _, err := gwClient.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: agolaOrg01, Visibility: gwapitypes.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	for _, user := range users {
-		if _, _, err := gwClient.AddOrgMember(ctx, agolaOrg01, user.ID, gwapitypes.MemberRoleMember); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		_, _, err := gwClient.AddOrgMember(ctx, agolaOrg01, user.ID, gwapitypes.MemberRoleMember)
+		testutil.NilError(t, err)
 	}
 
 	t.Run("test get org members with default limit greater than org members", func(t *testing.T) {
 		res, resp, err := gwClient.GetOrgMembers(ctx, org.ID, &gwclient.ListOptions{SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedOrgMembers := 9
 		if len(res.Members) != expectedOrgMembers {
 			t.Fatalf("expected %d members, got %d members", expectedOrgMembers, len(res.Members))
@@ -4964,9 +4591,8 @@ func TestGetOrgMembers(t *testing.T) {
 
 	t.Run("test get org members with limit less than org members", func(t *testing.T) {
 		res, resp, err := gwClient.GetOrgMembers(ctx, org.ID, &gwclient.ListOptions{Limit: 5, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedOrgMembers := 5
 		if len(res.Members) != expectedOrgMembers {
 			t.Fatalf("expected %d org members, got %d org members", expectedOrgMembers, len(res.Members))
@@ -4980,9 +4606,7 @@ func TestGetOrgMembers(t *testing.T) {
 		orgMembers := []*gwapitypes.OrgMemberResponse{}
 
 		res, resp, err := gwClient.GetOrgMembers(ctx, org.ID, &gwclient.ListOptions{Limit: 5, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		expectedOrgMembers := 5
 		if len(res.Members) != expectedOrgMembers {
@@ -4997,9 +4621,8 @@ func TestGetOrgMembers(t *testing.T) {
 		// fetch next results
 		for {
 			res, resp, err = gwClient.GetOrgMembers(ctx, org.ID, &gwclient.ListOptions{Cursor: resp.Cursor, Limit: 5})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			expectedOrgMembers := 5
 			if resp.Cursor != "" && len(res.Members) != expectedOrgMembers {
 				t.Fatalf("expected %d org members, got %d org members", expectedOrgMembers, len(res.Members))
@@ -5042,36 +4665,30 @@ func TestGetUserOrgs(t *testing.T) {
 	gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, sc.config.Gateway.AdminToken)
 
 	user, _, err := gwClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: "orguser01"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	orgs := []*gwapitypes.OrgResponse{}
 	for i := 1; i < 10; i++ {
 		org, _, err := gwClient.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: fmt.Sprintf("org%d", i), Visibility: gwapitypes.VisibilityPublic})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		orgs = append(orgs, org)
 	}
 
 	for _, org := range orgs {
-		if _, _, err := gwClient.AddOrgMember(ctx, org.ID, user.ID, gwapitypes.MemberRoleMember); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		_, _, err := gwClient.AddOrgMember(ctx, org.ID, user.ID, gwapitypes.MemberRoleMember)
+		testutil.NilError(t, err)
 	}
 
 	tokenUser, _, err := gwClient.CreateUserToken(ctx, user.ID, &gwapitypes.CreateUserTokenRequest{TokenName: "test"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	gwClient = gwclient.NewClient(sc.config.Gateway.APIExposedURL, tokenUser.Token)
 
 	t.Run("test get user orgs with default limit greater than user orgs", func(t *testing.T) {
 		userOrgs, resp, err := gwClient.GetUserOrgs(ctx, &gwclient.ListOptions{SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedUserOrgs := 9
 		if len(userOrgs) != expectedUserOrgs {
 			t.Fatalf("expected %d members, got %d members", expectedUserOrgs, len(userOrgs))
@@ -5083,9 +4700,8 @@ func TestGetUserOrgs(t *testing.T) {
 
 	t.Run("test get user orgs with limit less than user orgs", func(t *testing.T) {
 		res, resp, err := gwClient.GetUserOrgs(ctx, &gwclient.ListOptions{Limit: 5, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		expectedUserOrgs := 5
 		if len(res) != expectedUserOrgs {
 			t.Fatalf("expected %d user orgs, got %d user orgs", expectedUserOrgs, len(res))
@@ -5099,9 +4715,7 @@ func TestGetUserOrgs(t *testing.T) {
 		respAllUserOrgs := []*gwapitypes.UserOrgResponse{}
 
 		respUserOrgs, resp, err := gwClient.GetUserOrgs(ctx, &gwclient.ListOptions{Limit: 5, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		expectedUserOrgs := 5
 		if len(respUserOrgs) != expectedUserOrgs {
@@ -5116,9 +4730,8 @@ func TestGetUserOrgs(t *testing.T) {
 		// fetch next results
 		for {
 			respUserOrgs, resp, err = gwClient.GetUserOrgs(ctx, &gwclient.ListOptions{Cursor: resp.Cursor, Limit: 5})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			expectedUserOrgs := 5
 			if resp.Cursor != "" && len(respUserOrgs) != expectedUserOrgs {
 				t.Fatalf("expected %d user orgs, got %d user orgs", expectedUserOrgs, len(respUserOrgs))
@@ -5159,17 +4772,12 @@ func TestMaintenance(t *testing.T) {
 				gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, sc.config.Gateway.AdminToken)
 
 				_, err := gwClient.EnableMaintenance(ctx, configstoreService)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
+				testutil.NilError(t, err)
 
 				_, err = gwClient.EnableMaintenance(ctx, runserviceService)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 			},
 		},
 		{
@@ -5178,14 +4786,10 @@ func TestMaintenance(t *testing.T) {
 				gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, sc.config.Gateway.AdminToken)
 
 				_, _, err := gwClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser01})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				token, _, err := gwClient.CreateUserToken(ctx, agolaUser01, &gwapitypes.CreateUserTokenRequest{TokenName: "tokenuser01"})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				gwClient = gwclient.NewClient(sc.config.Gateway.APIExposedURL, token.Token)
 
@@ -5213,14 +4817,10 @@ func TestMaintenance(t *testing.T) {
 				gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, sc.config.Gateway.AdminToken)
 
 				_, _, err := gwClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser01})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				token, _, err := gwClient.CreateUserToken(ctx, agolaUser01, &gwapitypes.CreateUserTokenRequest{TokenName: "tokenuser01"})
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				gwClient = gwclient.NewClient(sc.config.Gateway.APIExposedURL, token.Token)
 
@@ -5248,14 +4848,10 @@ func TestMaintenance(t *testing.T) {
 				gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, sc.config.Gateway.AdminToken)
 
 				_, err := gwClient.EnableMaintenance(ctx, configstoreService)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_, err = gwClient.EnableMaintenance(ctx, runserviceService)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_ = testutil.Wait(30*time.Second, func() (bool, error) {
 					maintenanceStatus, _, err := gwClient.GetMaintenanceStatus(ctx, configstoreService)
@@ -5301,9 +4897,7 @@ func TestMaintenance(t *testing.T) {
 				gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, sc.config.Gateway.AdminToken)
 
 				_, err := gwClient.EnableMaintenance(ctx, configstoreService)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_ = testutil.Wait(30*time.Second, func() (bool, error) {
 					maintenanceStatus, _, err := gwClient.GetMaintenanceStatus(ctx, configstoreService)
@@ -5318,14 +4912,10 @@ func TestMaintenance(t *testing.T) {
 				})
 
 				_, err = gwClient.DisableMaintenance(ctx, configstoreService)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_, err = gwClient.EnableMaintenance(ctx, runserviceService)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				_ = testutil.Wait(30*time.Second, func() (bool, error) {
 					maintenanceStatus, _, err := gwClient.GetMaintenanceStatus(ctx, runserviceService)
@@ -5340,9 +4930,7 @@ func TestMaintenance(t *testing.T) {
 				})
 
 				_, err = gwClient.DisableMaintenance(ctx, runserviceService)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 			},
 		},
 		{
@@ -5425,9 +5013,7 @@ func TestExportImport(t *testing.T) {
 	giteaToken, token := createLinkedAccount(ctx, t, sc.gitea, sc.config)
 
 	giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, token)
 
@@ -5477,9 +5063,8 @@ func TestExportImport(t *testing.T) {
 	})
 
 	runs, _, err := gwClient.GetProjectRuns(ctx, project.ID, nil, nil, 0, 0, false)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if len(runs) != 1 {
 		t.Fatalf("expected %d run got: %d", 1, len(runs))
 	}
@@ -5487,62 +5072,43 @@ func TestExportImport(t *testing.T) {
 	gwClient = gwclient.NewClient(sc.config.Gateway.APIExposedURL, sc.config.Gateway.AdminToken)
 
 	users, _, err := gwClient.GetUsers(ctx, nil)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	projectgroup, _, err := gwClient.GetProjectGroup(ctx, "user/user01")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	remotesources, _, err := gwClient.GetRemoteSources(ctx, nil)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	user01Projects, _, err := gwClient.GetProjectGroupProjects(ctx, "user/user01")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	w, err := os.Create(filepath.Join(dir, "export-configstore"))
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	resp, err := gwClient.Export(ctx, configstoreService)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	defer resp.Body.Close()
 
 	_, err = io.Copy(w, resp.Body)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	w, err = os.Create(filepath.Join(dir, "export-runservice"))
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	resp, err = gwClient.Export(ctx, runserviceService)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	defer resp.Body.Close()
 
 	_, err = io.Copy(w, resp.Body)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	//add some data
 	_, _, err = gwClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser02})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	_, _, err = gwClient.CreateRemoteSource(ctx, &gwapitypes.CreateRemoteSourceRequest{
 		Name:                "github",
 		Type:                "gitea",
@@ -5550,23 +5116,16 @@ func TestExportImport(t *testing.T) {
 		AuthType:            "password",
 		SkipSSHHostKeyCheck: true,
 	})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	_, _, err = gwClient.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: agolaOrg01, Visibility: gwapitypes.VisibilityPublic})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	_, err = gwClient.EnableMaintenance(ctx, configstoreService)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	_, err = gwClient.EnableMaintenance(ctx, runserviceService)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	_ = testutil.Wait(30*time.Second, func() (bool, error) {
 		maintenanceStatus, _, err := gwClient.GetMaintenanceStatus(ctx, configstoreService)
@@ -5589,24 +5148,16 @@ func TestExportImport(t *testing.T) {
 	})
 
 	r, err := os.Open(filepath.Join(dir, "export-configstore"))
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	_, err = gwClient.Import(ctx, configstoreService, r)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	_, err = gwClient.DisableMaintenance(ctx, configstoreService)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	_, err = gwClient.DisableMaintenance(ctx, runserviceService)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	_ = testutil.Wait(30*time.Second, func() (bool, error) {
 		maintenanceStatus, _, err := gwClient.GetMaintenanceStatus(ctx, configstoreService)
@@ -5629,49 +5180,43 @@ func TestExportImport(t *testing.T) {
 	})
 
 	impUsers, _, err := gwClient.GetUsers(ctx, nil)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if diff := cmp.Diff(users, impUsers); diff != "" {
 		t.Fatalf("users mismatch (-want +got):\n%s", diff)
 	}
 
 	impProjectgroup, _, err := gwClient.GetProjectGroup(ctx, "user/user01")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if diff := cmp.Diff(projectgroup, impProjectgroup); diff != "" {
 		t.Fatalf("projectgroup mismatch (-want +got):\n%s", diff)
 	}
 
 	impRemotesources, _, err := gwClient.GetRemoteSources(ctx, nil)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if diff := cmp.Diff(remotesources, impRemotesources); diff != "" {
 		t.Fatalf("remotesources mismatch (-want +got):\n%s", diff)
 	}
 
 	impUser01Projects, _, err := gwClient.GetProjectGroupProjects(ctx, "user/user01")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if diff := cmp.Diff(user01Projects, impUser01Projects); diff != "" {
 		t.Fatalf("user01 projects mismatch (-want +got):\n%s", diff)
 	}
 
 	impRuns, _, err := gwClient.GetProjectRuns(ctx, project.ID, nil, nil, 0, 0, false)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if diff := cmp.Diff(runs, impRuns); diff != "" {
 		t.Fatalf("runs mismatch (-want +got):\n%s", diff)
 	}
 
 	orgs, _, err := gwClient.GetOrgs(ctx, nil)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if len(orgs) != 0 {
 		t.Fatalf("expected 0 orgs got: %d", len(orgs))
 	}
@@ -5758,9 +5303,7 @@ func TestGetProjectRuns(t *testing.T) {
 			giteaToken, token := createLinkedAccount(ctx, t, sc.gitea, sc.config)
 
 			giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, token)
 
@@ -5786,9 +5329,7 @@ func TestGetProjectRuns(t *testing.T) {
 			})
 
 			runs, _, err := gwClient.GetProjectRuns(ctx, project.ID, tt.phaseFilter, tt.resultFilter, 0, 0, false)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			t.Logf("runs: %s", util.Dump(runs))
 
@@ -5824,9 +5365,7 @@ func TestGetProjectRuns(t *testing.T) {
 		giteaToken, token := createLinkedAccount(ctx, t, sc.gitea, sc.config)
 
 		giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, token)
 
@@ -5951,9 +5490,7 @@ func TestRunEventsNotification(t *testing.T) {
 			giteaAPIURL := fmt.Sprintf("http://%s:%s", sc.gitea.HTTPListenAddress, sc.gitea.HTTPPort)
 
 			giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, tokenUser01)
 
@@ -5978,9 +5515,8 @@ func TestRunEventsNotification(t *testing.T) {
 			})
 
 			runs, _, err := gwClient.GetProjectRuns(ctx, project.ID, nil, nil, 0, 0, false)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			if len(runs) != 1 {
 				t.Fatalf("expected %d run got: %d", 1, len(runs))
 			}
@@ -5993,15 +5529,12 @@ func TestRunEventsNotification(t *testing.T) {
 			}
 
 			run, _, err := gwClient.GetProjectRun(ctx, project.ID, runs[0].Number)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			_ = testutil.Wait(30*time.Second, func() (bool, error) {
 				webhooks, err := wr.webhooks.getWebhooks()
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				if len(webhooks) < len(tt.expectedRunPhaseEvents) {
 					return false, nil
 				}
@@ -6010,21 +5543,16 @@ func TestRunEventsNotification(t *testing.T) {
 			})
 
 			webhooks, err := wr.webhooks.getWebhooks()
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			for i, w := range webhooks {
 				data, err := json.Marshal(w.webhookData)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
 
 				sig256 := hmac.New(sha256.New, []byte(sc.config.Notification.WebhookSecret))
 				_, err = io.MultiWriter(sig256).Write(data)
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
-				}
+				testutil.NilError(t, err)
+
 				signatureSHA256 := hex.EncodeToString(sig256.Sum(nil))
 				if signatureSHA256 != w.signature {
 					t.Fatalf("expected webhook signature %q, got %q", signatureSHA256, w.signature)
@@ -6206,9 +5734,7 @@ func TestCommitStatusDelivery(t *testing.T) {
 			giteaAPIURL := fmt.Sprintf("http://%s:%s", sc.gitea.HTTPListenAddress, sc.gitea.HTTPPort)
 
 			giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			gwClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, tokenUser01)
 
@@ -6233,9 +5759,8 @@ func TestCommitStatusDelivery(t *testing.T) {
 			})
 
 			runs, _, err := gwClient.GetProjectRuns(ctx, project.ID, nil, nil, 0, 0, false)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			if len(runs) != 1 {
 				t.Fatalf("expected %d run got: %d", 1, len(runs))
 			}
@@ -6261,14 +5786,11 @@ func TestCommitStatusDelivery(t *testing.T) {
 			})
 
 			targetURL, err := webRunURL(sc.config.Notification.WebExposedURL, project.ID, runs[0].Number)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
 
 			combinedStatus, _, err := giteaClient.GetCombinedStatus(agolaUser01, giteaRepo.Name, "master")
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			if combinedStatus.State != tt.expectedGiteaStatusState {
 				t.Fatalf("expected commit state %q, got %q", tt.expectedGiteaStatusState, combinedStatus.State)
 			}
@@ -6328,42 +5850,32 @@ func TestProjectRunActions(t *testing.T) {
 		giteaAPIURL := fmt.Sprintf("http://%s:%s", sc.gitea.HTTPListenAddress, sc.gitea.HTTPPort)
 
 		giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		gwAdminClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, sc.config.Gateway.AdminToken)
 		gwUser01Client := gwclient.NewClient(sc.config.Gateway.APIExposedURL, tokenUser01)
 
 		_, _, err = gwAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser02})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		token, _, err := gwAdminClient.CreateUserToken(ctx, agolaUser02, &gwapitypes.CreateUserTokenRequest{TokenName: "testtoken"})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		gwUser02Client := gwclient.NewClient(sc.config.Gateway.APIExposedURL, token.Token)
 
 		_, _, err = gwAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser03})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		token, _, err = gwAdminClient.CreateUserToken(ctx, agolaUser03, &gwapitypes.CreateUserTokenRequest{TokenName: "testtoken"})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		gwUser03Client := gwclient.NewClient(sc.config.Gateway.APIExposedURL, token.Token)
 
 		_, _, err = gwUser01Client.CreateOrg(ctx, &gwapitypes.CreateOrgRequest{Name: agolaOrg01, Visibility: gwapitypes.VisibilityPublic})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		_, _, err = gwUser01Client.AddOrgMember(ctx, agolaOrg01, agolaUser02, gwapitypes.MemberRoleMember)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		giteaRepo, project := createProject(ctx, t, giteaClient, gwUser01Client, withParentRef(path.Join("org", agolaOrg01)), withMembersCanPerformRunActions(true))
 
@@ -6388,9 +5900,8 @@ func TestProjectRunActions(t *testing.T) {
 		})
 
 		runs, _, err := gwUser01Client.GetProjectRuns(ctx, project.ID, nil, nil, 0, 0, false)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(runs) != 1 {
 			t.Fatalf("expected %d run got: %d", 1, len(runs))
 		}
@@ -6406,9 +5917,7 @@ func TestProjectRunActions(t *testing.T) {
 			ActionType: gwapitypes.RunActionTypeRestart,
 			FromStart:  true,
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		// test org run actions executed by an organization member type with project MembersCanPerformRunActions set to true
 
@@ -6416,9 +5925,7 @@ func TestProjectRunActions(t *testing.T) {
 			ActionType: gwapitypes.RunActionTypeRestart,
 			FromStart:  true,
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		// test org run actions executed by an user that isn't organization member
 
@@ -6438,9 +5945,7 @@ func TestProjectRunActions(t *testing.T) {
 		_, _, err = gwUser01Client.UpdateProject(ctx, project.ID, &gwapitypes.UpdateProjectRequest{
 			MembersCanPerformRunActions: util.BoolP(false),
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		_, _, err = gwUser02Client.ProjectRunAction(ctx, project.ID, runs[0].Number, &gwapitypes.RunActionsRequest{
 			ActionType: gwapitypes.RunActionTypeRestart,
@@ -6471,21 +5976,17 @@ func TestProjectRunActions(t *testing.T) {
 		gwUser01Client := gwclient.NewClient(sc.config.Gateway.APIExposedURL, tokenUser01)
 
 		_, _, err := gwAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser02})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		token, _, err := gwAdminClient.CreateUserToken(ctx, agolaUser02, &gwapitypes.CreateUserTokenRequest{TokenName: "testtoken"})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		gwUser02Client := gwclient.NewClient(sc.config.Gateway.APIExposedURL, token.Token)
 
 		giteaAPIURL := fmt.Sprintf("http://%s:%s", sc.gitea.HTTPListenAddress, sc.gitea.HTTPPort)
 
 		giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		giteaRepo, project := createProject(ctx, t, giteaClient, gwUser01Client)
 
@@ -6508,9 +6009,8 @@ func TestProjectRunActions(t *testing.T) {
 		})
 
 		runs, _, err := gwUser01Client.GetProjectRuns(ctx, project.ID, nil, nil, 0, 0, false)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(runs) != 1 {
 			t.Fatalf("expected %d run got: %d", 1, len(runs))
 		}
@@ -6526,9 +6026,7 @@ func TestProjectRunActions(t *testing.T) {
 			ActionType: gwapitypes.RunActionTypeRestart,
 			FromStart:  true,
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		// test user run actions unauthorized
 
@@ -6590,21 +6088,17 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 	gwUserAdminClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, sc.config.Gateway.AdminToken)
 
 	_, _, err := gwUserAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser02})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	user02Token, _, err := gwUserAdminClient.CreateUserToken(ctx, agolaUser02, &gwapitypes.CreateUserTokenRequest{TokenName: "token01"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	gwUser02Client := gwclient.NewClient(sc.config.Gateway.APIExposedURL, user02Token.Token)
 
 	giteaAPIURL := fmt.Sprintf("http://%s:%s", sc.gitea.HTTPListenAddress, sc.gitea.HTTPPort)
 
 	giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	giteaRepo, project := createProject(ctx, t, giteaClient, gwUser01Client, withVisibility(gwapitypes.VisibilityPrivate))
 
@@ -6627,9 +6121,8 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 	})
 
 	runs, _, err := gwUser01Client.GetProjectRuns(ctx, project.ID, nil, nil, 0, 0, false)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if len(runs) == 0 {
 		t.Fatalf("expected %d run got: %d", 1, len(runs))
 	}
@@ -6661,9 +6154,8 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 
 	t.Run("test get project run webhook deliveries", func(t *testing.T) {
 		runWebhookDeliveries, resp, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(runWebhookDeliveries) != 4 {
 			t.Fatalf("expected 4 runWebhookDeliveries got: %d", len(runWebhookDeliveries))
 		}
@@ -6679,16 +6171,12 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 
 	t.Run("test get project run webhook deliveries with limit less than project run webhook deliveries continuation", func(t *testing.T) {
 		runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		respAllRunWebhookDeliveries := []*gwapitypes.RunWebhookDeliveryResponse{}
 
 		respRunWebhookDeliveries, resp, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 1, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		expectedRunWebhookDeliveries := 1
 		if len(respRunWebhookDeliveries) != expectedRunWebhookDeliveries {
@@ -6703,9 +6191,8 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 		// fetch next results
 		for {
 			respRunWebhookDeliveries, resp, err = gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Cursor: resp.Cursor, Limit: 1})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			if resp.Cursor != "" && len(respRunWebhookDeliveries) != expectedRunWebhookDeliveries {
 				t.Fatalf("expected %d project run webhook deliveries, got %d project run webhook deliveries", expectedRunWebhookDeliveries, len(respRunWebhookDeliveries))
 			}
@@ -6749,9 +6236,8 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 
 	t.Run("test get project run webhook deliveries with deliverystatus = delivered", func(t *testing.T) {
 		runWebhookDeliveries, resp, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, []string{string(nstypes.DeliveryStatusDelivered)}, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(runWebhookDeliveries) != 4 {
 			t.Fatalf("expected 4 runWebhookDeliveries got: %d", len(runWebhookDeliveries))
 		}
@@ -6762,9 +6248,8 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 
 	t.Run("test get project run webhook deliveries with deliverystatus = deliveryError", func(t *testing.T) {
 		runWebhookDeliveries, resp, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, []string{string(nstypes.DeliveryStatusDeliveryError)}, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(runWebhookDeliveries) != 0 {
 			t.Fatalf("expected 0 runWebhookDeliveries got: %d", len(runWebhookDeliveries))
 		}
@@ -6817,21 +6302,17 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		gwUserAdminClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, sc.config.Gateway.AdminToken)
 
 		_, _, err := gwUserAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser02})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		user02Token, _, err := gwUserAdminClient.CreateUserToken(ctx, agolaUser02, &gwapitypes.CreateUserTokenRequest{TokenName: "token01"})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		gwUser02Client := gwclient.NewClient(sc.config.Gateway.APIExposedURL, user02Token.Token)
 
 		giteaAPIURL := fmt.Sprintf("http://%s:%s", sc.gitea.HTTPListenAddress, sc.gitea.HTTPPort)
 
 		giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		giteaRepo, project := createProject(ctx, t, giteaClient, gwUser01Client, withVisibility(gwapitypes.VisibilityPrivate))
 
@@ -6854,9 +6335,8 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		})
 
 		runs, _, err := gwUser01Client.GetProjectRuns(ctx, project.ID, nil, nil, 0, 0, false)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(runs) == 0 {
 			t.Fatalf("expected %d run got: %d", 1, len(runs))
 		}
@@ -6887,9 +6367,8 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		})
 
 		runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(runWebhookDeliveries) != 4 {
 			t.Fatalf("expected 4 runWebhookDeliveries got: %d", len(runWebhookDeliveries))
 		}
@@ -6900,9 +6379,8 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		}
 
 		_, err = gwUser01Client.ProjectRunWebhookRedelivery(ctx, project.ID, runWebhookDeliveries[0].ID)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		_ = testutil.Wait(30*time.Second, func() (bool, error) {
 			runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
 			if err != nil {
@@ -6916,9 +6394,8 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 			return true, nil
 		})
 		runWebhookDeliveries, _, err = gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(runWebhookDeliveries) != 5 {
 			t.Fatalf("expected 5 runWebhookDeliveries got: %d", len(runWebhookDeliveries))
 		}
@@ -6951,21 +6428,17 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		gwUserAdminClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, sc.config.Gateway.AdminToken)
 
 		_, _, err := gwUserAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser02})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		user02Token, _, err := gwUserAdminClient.CreateUserToken(ctx, agolaUser02, &gwapitypes.CreateUserTokenRequest{TokenName: "token01"})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		gwUser02Client := gwclient.NewClient(sc.config.Gateway.APIExposedURL, user02Token.Token)
 
 		giteaAPIURL := fmt.Sprintf("http://%s:%s", sc.gitea.HTTPListenAddress, sc.gitea.HTTPPort)
 
 		giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		giteaRepo, project := createProject(ctx, t, giteaClient, gwUser01Client, withVisibility(gwapitypes.VisibilityPrivate))
 
@@ -6988,9 +6461,8 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		})
 
 		runs, _, err := gwUser01Client.GetProjectRuns(ctx, project.ID, nil, nil, 0, 0, false)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(runs) == 0 {
 			t.Fatalf("expected %d run got: %d", 1, len(runs))
 		}
@@ -7021,9 +6493,8 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		})
 
 		runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(runWebhookDeliveries) != 4 {
 			t.Fatalf("expected 4 runWebhookDeliveries got: %d", len(runWebhookDeliveries))
 		}
@@ -7034,14 +6505,11 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		}
 
 		_, err = gwUser01Client.ProjectRunWebhookRedelivery(ctx, project.ID, runWebhookDeliveries[0].ID)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		runWebhookDeliveries, _, err = gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(runWebhookDeliveries) != 5 {
 			t.Fatalf("expected 5 runWebhookDeliveries got: %d", len(runWebhookDeliveries))
 		}
@@ -7093,9 +6561,7 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		giteaAPIURL := fmt.Sprintf("http://%s:%s", sc.gitea.HTTPListenAddress, sc.gitea.HTTPPort)
 
 		giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		_, project := createProject(ctx, t, giteaClient, gwUser01Client, withVisibility(gwapitypes.VisibilityPrivate))
 
@@ -7125,9 +6591,7 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		giteaAPIURL := fmt.Sprintf("http://%s:%s", sc.gitea.HTTPListenAddress, sc.gitea.HTTPPort)
 
 		giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		giteaRepo, project01 := createProject(ctx, t, giteaClient, gwUser01Client, withVisibility(gwapitypes.VisibilityPrivate))
 
@@ -7138,9 +6602,7 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 			RepoPath:         path.Join(giteaUser01, "repo01"),
 			Visibility:       gwapitypes.VisibilityPublic,
 		})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		push(t, config, giteaRepo.CloneURL, giteaToken, "commit", false)
 
@@ -7161,9 +6623,8 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		})
 
 		runs, _, err := gwUser01Client.GetProjectRuns(ctx, project01.ID, nil, nil, 0, 0, false)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(runs) == 0 {
 			t.Fatalf("expected %d run got: %d", 1, len(runs))
 		}
@@ -7194,9 +6655,8 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		})
 
 		runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project01.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(runWebhookDeliveries) != 4 {
 			t.Fatalf("expected 4 runWebhookDeliveries got: %d", len(runWebhookDeliveries))
 		}
@@ -7259,21 +6719,17 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 	gwUserAdminClient := gwclient.NewClient(sc.config.Gateway.APIExposedURL, sc.config.Gateway.AdminToken)
 
 	_, _, err := gwUserAdminClient.CreateUser(ctx, &gwapitypes.CreateUserRequest{UserName: agolaUser02})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	user02Token, _, err := gwUserAdminClient.CreateUserToken(ctx, agolaUser02, &gwapitypes.CreateUserTokenRequest{TokenName: "token01"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	gwUser02Client := gwclient.NewClient(sc.config.Gateway.APIExposedURL, user02Token.Token)
 
 	giteaAPIURL := fmt.Sprintf("http://%s:%s", sc.gitea.HTTPListenAddress, sc.gitea.HTTPPort)
 
 	giteaClient, err := gitea.NewClient(giteaAPIURL, gitea.SetToken(giteaToken))
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	giteaRepo, project := createProject(ctx, t, giteaClient, gwUser01Client, withVisibility(gwapitypes.VisibilityPrivate))
 
@@ -7302,9 +6758,8 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 	})
 
 	runs, _, err := gwUser01Client.GetProjectRuns(ctx, project.ID, nil, nil, 0, 0, true)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
+
 	if len(runs) != runCount {
 		t.Fatalf("expected %d run got: %d", runCount, len(runs))
 	}
@@ -7337,9 +6792,8 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 
 	t.Run("test get project commit status deliveries", func(t *testing.T) {
 		commitStatusDeliveries, resp, err := gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(commitStatusDeliveries) != 2*runCount {
 			t.Fatalf("expected %d commitStatusDeliveries got: %d", 2*runCount, len(commitStatusDeliveries))
 		}
@@ -7355,16 +6809,12 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 
 	t.Run("test get project commit status deliveries with limit less than project commit status deliveries continuation", func(t *testing.T) {
 		commitStatusDeliveries, _, err := gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		respAllCommitStatusDeliveries := []*gwapitypes.CommitStatusDeliveryResponse{}
 
 		respCommitStatusDeliveries, resp, err := gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 1, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
 
 		expectedCommitStatusDeliveries := 1
 		if len(respCommitStatusDeliveries) != expectedCommitStatusDeliveries {
@@ -7379,9 +6829,8 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 		// fetch next results
 		for {
 			respCommitStatusDeliveries, resp, err = gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Cursor: resp.Cursor, Limit: 1})
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			testutil.NilError(t, err)
+
 			if resp.Cursor != "" && len(respCommitStatusDeliveries) != expectedCommitStatusDeliveries {
 				t.Fatalf("expected %d project commit status deliveries, got %d project commit status deliveries", expectedCommitStatusDeliveries, len(respCommitStatusDeliveries))
 			}
@@ -7425,9 +6874,8 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 
 	t.Run("test get project commit status deliveries with deliverystatus = delivered", func(t *testing.T) {
 		commitStatusDeliveries, resp, err := gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, []string{string(nstypes.DeliveryStatusDelivered)}, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(commitStatusDeliveries) != 2*runCount {
 			t.Fatalf("expected %d commitStatusDeliveries got: %d", 2*runCount, len(commitStatusDeliveries))
 		}
@@ -7438,9 +6886,8 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 
 	t.Run("test get project commit status deliveries with deliverystatus = deliveryError", func(t *testing.T) {
 		commitStatusDeliveries, resp, err := gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, []string{string(nstypes.DeliveryStatusDeliveryError)}, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
+		testutil.NilError(t, err)
+
 		if len(commitStatusDeliveries) != 0 {
 			t.Fatalf("expected 0 commitStatusDeliveries got: %d", len(commitStatusDeliveries))
 		}

--- a/tests/webhooksreceiver.go
+++ b/tests/webhooksreceiver.go
@@ -102,16 +102,13 @@ func setupWebhooksReceiver(pctx context.Context, t *testing.T, dir string) *webh
 	}
 
 	port, err := testutil.GetFreePort(dockerBridgeAddress, true, false)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	testutil.NilError(t, err)
 
 	wr.listenAddress = fmt.Sprintf("%s:%s", dockerBridgeAddress, port)
 	wr.exposedURL = fmt.Sprintf("http://%s:%s", dockerBridgeAddress, port)
 
-	if err := wr.start(); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	err = wr.start()
+	testutil.NilError(t, err)
 
 	go func() {
 		<-ctx.Done()


### PR DESCRIPTION
Add a NilError helper based on assert.NilError that will log detailed
test errors when DETAILED_ERRORS env var is true.

Use this function in all tests.