### PR TITLE
executor: add option to define docker driver network

### DIFF
--- a/internal/services/config/config.go
+++ b/internal/services/config/config.go
@@ -182,6 +182,14 @@ type Executor struct {
 	ActiveTasksLimit int `yaml:"activeTasksLimit"`
 
 	AllowPrivilegedContainers bool `yaml:"allowPrivilegedContainers"`
+
+	// docker specific configuration
+	Docker DockerExecutor `yaml:"docker"`
+}
+
+type DockerExecutor struct {
+	// docker network to use when creating containers
+	Network string `yaml:"network"`
 }
 
 type InitImage struct {

--- a/internal/services/executor/driver/docker_test.go
+++ b/internal/services/executor/driver/docker_test.go
@@ -41,7 +41,7 @@ func TestDockerPod(t *testing.T) {
 
 	initImage := "busybox:stable"
 
-	d, err := NewDockerDriver(log, "executorid01", toolboxPath, initImage, nil)
+	d, err := NewDockerDriver(log, "executorid01", toolboxPath, initImage)
 	testutil.NilError(t, err)
 
 	ctx := context.Background()

--- a/internal/services/executor/driver/k8s.go
+++ b/internal/services/executor/driver/k8s.go
@@ -98,7 +98,15 @@ type K8sPod struct {
 	initVolumeDir string
 }
 
-func NewK8sDriver(log zerolog.Logger, executorID, toolboxPath, initImage string, initDockerConfig *registry.DockerConfig) (*K8sDriver, error) {
+type K8sDriverCreateOption func(*K8sDriver)
+
+func WithK8sDriverInitDockerConfig(initDockerConfig *registry.DockerConfig) func(*K8sDriver) {
+	return func(d *K8sDriver) {
+		d.initDockerConfig = initDockerConfig
+	}
+}
+
+func NewK8sDriver(log zerolog.Logger, executorID, toolboxPath, initImage string, opts ...K8sDriverCreateOption) (*K8sDriver, error) {
 	kubeClientConfig := NewKubeClientConfig("", "", "")
 	kubecfg, err := kubeClientConfig.ClientConfig()
 	if err != nil {
@@ -115,15 +123,18 @@ func NewK8sDriver(log zerolog.Logger, executorID, toolboxPath, initImage string,
 	}
 
 	d := &K8sDriver{
-		log:              log,
-		restconfig:       kubecfg,
-		client:           kubecli,
-		toolboxPath:      toolboxPath,
-		initImage:        initImage,
-		initDockerConfig: initDockerConfig,
-		namespace:        namespace,
-		executorID:       executorID,
-		k8sLabelArch:     corev1.LabelArchStable,
+		log:          log,
+		restconfig:   kubecfg,
+		client:       kubecli,
+		toolboxPath:  toolboxPath,
+		initImage:    initImage,
+		namespace:    namespace,
+		executorID:   executorID,
+		k8sLabelArch: corev1.LabelArchStable,
+	}
+
+	for _, o := range opts {
+		o(d)
 	}
 
 	serverVersion, err := d.client.Discovery().ServerVersion()

--- a/internal/services/executor/executor.go
+++ b/internal/services/executor/executor.go
@@ -1496,12 +1496,12 @@ func NewExecutor(ctx context.Context, log zerolog.Logger, c *config.Executor) (*
 	var d driver.Driver
 	switch c.Driver.Type {
 	case config.DriverTypeDocker:
-		d, err = driver.NewDockerDriver(log, e.id, e.c.ToolboxPath, e.c.InitImage.Image, initDockerConfig)
+		d, err = driver.NewDockerDriver(log, e.id, e.c.ToolboxPath, e.c.InitImage.Image, driver.WithDockerDriverNetwork(e.c.Docker.Network), driver.WithDockerDriverInitDockerConfig(initDockerConfig))
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create docker driver")
 		}
 	case config.DriverTypeK8s:
-		d, err = driver.NewK8sDriver(log, e.id, c.ToolboxPath, e.c.InitImage.Image, initDockerConfig)
+		d, err = driver.NewK8sDriver(log, e.id, c.ToolboxPath, e.c.InitImage.Image, driver.WithK8sDriverInitDockerConfig(initDockerConfig))
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create kubernetes driver")
 		}


### PR DESCRIPTION
* Add an option to define the network the docker driver will use when creating containers. The network should already exist.
* Use option pattern to avoid adding too many parameters to the constructor functions.