### PR TITLE
notification: rename GetProjectRunWebhookDeliveriesAfterSequence func

### DIFF
--- a/internal/services/notification/db/db.go
+++ b/internal/services/notification/db/db.go
@@ -83,7 +83,7 @@ func mustSingleRow[T any](s []*T) (*T, error) {
 	return s[0], nil
 }
 
-func (d *DB) GetProjectRunWebhookDeliveriesAfterSequence(tx *sql.Tx, afterSequence uint64, limit int) ([]*types.RunWebhookDelivery, error) {
+func (d *DB) GetRunWebhookDeliveriesAfterSequence(tx *sql.Tx, afterSequence uint64, limit int) ([]*types.RunWebhookDelivery, error) {
 	q := runWebhookDeliverySelect().OrderBy("sequence").Asc()
 	q.Where(q.G("sequence", afterSequence))
 	if limit > 0 {

--- a/internal/services/notification/notification_test.go
+++ b/internal/services/notification/notification_test.go
@@ -294,7 +294,7 @@ func getRunWebhookDeliveries(t *testing.T, ctx context.Context, ns *Notification
 
 	err := ns.d.Do(ctx, func(tx *sql.Tx) error {
 		var err error
-		wd, err = ns.d.GetProjectRunWebhookDeliveriesAfterSequence(tx, 0, 0)
+		wd, err = ns.d.GetRunWebhookDeliveriesAfterSequence(tx, 0, 0)
 		if err != nil {
 			return errors.WithStack(err)
 		}


### PR DESCRIPTION
Rename function GetProjectRunWebhookDeliveriesAfterSequence to GetRunWebhookDeliveriesAfterSequence since it doesn't filter by project.