### PR TITLE
agolademo: use docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,4 @@ SHELL ["/bin/bash", "-c"]
 
 RUN mkdir -p /data/agola/{configstore,runservice,executor,notification,gitserver}
 
-# copy the example config
-COPY examples/agolademo/config.yml .
-
 ENTRYPOINT ["/bin/agola"]

--- a/examples/agolademo/README.md
+++ b/examples/agolademo/README.md
@@ -1,0 +1,105 @@
+# Agola demo
+
+This demo uses [docker compose](https://docs.docker.com/compose/) to create containers, volumes, networks etc...
+
+The demo will use only IPs to avoid users modifying local hosts file to resolve containers IPs.
+
+Specifically:
+
+* It'll create a custom bridged network (`agolademo_net1`) with subnet 172.30.0.0/16.
+* It'll create docker volumes for agola and gitea containers.
+* Start agola and gitea with a configuration suitable for the setup.
+
+## Start
+
+Move to the agolademo directory:
+
+``` sh
+cd examples/agolademo
+```
+
+Start the demo infrastructure
+
+``` sh
+docker compose up
+```
+
+## Connect
+
+Point your browser to <http://172.30.0.2:8000>
+
+You'll see the main agola ui page with a `Sign up` and a `Login` button at the top right. But before being able to register and login we should first link agola with gitea.
+
+## Setup gitea
+
+* Access gitea on <http://172.30.0.3:3000>
+* Register a new user.
+* Under your user `user settings` -> `SSH / GPG Keys` -> `Manage SSH Keys` add your ssh public key (to be able to push to repositories).
+* Now create an oauth2 app under your `user settings` -> `Applications` -> `Manage OAuth2 Applications`. As the application name you can use `Agola` and as redirect uri use `http://172.30.0.2:8000/oauth2/callback`. Keep note of the provided `Client ID` and `Client Secret` and then click `Save`.
+
+## Add a gitea remote source
+
+A remote source defines a remote git provider (like gitea, gitlab, github).
+
+The create a remote source we'll use the agola command in cli mode:
+
+``` sh
+docker run --network agolademo_net1 --rm sorintlab/agolademo --token "admintoken" --gateway-url http://172.30.0.2:8000 remotesource create \
+--name gitea \
+--type gitea \
+--api-url http://172.30.0.3:3000 \
+--auth-type oauth2 \
+--clientid $GITEA_APP_CLIENTID \
+--secret $GITEA_APP_CLIENTSECRET \
+--skip-ssh-host-key-check
+```
+
+"admintoken" is a token defined in the default agolademo configuration and will let you act with the API as an admin without the need of a user created inside agola.
+
+* `--skip-ssh-host-key-check` is used to speed up things and tells agola to not check gitea host ssh host key when cloning repositories. The right thing to do will be to provide the ssh host key using the option `--ssh-host-key`. You can get the host key using `ssh-keyscan $giteahost` and choosing the ecdsa or rsa host key provided line (use the whole line)
+
+### Register
+
+Login to the agola web ui on <http://172.30.0.2:8000> and choose **Sign up**, then **Register with gitea**. If everything goes well gitea will ask you Authorize the applicaton and then you'll be redirected back to the user registration form. Once registered you can Login.
+
+### Create a user API Token
+
+Use the web interface or the cli:
+
+``` sh
+docker run --network agolademo_net1 --rm sorintlab/agolademo --token admintoken --gateway-url http://172.30.0.2:8000 user token create -n $YOUR_AGOLA_USERNAME -t default
+```
+
+Save the token since it won't be displayed again.
+
+#### Testing with an example repository
+
+We'll use the [agola-example-go](https://github.com/agola-io/agola-example-go) repository
+
+* Clone to above repository locally
+* Create a repository on gitea called `agola-example-go`
+* Create a project in agola connected to the gitea repository using the web interface or the cli:
+
+``` sh
+docker run --network agolademo_net1 --rm sorintlab/agolademo --token $TOKEN --gateway-url http://172.30.0.2:8000 project create \
+--parent "user/$AGOLAUSER" \
+--name agola-example-go \
+--remote-source gitea \
+--repo-path $GITEAUSER/agola-example-go
+```
+
+where:
+
+* `--token` is your agola user API token
+* `--name` is the agola project associated to your gitea repository that you want to create
+* `--remote-source` is the remote source providing the repository
+* `--repo-path` is the remote source repository path
+
+* Push the `agola-example-go` repository you've previousy cloned to the gitea repository:
+
+``` sh
+git remote add mygitea git@172.30.0.3:$GITEAUSER/agola-example-go.git
+git push -u mygitea master
+```
+
+If everything is ok, you should see a **run** started in the agola web ui (<http://172.30.0.2:8000>). If something went wrong you should take a look at the agola container logs.

--- a/examples/agolademo/agola/config.yml
+++ b/examples/agolademo/agola/config.yml
@@ -1,6 +1,6 @@
 gateway:
-  apiExposedURL: "http://172.17.0.1:8000"
-  webExposedURL: "http://172.17.0.1:8000"
+  apiExposedURL: "http://172.30.0.2:8000"
+  webExposedURL: "http://172.30.0.2:8000"
   runserviceURL: "http://localhost:4000"
   configstoreURL: "http://localhost:4002"
   gitserverURL: "http://localhost:4003"
@@ -26,7 +26,7 @@ scheduler:
   runserviceURL: "http://localhost:4000"
 
 notification:
-  webExposedURL: "http://172.17.0.1:8000"
+  webExposedURL: "http://172.30.0.2:8000"
   runserviceURL: "http://localhost:4000"
   configstoreURL: "http://localhost:4002"
   db:
@@ -66,6 +66,8 @@ executor:
   activeTasksLimit: 2
   driver:
     type: docker
+  docker:
+    network: agolademo_net1
 
 gitserver:
   dataDir: /data/agola/gitserver

--- a/examples/agolademo/docker-compose.yml
+++ b/examples/agolademo/docker-compose.yml
@@ -1,0 +1,56 @@
+name:
+  agolademo
+
+services:
+  agola:
+    image: "agolademo"
+    command: serve --components all-base,executor
+    configs:
+      - source: agola
+        target: /config.yml
+    networks:
+      net1:
+        ipv4_address: 172.30.0.2
+    # ports:
+    #   - "8000:8000"
+    volumes:
+      - agola-data:/data/agola
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  gitea:
+    image: gitea/gitea:1.21.6
+    restart: always
+    environment:
+      - USER_UID=1000
+      - USER_GID=1000
+    configs:
+      - source: gitea
+        target: /data/gitea/conf/app.ini
+    networks:
+      net1:
+        ipv4_address: 172.30.0.3
+    volumes:
+      - gitea-data:/data
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    # ports:
+    #   - "3000:3000"
+    #   - "2222:22"
+
+networks:
+  net1:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.30.0.0/16
+          gateway: 172.30.0.1
+
+volumes:
+  agola-data:
+  gitea-data:
+
+configs:
+  agola:
+    file: ./agola/config.yml
+  gitea:
+    file: ./gitea/app.ini

--- a/examples/agolademo/gitea/app.ini
+++ b/examples/agolademo/gitea/app.ini
@@ -1,0 +1,101 @@
+APP_NAME = Gitea: Git with a cup of tea
+RUN_MODE = prod
+RUN_USER = git
+WORK_PATH = /data/gitea
+
+[repository]
+ROOT = /data/git/repositories
+
+[repository.local]
+LOCAL_COPY_PATH = /data/gitea/tmp/local-repo
+
+[repository.upload]
+TEMP_PATH = /data/gitea/uploads
+
+[server]
+APP_DATA_PATH = /data/gitea
+DOMAIN = 172.30.0.3
+SSH_DOMAIN = 172.30.0.3
+HTTP_PORT = 3000
+ROOT_URL = http://172.30.0.3:3000/
+DISABLE_SSH = false
+SSH_PORT = 22
+SSH_LISTEN_PORT = 22
+LFS_START_SERVER = true
+LFS_JWT_SECRET = _KBQYiMGNk6Sat-A38Xr_mI3pt41aWC7Bl4y0dzC7oE
+OFFLINE_MODE = false
+
+[database]
+PATH = /data/gitea/gitea.db
+DB_TYPE = sqlite3
+HOST = localhost:3306
+NAME = gitea
+USER = root
+PASSWD =
+LOG_SQL = false
+SCHEMA =
+SSL_MODE = disable
+
+[indexer]
+ISSUE_INDEXER_PATH = /data/gitea/indexers/issues.bleve
+
+[session]
+PROVIDER_CONFIG = /data/gitea/sessions
+PROVIDER = file
+
+[picture]
+AVATAR_UPLOAD_PATH = /data/gitea/avatars
+REPOSITORY_AVATAR_UPLOAD_PATH = /data/gitea/repo-avatars
+
+[attachment]
+PATH = /data/gitea/attachments
+
+[log]
+MODE = console
+LEVEL = info
+ROOT_PATH = /data/gitea/log
+
+[security]
+INSTALL_LOCK = true
+SECRET_KEY =
+REVERSE_PROXY_LIMIT = 1
+REVERSE_PROXY_TRUSTED_PROXIES = *
+INTERNAL_TOKEN = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE3MDkxMDg2MzR9.D86x1hVeM1pVzv02DAPIaTja-Dmz2g8VVx6LmpJU3mY
+PASSWORD_HASH_ALGO = pbkdf2
+
+[service]
+DISABLE_REGISTRATION = false
+REQUIRE_SIGNIN_VIEW = false
+REGISTER_EMAIL_CONFIRM = false
+ENABLE_NOTIFY_MAIL = false
+ALLOW_ONLY_EXTERNAL_REGISTRATION = false
+ENABLE_CAPTCHA = false
+DEFAULT_KEEP_EMAIL_PRIVATE = false
+DEFAULT_ALLOW_CREATE_ORGANIZATION = true
+DEFAULT_ENABLE_TIMETRACKING = true
+NO_REPLY_ADDRESS = noreply.localhost
+
+[lfs]
+PATH = /data/git/lfs
+
+[mailer]
+ENABLED = false
+
+[openid]
+ENABLE_OPENID_SIGNIN = true
+ENABLE_OPENID_SIGNUP = true
+
+[cron.update_checker]
+ENABLED = false
+
+[repository.pull-request]
+DEFAULT_MERGE_STYLE = merge
+
+[repository.signing]
+DEFAULT_TRUST_MODEL = committer
+
+[oauth2]
+JWT_SECRET = WXdII84HRlC6zFipArromJuC03fg2yyvgYe23FXkwLg
+
+[webhook]
+ALLOWED_HOST_LIST = *


### PR DESCRIPTION
Improve the agola demo by using docker compose:

* Use a dedicated bridged network
* Adapt the agola and gitea config for the new setup

* Also add a README.md (with the same contents of the tryit
  documentation on the agola site, that will be updated).