### PR TITLE
*: commitstatus/runwebook delivery save filter inside cursor

### DIFF
--- a/internal/services/gateway/action/cursor.go
+++ b/internal/services/gateway/action/cursor.go
@@ -37,8 +37,10 @@ type StartCursor struct {
 	SortDirection SortDirection
 }
 
-type StartSequenceCursor struct {
+type DeliveryCursor struct {
 	StartSequence uint64
 
 	SortDirection SortDirection
+
+	DeliveryStatusFilter []string
 }

--- a/internal/services/gateway/api/commitstatusdelivery.go
+++ b/internal/services/gateway/api/commitstatusdelivery.go
@@ -65,11 +65,15 @@ func (h *ProjectCommitStatusDeliveries) do(w http.ResponseWriter, r *http.Reques
 	vars := mux.Vars(r)
 	projectRef := vars["projectref"]
 
-	deliveryStatusFilter := query["deliverystatus"]
-
 	ropts, err := parseRequestOptions(r)
 	if err != nil {
 		return nil, errors.WithStack(err)
+	}
+
+	deliveryStatusFilter := query["deliverystatus"]
+
+	if ropts.Cursor != "" && len(deliveryStatusFilter) > 0 {
+		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("only one of cursor or deliverystatus should be provided"))
 	}
 
 	areq := &action.GetProjectCommitStatusDeliveriesRequest{

--- a/internal/services/gateway/api/runwebhookdelivery.go
+++ b/internal/services/gateway/api/runwebhookdelivery.go
@@ -66,11 +66,15 @@ func (h *ProjectRunWebhookDeliveries) do(w http.ResponseWriter, r *http.Request)
 	vars := mux.Vars(r)
 	projectRef := vars["projectref"]
 
-	deliveryStatusFilter := query["deliverystatus"]
-
 	ropts, err := parseRequestOptions(r)
 	if err != nil {
 		return nil, errors.WithStack(err)
+	}
+
+	deliveryStatusFilter := query["deliverystatus"]
+
+	if ropts.Cursor != "" && len(deliveryStatusFilter) > 0 {
+		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("only one of cursor or deliverystatus should be provided"))
 	}
 
 	areq := &action.GetProjectRunWebhookDeliveriesRequest{

--- a/services/gateway/client/client.go
+++ b/services/gateway/client/client.go
@@ -812,13 +812,27 @@ func (c *Client) Import(ctx context.Context, serviceName string, r io.Reader) (*
 	return c.getResponse(ctx, "POST", fmt.Sprintf("/import/%s", serviceName), nil, jsonContent, r)
 }
 
-func (c *Client) GetProjectRunWebhookDeliveries(ctx context.Context, projectRef string, deliveryStatusFilter []string, opts *ListOptions) ([]*gwapitypes.RunWebhookDeliveryResponse, *Response, error) {
-	q := url.Values{}
-	opts.Add(q)
+type DeliveriesOptions struct {
+	*ListOptions
 
-	for _, deliveryStatus := range deliveryStatusFilter {
+	DeliveryStatusFilter []string
+}
+
+func (o *DeliveriesOptions) Add(q url.Values) {
+	if o == nil {
+		return
+	}
+
+	o.ListOptions.Add(q)
+
+	for _, deliveryStatus := range o.DeliveryStatusFilter {
 		q.Add("deliverystatus", deliveryStatus)
 	}
+}
+
+func (c *Client) GetProjectRunWebhookDeliveries(ctx context.Context, projectRef string, opts *DeliveriesOptions) ([]*gwapitypes.RunWebhookDeliveryResponse, *Response, error) {
+	q := url.Values{}
+	opts.Add(q)
 
 	runWebhookDeliveries := []*gwapitypes.RunWebhookDeliveryResponse{}
 	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/projects/%s/runwebhookdeliveries", url.PathEscape(projectRef)), q, common.JSONContent, nil, &runWebhookDeliveries)
@@ -829,13 +843,9 @@ func (c *Client) ProjectRunWebhookRedelivery(ctx context.Context, projectRef str
 	return c.getResponse(ctx, "PUT", fmt.Sprintf("/projects/%s/runwebhookdeliveries/%s/redelivery", projectRef, runWebhookDeliveryID), nil, jsonContent, nil)
 }
 
-func (c *Client) GetProjectCommitStatusDeliveries(ctx context.Context, projectRef string, deliveryStatusFilter []string, opts *ListOptions) ([]*gwapitypes.CommitStatusDeliveryResponse, *Response, error) {
+func (c *Client) GetProjectCommitStatusDeliveries(ctx context.Context, projectRef string, opts *DeliveriesOptions) ([]*gwapitypes.CommitStatusDeliveryResponse, *Response, error) {
 	q := url.Values{}
 	opts.Add(q)
-
-	for _, deliveryStatus := range deliveryStatusFilter {
-		q.Add("deliverystatus", deliveryStatus)
-	}
 
 	commitStatusDeliveries := []*gwapitypes.CommitStatusDeliveryResponse{}
 	resp, err := c.getParsedResponse(ctx, "GET", fmt.Sprintf("/projects/%s/commitstatusdeliveries", url.PathEscape(projectRef)), q, common.JSONContent, nil, &commitStatusDeliveries)

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -5705,7 +5705,7 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 	assert.Equal(t, runs[0].Result, rstypes.RunResultSuccess)
 
 	_ = testutil.Wait(30*time.Second, func() (bool, error) {
-		runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+		runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 		if err != nil {
 			return false, nil
 		}
@@ -5722,7 +5722,7 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 		return true, nil
 	})
 
-	runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+	runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 	testutil.NilError(t, err)
 
 	tests := []struct {
@@ -5837,7 +5837,7 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 			var cursor string
 
 			for {
-				respRunWebhookDeliveries, res, err := tt.client.GetProjectRunWebhookDeliveries(ctx, tt.projectRef, tt.deliveryStatusFilter, &gwclient.ListOptions{Cursor: cursor, Limit: tt.limit, SortDirection: sortDirection})
+				respRunWebhookDeliveries, res, err := tt.client.GetProjectRunWebhookDeliveries(ctx, tt.projectRef, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Cursor: cursor, Limit: tt.limit, SortDirection: sortDirection}, DeliveryStatusFilter: tt.deliveryStatusFilter})
 				if tt.expectedErr == "" {
 					testutil.NilError(t, err)
 				} else {
@@ -5946,7 +5946,7 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		assert.Equal(t, runs[0].Result, rstypes.RunResultSuccess)
 
 		_ = testutil.Wait(30*time.Second, func() (bool, error) {
-			runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+			runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 			if err != nil {
 				return false, nil
 			}
@@ -5963,7 +5963,7 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 			return true, nil
 		})
 
-		runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+		runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 		testutil.NilError(t, err)
 
 		assert.Assert(t, cmp.Len(runWebhookDeliveries, 4))
@@ -5975,7 +5975,7 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		testutil.NilError(t, err)
 
 		_ = testutil.Wait(30*time.Second, func() (bool, error) {
-			runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+			runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 			if err != nil {
 				return false, nil
 			}
@@ -5986,7 +5986,7 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 
 			return true, nil
 		})
-		runWebhookDeliveries, _, err = gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+		runWebhookDeliveries, _, err = gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 		testutil.NilError(t, err)
 
 		assert.Assert(t, cmp.Len(runWebhookDeliveries, 5))
@@ -6055,7 +6055,7 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		assert.Equal(t, runs[0].Result, rstypes.RunResultSuccess)
 
 		_ = testutil.Wait(30*time.Second, func() (bool, error) {
-			runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+			runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 			if err != nil {
 				return false, nil
 			}
@@ -6072,7 +6072,7 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 			return true, nil
 		})
 
-		runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+		runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 		testutil.NilError(t, err)
 
 		assert.Assert(t, cmp.Len(runWebhookDeliveries, 4))
@@ -6083,7 +6083,7 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		_, err = gwUser01Client.ProjectRunWebhookRedelivery(ctx, project.ID, runWebhookDeliveries[0].ID)
 		testutil.NilError(t, err)
 
-		runWebhookDeliveries, _, err = gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+		runWebhookDeliveries, _, err = gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 		testutil.NilError(t, err)
 
 		assert.Assert(t, cmp.Len(runWebhookDeliveries, 5))
@@ -6190,7 +6190,7 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		assert.Equal(t, runs[0].Result, rstypes.RunResultSuccess)
 
 		_ = testutil.Wait(30*time.Second, func() (bool, error) {
-			runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project01.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+			runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project01.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 			if err != nil {
 				return false, nil
 			}
@@ -6207,7 +6207,7 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 			return true, nil
 		})
 
-		runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project01.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+		runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project01.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 		testutil.NilError(t, err)
 
 		assert.Assert(t, cmp.Len(runWebhookDeliveries, 4))
@@ -6311,7 +6311,7 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 	}
 
 	_ = testutil.Wait(30*time.Second, func() (bool, error) {
-		commitStatusDeliveries, _, err := gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+		commitStatusDeliveries, _, err := gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 		if err != nil {
 			return false, nil
 		}
@@ -6328,7 +6328,7 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 		return true, nil
 	})
 
-	commitStatusDeliveries, resp, err := gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{SortDirection: gwapitypes.SortDirectionAsc})
+	commitStatusDeliveries, resp, err := gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{SortDirection: gwapitypes.SortDirectionAsc}})
 	testutil.NilError(t, err)
 
 	assert.Assert(t, cmp.Len(commitStatusDeliveries, 2*runCount))
@@ -6449,13 +6449,15 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 			var cursor string
 
 			for {
-				respCommitStatusDeliveries, res, err := tt.client.GetProjectCommitStatusDeliveries(ctx, tt.projectRef, tt.deliveryStatusFilter, &gwclient.ListOptions{Cursor: cursor, Limit: tt.limit, SortDirection: sortDirection})
+				respCommitStatusDeliveries, res, err := tt.client.GetProjectCommitStatusDeliveries(ctx, tt.projectRef, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Cursor: cursor, Limit: tt.limit, SortDirection: sortDirection}, DeliveryStatusFilter: tt.deliveryStatusFilter})
 				if tt.expectedErr == "" {
 					testutil.NilError(t, err)
 				} else {
 					assert.Error(t, err, tt.expectedErr)
 					return
 				}
+
+				testutil.NilError(t, err)
 
 				callsNumber++
 
@@ -6568,7 +6570,7 @@ func TestProjectCommitStatusRedelivery(t *testing.T) {
 		}
 
 		_ = testutil.Wait(30*time.Second, func() (bool, error) {
-			commitStatusDeliveries, _, err := gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+			commitStatusDeliveries, _, err := gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 			if err != nil {
 				return false, nil
 			}
@@ -6593,7 +6595,7 @@ func TestProjectCommitStatusRedelivery(t *testing.T) {
 			t.Fatalf("unexpected err: %v", err)
 		}
 
-		commitStatusDeliveries, _, err := gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+		commitStatusDeliveries, _, err := gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
@@ -6611,7 +6613,7 @@ func TestProjectCommitStatusRedelivery(t *testing.T) {
 			t.Fatalf("unexpected err: %v", err)
 		}
 		_ = testutil.Wait(30*time.Second, func() (bool, error) {
-			commitStatusDeliveries, _, err := gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionDesc})
+			commitStatusDeliveries, _, err := gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionDesc}})
 			if err != nil {
 				return false, nil
 			}
@@ -6626,7 +6628,7 @@ func TestProjectCommitStatusRedelivery(t *testing.T) {
 			return true, nil
 		})
 
-		commitStatusDeliveries, _, err = gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 1, SortDirection: gwapitypes.SortDirectionDesc})
+		commitStatusDeliveries, _, err = gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 1, SortDirection: gwapitypes.SortDirectionDesc}})
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
@@ -6642,7 +6644,7 @@ func TestProjectCommitStatusRedelivery(t *testing.T) {
 			t.Fatalf("unexpected err: %v", err)
 		}
 		_ = testutil.Wait(30*time.Second, func() (bool, error) {
-			commitStatusDeliveries, _, err := gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+			commitStatusDeliveries, _, err := gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 			if err != nil {
 				return false, nil
 			}
@@ -6654,7 +6656,7 @@ func TestProjectCommitStatusRedelivery(t *testing.T) {
 			return true, nil
 		})
 
-		commitStatusDeliveries, _, err = gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+		commitStatusDeliveries, _, err = gwUser01Client.GetProjectCommitStatusDeliveries(ctx, project.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
@@ -6742,7 +6744,7 @@ func TestProjectCommitStatusRedelivery(t *testing.T) {
 		}
 
 		_ = testutil.Wait(30*time.Second, func() (bool, error) {
-			runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+			runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 			if err != nil {
 				return false, nil
 			}
@@ -6759,7 +6761,7 @@ func TestProjectCommitStatusRedelivery(t *testing.T) {
 			return true, nil
 		})
 
-		runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+		runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
@@ -6777,7 +6779,7 @@ func TestProjectCommitStatusRedelivery(t *testing.T) {
 			t.Fatalf("unexpected err: %v", err)
 		}
 
-		runWebhookDeliveries, _, err = gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+		runWebhookDeliveries, _, err = gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
@@ -6915,7 +6917,7 @@ func TestProjectCommitStatusRedelivery(t *testing.T) {
 		}
 
 		_ = testutil.Wait(30*time.Second, func() (bool, error) {
-			runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project01.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+			runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project01.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 			if err != nil {
 				return false, nil
 			}
@@ -6932,7 +6934,7 @@ func TestProjectCommitStatusRedelivery(t *testing.T) {
 			return true, nil
 		})
 
-		runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project01.ID, nil, &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc})
+		runWebhookDeliveries, _, err := gwUser01Client.GetProjectRunWebhookDeliveries(ctx, project01.ID, &gwclient.DeliveriesOptions{ListOptions: &gwclient.ListOptions{Limit: 0, SortDirection: gwapitypes.SortDirectionAsc}})
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}


### PR DESCRIPTION
The api filter options should be saved inside the cursor.

Also check that not both cursor and filter query parameter are provided.