### PR TITLE
*: actions: ensure a default sort direction

### DIFF
--- a/internal/services/configstore/action/org.go
+++ b/internal/services/configstore/action/org.go
@@ -57,6 +57,9 @@ func (h *ActionHandler) GetOrgMembers(ctx context.Context, req *GetOrgMembersReq
 	if limit > 0 {
 		limit += 1
 	}
+	if req.SortDirection == "" {
+		req.SortDirection = types.SortDirectionAsc
+	}
 
 	var dbOrgMembers []*db.OrgUser
 	err := h.d.Do(ctx, func(tx *sql.Tx) error {
@@ -113,6 +116,9 @@ func (h *ActionHandler) GetOrgs(ctx context.Context, req *GetOrgsRequest) (*GetO
 	limit := req.Limit
 	if limit > 0 {
 		limit += 1
+	}
+	if req.SortDirection == "" {
+		req.SortDirection = types.SortDirectionAsc
 	}
 
 	visibilities := req.Visibilities

--- a/internal/services/configstore/action/remotesource.go
+++ b/internal/services/configstore/action/remotesource.go
@@ -42,6 +42,9 @@ func (h *ActionHandler) GetRemoteSources(ctx context.Context, req *GetRemoteSour
 	if limit > 0 {
 		limit += 1
 	}
+	if req.SortDirection == "" {
+		req.SortDirection = types.SortDirectionAsc
+	}
 
 	var remoteSources []*types.RemoteSource
 	err := h.d.Do(ctx, func(tx *sql.Tx) error {

--- a/internal/services/configstore/action/user.go
+++ b/internal/services/configstore/action/user.go
@@ -45,6 +45,9 @@ func (h *ActionHandler) GetUsers(ctx context.Context, req *GetUsersRequest) (*Ge
 	if limit > 0 {
 		limit += 1
 	}
+	if req.SortDirection == "" {
+		req.SortDirection = types.SortDirectionAsc
+	}
 
 	var users []*types.User
 	err := h.d.Do(ctx, func(tx *sql.Tx) error {
@@ -640,6 +643,9 @@ func (h *ActionHandler) GetUserOrgs(ctx context.Context, req *GetUserOrgsRequest
 	limit := req.Limit
 	if limit > 0 {
 		limit += 1
+	}
+	if req.SortDirection == "" {
+		req.SortDirection = types.SortDirectionAsc
 	}
 
 	var dbUserOrgs []*db.UserOrg

--- a/internal/services/configstore/configstore_test.go
+++ b/internal/services/configstore/configstore_test.go
@@ -905,6 +905,10 @@ func TestGetRemoteSources(t *testing.T) {
 		expectedCallsNumber int
 	}{
 		{
+			name:                "test get remote sources with limit = 0 and no sortdirection",
+			expectedCallsNumber: 1,
+		},
+		{
 			name:                "test get remote sources with limit = 0",
 			sortDirection:       types.SortDirectionAsc,
 			expectedCallsNumber: 1,
@@ -944,6 +948,8 @@ func TestGetRemoteSources(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			expectedRemoteSources := append([]*types.RemoteSource{}, remoteSources...)
+			// default sortdirection is asc
+
 			// reverse if sortDirection is desc
 			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == types.SortDirectionDesc {
@@ -1005,6 +1011,10 @@ func TestGetUsers(t *testing.T) {
 		expectedCallsNumber int
 	}{
 		{
+			name:                "test get users with limit = 0 and no sortdirection",
+			expectedCallsNumber: 1,
+		},
+		{
 			name:                "test get users with limit = 0",
 			sortDirection:       types.SortDirectionAsc,
 			expectedCallsNumber: 1,
@@ -1044,6 +1054,8 @@ func TestGetUsers(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			expectedUsers := append([]*types.User{}, users...)
+			// default sortdirection is asc
+
 			// reverse if sortDirection is desc
 			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == types.SortDirectionDesc {
@@ -1114,6 +1126,11 @@ func TestGetOrgs(t *testing.T) {
 		sortDirection       types.SortDirection
 		expectedCallsNumber int
 	}{
+		{
+			name:                "test get public orgs with limit = 0 and no sortdirection",
+			getPublicOrgsOnly:   true,
+			expectedCallsNumber: 1,
+		},
 		{
 			name:                "test get public orgs with limit = 0",
 			getPublicOrgsOnly:   true,
@@ -1208,6 +1225,7 @@ func TestGetOrgs(t *testing.T) {
 				expectedOrgs = append(expectedOrgs, allOrgs...)
 				visibilities = append(visibilities, types.VisibilityPrivate)
 			}
+			// default sortdirection is asc
 
 			// reverse if sortDirection is desc
 			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
@@ -1278,6 +1296,10 @@ func TestGetOrgMembers(t *testing.T) {
 		expectedCallsNumber int
 	}{
 		{
+			name:                "test get org members with limit = 0 and no sortdirection",
+			expectedCallsNumber: 1,
+		},
+		{
 			name:                "test get org members with limit = 0",
 			sortDirection:       types.SortDirectionAsc,
 			expectedCallsNumber: 1,
@@ -1317,6 +1339,8 @@ func TestGetOrgMembers(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			expectedUsers := append([]*types.User{}, users...)
+			// default sortdirection is asc
+
 			// reverse if sortDirection is desc
 			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == types.SortDirectionDesc {
@@ -1391,6 +1415,10 @@ func TestGetUserOrgs(t *testing.T) {
 		expectedCallsNumber int
 	}{
 		{
+			name:                "test get user orgs with limit = 0 and no sortdirection",
+			expectedCallsNumber: 1,
+		},
+		{
 			name:                "test get user orgs with limit = 0",
 			sortDirection:       types.SortDirectionAsc,
 			expectedCallsNumber: 1,
@@ -1430,6 +1458,8 @@ func TestGetUserOrgs(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			expectedOrgs := append([]*types.Organization{}, orgs...)
+			// default sortdirection is asc
+
 			// reverse if sortDirection is desc
 			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == types.SortDirectionDesc {

--- a/internal/services/gateway/action/commitstatusdelivery.go
+++ b/internal/services/gateway/action/commitstatusdelivery.go
@@ -62,6 +62,9 @@ func (h *ActionHandler) GetProjectCommitStatusDeliveries(ctx context.Context, re
 		sortDirection = inCursor.SortDirection
 		deliveryStatusFilter = inCursor.DeliveryStatusFilter
 	}
+	if sortDirection == "" {
+		sortDirection = SortDirectionAsc
+	}
 
 	commitStatusDeliveries, resp, err := h.notificationClient.GetProjectCommitStatusDeliveries(ctx, project.ID, &client.GetProjectCommitStatusDeliveriesOptions{ListOptions: &client.ListOptions{Limit: req.Limit, SortDirection: nstypes.SortDirection(sortDirection)}, StartSequence: inCursor.StartSequence, DeliveryStatusFilter: deliveryStatusFilter})
 	if err != nil {

--- a/internal/services/gateway/action/org.go
+++ b/internal/services/gateway/action/org.go
@@ -71,6 +71,9 @@ func (h *ActionHandler) GetOrgs(ctx context.Context, req *GetOrgsRequest) (*GetO
 		}
 		sortDirection = inCursor.SortDirection
 	}
+	if sortDirection == "" {
+		sortDirection = SortDirectionAsc
+	}
 
 	isAdmin := common.IsUserAdmin(ctx)
 
@@ -134,6 +137,9 @@ func (h *ActionHandler) GetOrgMembers(ctx context.Context, req *GetOrgMembersReq
 			return nil, errors.WithStack(err)
 		}
 		sortDirection = inCursor.SortDirection
+	}
+	if sortDirection == "" {
+		sortDirection = SortDirectionAsc
 	}
 
 	org, _, err := h.configstoreClient.GetOrg(ctx, req.OrgRef)

--- a/internal/services/gateway/action/remotesource.go
+++ b/internal/services/gateway/action/remotesource.go
@@ -55,6 +55,9 @@ func (h *ActionHandler) GetRemoteSources(ctx context.Context, req *GetRemoteSour
 		}
 		sortDirection = inCursor.SortDirection
 	}
+	if sortDirection == "" {
+		sortDirection = SortDirectionAsc
+	}
 
 	remoteSources, resp, err := h.configstoreClient.GetRemoteSources(ctx, &client.GetRemoteSourcesOptions{ListOptions: &client.ListOptions{Limit: req.Limit, SortDirection: cstypes.SortDirection(sortDirection)}, StartRemoteSourceName: inCursor.Start})
 	if err != nil {

--- a/internal/services/gateway/action/runwebhookdelivery.go
+++ b/internal/services/gateway/action/runwebhookdelivery.go
@@ -62,6 +62,9 @@ func (h *ActionHandler) GetProjectRunWebhookDeliveries(ctx context.Context, req 
 		sortDirection = inCursor.SortDirection
 		deliveryStatusFilter = inCursor.DeliveryStatusFilter
 	}
+	if sortDirection == "" {
+		sortDirection = SortDirectionAsc
+	}
 
 	runWebhookDeliveries, resp, err := h.notificationClient.GetProjectRunWebhookDeliveries(ctx, project.ID, &client.GetProjectRunWebhookDeliveriesOptions{ListOptions: &client.ListOptions{Limit: req.Limit, SortDirection: nstypes.SortDirection(sortDirection)}, StartSequence: inCursor.StartSequence, DeliveryStatusFilter: deliveryStatusFilter})
 	if err != nil {

--- a/internal/services/gateway/action/user.go
+++ b/internal/services/gateway/action/user.go
@@ -116,6 +116,9 @@ func (h *ActionHandler) GetUserOrgs(ctx context.Context, req *GetUserOrgsRequest
 		}
 		sortDirection = inCursor.SortDirection
 	}
+	if sortDirection == "" {
+		sortDirection = SortDirectionAsc
+	}
 
 	orgs, resp, err := h.configstoreClient.GetUserOrgs(ctx, req.UserRef, &client.GetUserOrgsOptions{ListOptions: &client.ListOptions{Limit: req.Limit, SortDirection: cstypes.SortDirection(sortDirection)}, StartOrgName: inCursor.Start})
 	if err != nil {
@@ -167,6 +170,9 @@ func (h *ActionHandler) GetUsers(ctx context.Context, req *GetUsersRequest) (*Ge
 			return nil, errors.WithStack(err)
 		}
 		sortDirection = inCursor.SortDirection
+	}
+	if sortDirection == "" {
+		sortDirection = SortDirectionAsc
 	}
 
 	csusers, resp, err := h.configstoreClient.GetUsers(ctx, &client.GetUsersOptions{ListOptions: &client.ListOptions{Limit: req.Limit, SortDirection: cstypes.SortDirection(sortDirection)}, StartUserName: inCursor.Start})

--- a/internal/services/notification/action/commitstatusdelivery.go
+++ b/internal/services/notification/action/commitstatusdelivery.go
@@ -45,6 +45,9 @@ func (h *ActionHandler) GetProjectCommitStatusDeliveries(ctx context.Context, re
 	if limit > 0 {
 		limit += 1
 	}
+	if req.SortDirection == "" {
+		req.SortDirection = types.SortDirectionAsc
+	}
 
 	var commitStatusDeliveries []*types.CommitStatusDelivery
 	err := h.d.Do(ctx, func(tx *sql.Tx) error {

--- a/internal/services/notification/action/runwebhookdelivery.go
+++ b/internal/services/notification/action/runwebhookdelivery.go
@@ -45,6 +45,9 @@ func (h *ActionHandler) GetProjectRunWebhookDeliveries(ctx context.Context, req 
 	if limit > 0 {
 		limit += 1
 	}
+	if req.SortDirection == "" {
+		req.SortDirection = types.SortDirectionAsc
+	}
 
 	var runWebookDeliveries []*types.RunWebhookDelivery
 	err := h.d.Do(ctx, func(tx *sql.Tx) error {

--- a/internal/services/notification/notification_test.go
+++ b/internal/services/notification/notification_test.go
@@ -541,6 +541,11 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 		expectedCallsNumber                int
 	}{
 		{
+			name:                               "test get run webhook deliveries with limit = 0 and no sortdirection",
+			expectedRunWebhookDeliveriesNumber: 20,
+			expectedCallsNumber:                1,
+		},
+		{
 			name:                               "test get run webhook deliveries with limit = 0",
 			sortDirection:                      types.SortDirectionAsc,
 			expectedRunWebhookDeliveriesNumber: 20,
@@ -614,6 +619,7 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 				}
 				expectedProject01RunWebhookDeliveries = append(expectedProject01RunWebhookDeliveries, c)
 			}
+			// default sortdirection is asc
 
 			// reverse if sortDirection is desc
 			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
@@ -959,6 +965,11 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 		expectedCallsNumber                  int
 	}{
 		{
+			name:                                 "test get commit status deliveries with limit = 0 and no sortdirection",
+			expectedCommitStatusDeliveriesNumber: 20,
+			expectedCallsNumber:                  1,
+		},
+		{
 			name:                                 "test get commit status deliveries with limit = 0",
 			sortDirection:                        types.SortDirectionAsc,
 			expectedCommitStatusDeliveriesNumber: 20,
@@ -1032,6 +1043,7 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 				}
 				expectedProject01CommitStatusDeliveries = append(expectedProject01CommitStatusDeliveries, c)
 			}
+			// default sortdirection is asc
 
 			// reverse if sortDirection is desc
 			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21

--- a/services/configstore/client/client.go
+++ b/services/configstore/client/client.go
@@ -54,8 +54,6 @@ func (o *ListOptions) Add(q url.Values) {
 	case cstypes.SortDirectionDesc:
 		q.Add("sortdirection", "desc")
 	case cstypes.SortDirectionAsc:
-		fallthrough
-	default:
 		q.Add("sortdirection", "asc")
 	}
 }

--- a/services/notification/client/client.go
+++ b/services/notification/client/client.go
@@ -52,8 +52,6 @@ func (o *ListOptions) Add(q url.Values) {
 	case types.SortDirectionDesc:
 		q.Add("sortdirection", "desc")
 	case types.SortDirectionAsc:
-		fallthrough
-	default:
 		q.Add("sortdirection", "asc")
 	}
 }

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -3907,6 +3907,10 @@ func TestGetRemoteSources(t *testing.T) {
 		expectedCallsNumber int
 	}{
 		{
+			name:                "test get remote sources with limit = 0 and no sortdirection",
+			expectedCallsNumber: 1,
+		},
+		{
 			name:                "test get remote sources with limit = 0",
 			sortDirection:       gwapitypes.SortDirectionAsc,
 			expectedCallsNumber: 1,
@@ -3946,6 +3950,8 @@ func TestGetRemoteSources(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			expectedRemoteSources := append([]*gwapitypes.RemoteSourceResponse{}, remoteSources...)
+			// default sortdirection is asc
+
 			// reverse if sortDirection is desc
 			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == gwapitypes.SortDirectionDesc {
@@ -4008,6 +4014,10 @@ func TestGetUsers(t *testing.T) {
 		expectedCallsNumber int
 	}{
 		{
+			name:                "test get users with limit = 0 and no sortdirection",
+			expectedCallsNumber: 1,
+		},
+		{
 			name:                "test get users with limit = 0",
 			sortDirection:       gwapitypes.SortDirectionAsc,
 			expectedCallsNumber: 1,
@@ -4047,6 +4057,8 @@ func TestGetUsers(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			expectedUsers := append([]*gwapitypes.UserResponse{}, users...)
+			// default sortdirection is asc
+
 			// reverse if sortDirection is desc
 			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == gwapitypes.SortDirectionDesc {
@@ -4128,6 +4140,11 @@ func TestGetOrgs(t *testing.T) {
 		sortDirection       gwapitypes.SortDirection
 		expectedCallsNumber int
 	}{
+		{
+			name:                "test get public orgs with limit = 0 and no sortdirection",
+			getPublicOrgsOnly:   true,
+			expectedCallsNumber: 1,
+		},
 		{
 			name:                "test get public orgs with limit = 0",
 			getPublicOrgsOnly:   true,
@@ -4223,6 +4240,7 @@ func TestGetOrgs(t *testing.T) {
 				expectedOrgs = append(expectedOrgs, allOrgs...)
 				client = gwAdminClient
 			}
+			// default sortdirection is asc
 
 			// reverse if sortDirection is desc
 			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
@@ -4295,6 +4313,10 @@ func TestGetOrgMembers(t *testing.T) {
 		expectedCallsNumber int
 	}{
 		{
+			name:                "test get org members with limit = 0 and no sortdirection",
+			expectedCallsNumber: 1,
+		},
+		{
 			name:                "test get org members with limit = 0",
 			sortDirection:       gwapitypes.SortDirectionAsc,
 			expectedCallsNumber: 1,
@@ -4334,6 +4356,8 @@ func TestGetOrgMembers(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			expectedOrgMembers := append([]*gwapitypes.OrgMemberResponse{}, allOrgMembers...)
+			// default sortdirection is asc
+
 			// reverse if sortDirection is desc
 			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == gwapitypes.SortDirectionDesc {
@@ -4410,6 +4434,10 @@ func TestGetUserOrgs(t *testing.T) {
 		expectedCallsNumber int
 	}{
 		{
+			name:                "test get user orgs with limit = 0 and no sortdirection",
+			expectedCallsNumber: 1,
+		},
+		{
 			name:                "test get user orgs with limit = 0",
 			sortDirection:       gwapitypes.SortDirectionAsc,
 			expectedCallsNumber: 1,
@@ -4449,6 +4477,8 @@ func TestGetUserOrgs(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			expectedUserOrgs := append([]*gwapitypes.OrgResponse{}, orgs...)
+			// default sortdirection is asc
+
 			// reverse if sortDirection is desc
 			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == gwapitypes.SortDirectionDesc {
@@ -5736,6 +5766,12 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 		expectedErr          string
 	}{
 		{
+			name:                "test get project run webhook deliveries with limit = 0 and no sortdirection",
+			client:              gwUser01Client,
+			projectRef:          project.ID,
+			expectedCallsNumber: 1,
+		},
+		{
 			name:                "test get project run webhook deliveries with limit = 0",
 			client:              gwUser01Client,
 			projectRef:          project.ID,
@@ -5822,6 +5858,7 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 				}
 				expectedProject01RunWebhookDeliveries = append(expectedProject01RunWebhookDeliveries, r)
 			}
+			// default sortdirection is asc
 
 			// reverse if sortDirection is desc
 			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
@@ -6348,6 +6385,12 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 		expectedErr          string
 	}{
 		{
+			name:                "test get project commit status deliveries with limit = 0 and no sortdirection",
+			client:              gwUser01Client,
+			projectRef:          project.ID,
+			expectedCallsNumber: 1,
+		},
+		{
 			name:                "test get project commit status deliveries with limit = 0",
 			client:              gwUser01Client,
 			projectRef:          project.ID,
@@ -6434,6 +6477,7 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 				}
 				expectedProject01CommitStatusDeliveries = append(expectedProject01CommitStatusDeliveries, c)
 			}
+			// default sortdirection is asc
 
 			// reverse if sortDirection is desc
 			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21


### PR DESCRIPTION
For all the services, both underlying services and the gateway, ensure a default sort direction is provided and so also used in the returned cursor.
Not having a default sort direction could lead to unpredictable results between calls depending on the underlying database.