### PR TITLE
notification: fix db func GetProjectRunWebhookDeliveriesAfterSequenceByProjectID

### DIFF
--- a/internal/services/notification/db/db.go
+++ b/internal/services/notification/db/db.go
@@ -111,11 +111,13 @@ func (d *DB) GetProjectRunWebhookDeliveriesAfterSequenceByProjectID(tx *sql.Tx, 
 	case types.SortDirectionDesc:
 		q.Desc()
 	}
-	switch sortDirection {
-	case types.SortDirectionAsc:
-		q.Where(q.G("sequence", afterSequence))
-	case types.SortDirectionDesc:
-		q.Where(q.L("sequence", afterSequence))
+	if afterSequence > 0 {
+		switch sortDirection {
+		case types.SortDirectionAsc:
+			q.Where(q.G("sequence", afterSequence))
+		case types.SortDirectionDesc:
+			q.Where(q.L("sequence", afterSequence))
+		}
 	}
 
 	if limit > 0 {


### PR DESCRIPTION
fix db func GetProjectRunWebhookDeliveriesAfterSequenceByProjectID since startSequence is not provided when the client ask by the first run webhook delivery.