### PR TITLE
notification: fix cleaners infinite loop.

### DIFF
--- a/internal/services/notification/commitstatus.go
+++ b/internal/services/notification/commitstatus.go
@@ -161,9 +161,10 @@ func (n *NotificationService) commitStatusesCleaner(ctx context.Context, commitS
 	}
 	defer func() { _ = l.Unlock() }()
 
+	var afterCommitStatusID string
+
 	for {
 		var commitStatuses []*types.CommitStatus
-		var afterCommitStatusID string
 
 		err := n.d.Do(ctx, func(tx *sql.Tx) error {
 			var err error

--- a/internal/services/notification/commitstatusdelivery.go
+++ b/internal/services/notification/commitstatusdelivery.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	MaxCommitStatusDeliveriesQueryLimit = 40
+	maxCommitStatusDeliveriesQueryLimit = 40
 	CommitStatusDeliveriesLockKey       = "commitstatusdeliveryevents"
 
 	// commitstatusDeliveriesInterval is the time to wait between every commitStatusDeliveriesHandler call.
@@ -71,7 +71,7 @@ func (n *NotificationService) commitStatusDeliveriesHandler(ctx context.Context)
 
 		err := n.d.Do(ctx, func(tx *sql.Tx) error {
 			var err error
-			commitStatusDeliveries, err = n.d.GetProjectCommitStatusDeliveriesAfterSequenceByProjectID(tx, curCommitStatusDeliverySequence, "", []types.DeliveryStatus{types.DeliveryStatusNotDelivered}, MaxCommitStatusDeliveriesQueryLimit, types.SortDirectionAsc)
+			commitStatusDeliveries, err = n.d.GetProjectCommitStatusDeliveriesAfterSequenceByProjectID(tx, curCommitStatusDeliverySequence, "", []types.DeliveryStatus{types.DeliveryStatusNotDelivered}, maxCommitStatusDeliveriesQueryLimit, types.SortDirectionAsc)
 			if err != nil {
 				return errors.WithStack(err)
 			}
@@ -90,7 +90,7 @@ func (n *NotificationService) commitStatusDeliveriesHandler(ctx context.Context)
 			curCommitStatusDeliverySequence = c.Sequence
 		}
 
-		if len(commitStatusDeliveries) < MaxCommitStatusDeliveriesQueryLimit {
+		if len(commitStatusDeliveries) < maxCommitStatusDeliveriesQueryLimit {
 			return nil
 		}
 	}

--- a/internal/services/notification/notification_test.go
+++ b/internal/services/notification/notification_test.go
@@ -92,7 +92,7 @@ func TestRunWebhookDelivery(t *testing.T) {
 		ns.c.WebhookURL = fmt.Sprintf("%s/%s", wr.exposedURL, "webhooks")
 		ns.c.WebhookSecret = webhookSecret
 
-		runWebhooks := make([]*types.RunWebhook, MaxRunWebhookDeliveriesQueryLimit+10)
+		runWebhooks := make([]*types.RunWebhook, maxRunWebhookDeliveriesQueryLimit+10)
 		for i := 0; i < len(runWebhooks); i++ {
 			runWebhooks[i] = createRunWebhook(t, ctx, ns, project01)
 			createRunWebhookDelivery(t, ctx, ns, runWebhooks[i].ID, types.DeliveryStatusNotDelivered)
@@ -351,7 +351,7 @@ func TestCommitStatusDelivery(t *testing.T) {
 		cs := setupStubCommitStatusUpdater()
 		ns.u = cs
 
-		commitStatuses := make([]*types.CommitStatus, MaxCommitStatusDeliveriesQueryLimit+10)
+		commitStatuses := make([]*types.CommitStatus, maxCommitStatusDeliveriesQueryLimit+10)
 		for i := 0; i < len(commitStatuses); i++ {
 			commitStatuses[i] = createCommitStatus(t, ctx, ns, i, fmt.Sprintf("projectID-%d", i))
 			createCommitStatusDelivery(t, ctx, ns, commitStatuses[i].ID, types.DeliveryStatusNotDelivered)
@@ -698,7 +698,7 @@ func TestRunWebhooksCleaner(t *testing.T) {
 	expectedRunWebhooks := make([]*types.RunWebhook, 0)
 	expectedRunWebhookDeliveries := make([]*types.RunWebhookDelivery, 0)
 
-	for i := 0; i < 5; i++ {
+	for i := 0; i < maxRunWebhooksQueryLimit+10; i++ {
 		runWebhook := createRunWebhook(t, ctx, ns, project01)
 		expectedRunWebhooks = append(expectedRunWebhooks, runWebhook)
 
@@ -706,7 +706,7 @@ func TestRunWebhooksCleaner(t *testing.T) {
 		expectedRunWebhookDeliveries = append(expectedRunWebhookDeliveries, createRunWebhookDelivery(t, ctx, ns, runWebhook.ID, types.DeliveryStatusNotDelivered))
 	}
 
-	for i := 0; i < 5; i++ {
+	for i := 0; i < maxRunWebhooksQueryLimit+10; i++ {
 		runWebhook := createRunWebhook(t, ctx, ns, project02)
 		expectedRunWebhooks = append(expectedRunWebhooks, runWebhook)
 
@@ -715,7 +715,7 @@ func TestRunWebhooksCleaner(t *testing.T) {
 	}
 
 	runWebhookCreationTime := time.Now().Add(-1 * time.Hour)
-	for i := 0; i < 50; i++ {
+	for i := 0; i < maxRunWebhooksQueryLimit+10; i++ {
 		runWebhook := createRunWebhook(t, ctx, ns, project01)
 		createRunWebhookDelivery(t, ctx, ns, runWebhook.ID, types.DeliveryStatusDelivered)
 		createRunWebhookDelivery(t, ctx, ns, runWebhook.ID, types.DeliveryStatusNotDelivered)
@@ -900,7 +900,7 @@ func TestCommitStatusesCleaner(t *testing.T) {
 	expectedCommitStatuses := make([]*types.CommitStatus, 0)
 	expectedCommitStatusDeliveries := make([]*types.CommitStatusDelivery, 0)
 
-	for i := 0; i < 5; i++ {
+	for i := 0; i < maxCommitStatusesQueryLimit+10; i++ {
 		commitStatus := createCommitStatus(t, ctx, ns, 1, fmt.Sprintf("projectID-%d", i))
 		expectedCommitStatuses = append(expectedCommitStatuses, commitStatus)
 
@@ -909,7 +909,7 @@ func TestCommitStatusesCleaner(t *testing.T) {
 	}
 
 	commitStatusCreationTime := time.Now().Add(-1 * time.Hour)
-	for i := 0; i < 50; i++ {
+	for i := 0; i < maxCommitStatusesQueryLimit+10; i++ {
 		commitStatus := createCommitStatus(t, ctx, ns, i, fmt.Sprintf("projectID-%d", i))
 		createCommitStatusDelivery(t, ctx, ns, commitStatus.ID, types.DeliveryStatusDelivered)
 		createCommitStatusDelivery(t, ctx, ns, commitStatus.ID, types.DeliveryStatusNotDelivered)

--- a/internal/services/notification/runwebhookdelivery.go
+++ b/internal/services/notification/runwebhookdelivery.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	MaxRunWebhookDeliveriesQueryLimit = 40
+	maxRunWebhookDeliveriesQueryLimit = 40
 	RunWebhookDeliveriesLockKey       = "runwebhookdeliveryevents"
 
 	// runWebhookDeliveriesInterval is the time to wait between every runWebhookDeliveriesHandler call.
@@ -71,7 +71,7 @@ func (n *NotificationService) runWebhookDeliveriesHandler(ctx context.Context) e
 
 		err := n.d.Do(ctx, func(tx *sql.Tx) error {
 			var err error
-			runWebhookDeliveries, err = n.d.GetProjectRunWebhookDeliveriesAfterSequenceByProjectID(tx, curRunWebhookDeliverySequence, "", []types.DeliveryStatus{types.DeliveryStatusNotDelivered}, MaxRunWebhookDeliveriesQueryLimit, types.SortDirectionAsc)
+			runWebhookDeliveries, err = n.d.GetProjectRunWebhookDeliveriesAfterSequenceByProjectID(tx, curRunWebhookDeliverySequence, "", []types.DeliveryStatus{types.DeliveryStatusNotDelivered}, maxRunWebhookDeliveriesQueryLimit, types.SortDirectionAsc)
 			if err != nil {
 				return errors.WithStack(err)
 			}
@@ -90,7 +90,7 @@ func (n *NotificationService) runWebhookDeliveriesHandler(ctx context.Context) e
 			curRunWebhookDeliverySequence = r.Sequence
 		}
 
-		if len(runWebhookDeliveries) < MaxRunWebhookDeliveriesQueryLimit {
+		if len(runWebhookDeliveries) < maxRunWebhookDeliveriesQueryLimit {
 			return nil
 		}
 	}

--- a/internal/services/notification/webhooks.go
+++ b/internal/services/notification/webhooks.go
@@ -155,9 +155,10 @@ func (n *NotificationService) runWebhooksCleaner(ctx context.Context, runWebhook
 	}
 	defer func() { _ = l.Unlock() }()
 
+	var afterRunWebhookID string
+
 	for {
 		var runWebhooks []*nstypes.RunWebhook
-		var afterRunWebhookID string
 
 		err := n.d.Do(ctx, func(tx *sql.Tx) error {
 			var err error


### PR DESCRIPTION
The variable holding the next starting id was defined inside the loop instead than outside.

Improve tests to trigger multiple loops