### PR TITLE
*: update to go 1.22

### DIFF
--- a/.agola/config.jsonnet
+++ b/.agola/config.jsonnet
@@ -128,7 +128,7 @@ local task_build_push_images(name, target, push) =
         [
           task_build_go(version, arch),
         ]
-        for version in ['1.20', '1.21']
+        for version in ['1.21', '1.22']
         for arch in ['amd64' /*, 'arm64' */]
       ]) + [
         {
@@ -139,7 +139,7 @@ local task_build_push_images(name, target, push) =
             { type: 'run', command: 'SKIP_K8S_TESTS=1 AGOLA_TOOLBOX_PATH="./bin" ./bin/docker-tests -test.parallel 5 -test.v' },
           ],
           depends: [
-            'build go 1.21 amd64',
+            'build go 1.22 amd64',
           ],
         },
         {
@@ -162,7 +162,7 @@ local task_build_push_images(name, target, push) =
             { type: 'run', name: 'integration tests', command: 'AGOLA_BIN_DIR="./bin" GITEA_PATH=${PWD}/bin/gitea DOCKER_BRIDGE_ADDRESS="172.18.0.1" ./bin/integration-tests -test.parallel 3 -test.v' },
           ],
           depends: [
-            'build go 1.21 amd64',
+            'build go 1.22 amd64',
           ],
         },
         {

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM $AGOLAWEB_IMAGE as agola-web
 #######
 
 # base build image
-FROM golang:1.21-bookworm AS build_base
+FROM golang:1.22-bookworm AS build_base
 
 WORKDIR /agola
 

--- a/cmd/agola/cmd/runlist.go
+++ b/cmd/agola/cmd/runlist.go
@@ -15,9 +15,10 @@
 package cmd
 
 import (
+	"cmp"
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/rs/zerolog/log"
 	"github.com/sorintlab/errors"
@@ -166,11 +167,11 @@ func runList(cmd *cobra.Command, args []string) error {
 				tasks = append(tasks, t)
 			}
 
-			sort.Slice(tasks, func(i, j int) bool {
-				if tasks[i].level != tasks[j].level {
-					return tasks[i].level < tasks[j].level
+			slices.SortFunc(tasks, func(a, b *taskDetails) int {
+				if n := cmp.Compare(a.level, b.level); n != 0 {
+					return n
 				}
-				return tasks[i].name < tasks[j].name
+				return cmp.Compare(a.name, b.name)
 			})
 
 			runs[i] = &runDetails{

--- a/cmd/agola/cmd/serve.go
+++ b/cmd/agola/cmd/serve.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/rs/zerolog/log"
 	"github.com/sorintlab/errors"
@@ -31,7 +32,6 @@ import (
 	"agola.io/agola/internal/services/notification"
 	"agola.io/agola/internal/services/runservice"
 	"agola.io/agola/internal/services/scheduler"
-	"agola.io/agola/internal/util"
 )
 
 var (
@@ -82,10 +82,10 @@ func init() {
 }
 
 func isComponentEnabled(name string) bool {
-	if util.StringInSlice(serveOpts.components, "all-base") && name != "executor" {
+	if slices.Contains(serveOpts.components, "all-base") && name != "executor" {
 		return true
 	}
-	return util.StringInSlice(serveOpts.components, name)
+	return slices.Contains(serveOpts.components, name)
 }
 
 func serve(cmd *cobra.Command, args []string) error {
@@ -95,7 +95,7 @@ func serve(cmd *cobra.Command, args []string) error {
 		return errors.Errorf("no enabled components")
 	}
 	for _, ec := range serveOpts.components {
-		if !util.StringInSlice(componentsNames, ec) {
+		if !slices.Contains(componentsNames, ec) {
 			return errors.Errorf("unknown component name %q", ec)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module agola.io/agola
 
-go 1.20
+go 1.21
 
 require (
 	ariga.io/atlas v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -5,9 +5,11 @@ code.gitea.io/sdk/gitea v0.16.0/go.mod h1:ndkDk99BnfiUCCYEUhpNzi0lpmApXlwRFqClBl
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9vkmnHYOMsOr4WLk+Vo07yKIzd94sVoIqshQ4bU=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
@@ -19,6 +21,7 @@ github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Microsoft/hcsshim v0.11.1 h1:hJ3s7GbWlGK4YVV92sO88BQSyF4ZLVy7/awqOlPxFbA=
+github.com/Microsoft/hcsshim v0.11.1/go.mod h1:nFJmaO4Zr5Y7eADdFOpYswDDlNVbvcIJJNJLECr5JQg=
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c h1:kMFnB0vCcX7IL/m9Y5LO+KQYv+t1CQOiFe6+SV2J7bE=
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/acomagu/bufpipe v1.0.4 h1:e3H4WUzM3npvo5uv95QuJM3cQspFNtFBzvJ2oNjKIDQ=
@@ -26,9 +29,11 @@ github.com/acomagu/bufpipe v1.0.4/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
+github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
 github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
@@ -65,6 +70,7 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/elazarl/go-bindata-assetfs v1.0.1 h1:m0kkaHRKEu7tUIUFVwhGGGYClXvyl4RE03qmvRTNfbw=
 github.com/elazarl/go-bindata-assetfs v1.0.1/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a h1:mATvB/9r/3gvcejNsXKSkQ6lcIaNec2nyfOdlTBR2lU=
+github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
@@ -73,9 +79,11 @@ github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
+github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
+github.com/gliderlabs/ssh v0.3.5/go.mod h1:8XB4KraRrX39qHhT6yxPsHedjA08I/uBVwj4xC+/+z4=
 github.com/go-bindata/go-bindata v3.1.2+incompatible h1:5vjJMVhowQdPzjE1LdxyFF7YFTXg5IgGVW4gBr5IbvE=
 github.com/go-bindata/go-bindata v3.1.2+incompatible/go.mod h1:xK8Dsgwmeed+BBsSy2XTopBn/8uK2HWuGSnA11C3Joo=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=
@@ -85,6 +93,7 @@ github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmS
 github.com/go-git/go-billy/v5 v5.5.0 h1:yEY4yhzCDuMGSv83oGxiBotRzhwhNr8VZyphhiu+mTU=
 github.com/go-git/go-billy/v5 v5.5.0/go.mod h1:hmexnoNsr2SJU1Ju67OaNz5ASJY3+sHgFRpCtpDCKow=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20230305113008-0c11038e723f h1:Pz0DHeFij3XFhoBRGUDPzSJ+w2UcK5/0JvF8DRI58r8=
+github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20230305113008-0c11038e723f/go.mod h1:8LHG1a3SRW71ettAD/jW13h8c6AqjVSeL11RAdgaqpo=
 github.com/go-git/go-git/v5 v5.9.0 h1:cD9SFA7sHVRdJ7AYck1ZaAa/yeuBvGPxwXDL8cxrObY=
 github.com/go-git/go-git/v5 v5.9.0/go.mod h1:RKIqga24sWdMGZF+1Ekv9kylsDz6LzdTSI2s/OsZWE0=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -101,7 +110,9 @@ github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+
 github.com/go-openapi/swag v0.22.4 h1:QLMzNJnMGPRNDCbySlcj1x01tzU8/9LTTL9hZZZogBU=
 github.com/go-openapi/swag v0.22.4/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
+github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
 github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
@@ -134,6 +145,7 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
 github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -197,11 +209,13 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=
+github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
@@ -242,6 +256,7 @@ github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0Gq
 github.com/moby/sys/sequential v0.5.0 h1:OPvI35Lzn9K04PBbCLW0g4LcFAJgHsvXsRyewg5lXtc=
 github.com/moby/sys/sequential v0.5.0/go.mod h1:tH2cOOs5V9MlPiXcQzRC+eEyab644PWKGRYaaV5ZZlo=
 github.com/moby/term v0.0.0-20221205130635-1aeaba878587 h1:HfkjXDfhgVaN5rmueG8cL8KKeFNecRCXFhaJ2qZ5SKA=
+github.com/moby/term v0.0.0-20221205130635-1aeaba878587/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -249,10 +264,13 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
+github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.9.4 h1:xR7vG4IXt5RWx6FfIjyAtsoMAtnc3C/rFXBBd2AjZwE=
+github.com/onsi/ginkgo/v2 v2.9.4/go.mod h1:gCQYp2Q+kSoIj7ykSVb9nskRSsR6PUj4AiLywzIhbKM=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
+github.com/onsi/gomega v1.27.10/go.mod h1:RsS8tutOdbdgzbPtzzATp12yT7kM5I5aElG3evPbQ0M=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc5 h1:Ygwkfw9bpDvs+c9E34SdgGOj41dX/cbdlwvlWt0pnFI=
@@ -267,6 +285,7 @@ github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
+github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.26.1/go.mod h1:/wSSJWX7lVrsOwlbyTRSOJvqRlc+WjWlfes+CiJ+tmc=
@@ -312,6 +331,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/xanzy/go-gitlab v0.93.1 h1:f7J33cw/P9b/8paIOoH0F3H+TFrswvWHs6yUgoTp9LY=
 github.com/xanzy/go-gitlab v0.93.1/go.mod h1:5ryv+MnpZStBH8I/77HuQBsMbBGANtVpLWC15qOjWAw=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
@@ -454,6 +474,7 @@ gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
+gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 k8s.io/api v0.28.2 h1:9mpl5mOb6vXZvqbQmankOfPIGiudghwCoLl1EYfUZbw=
 k8s.io/api v0.28.2/go.mod h1:RVnJBsjU8tcMq7C3iaRSGMeaKt2TWEUXcpIt/90fjEg=
 k8s.io/apimachinery v0.28.2 h1:KCOJLrc6gu+wV1BYgwik4AF4vXOlVJPdiqn0yAWWwXQ=

--- a/internal/runconfig/runconfig_test.go
+++ b/internal/runconfig/runconfig_test.go
@@ -441,7 +441,7 @@ func TestGetAllParents(t *testing.T) {
 				for _, p := range allParents {
 					allParentsList = append(allParentsList, p.ID)
 				}
-				assert.Assert(t, util.CompareStringSliceNoOrder(tt.out[task.ID], allParentsList), "task: %s, want: %s, got: %s", task.ID, util.Dump(tt.out[task.ID]), util.Dump(allParentsList))
+				assert.Assert(t, util.EqualStringSliceNoOrder(tt.out[task.ID], allParentsList), "task: %s, want: %s, got: %s", task.ID, util.Dump(tt.out[task.ID]), util.Dump(allParentsList))
 			}
 		})
 	}

--- a/internal/services/config/config.go
+++ b/internal/services/config/config.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"os"
+	"slices"
 	"time"
 
 	"github.com/sorintlab/errors"
@@ -658,8 +659,8 @@ func Validate(c *Config, componentsNames []string) error {
 }
 
 func isComponentEnabled(componentsNames []string, name string) bool {
-	if util.StringInSlice(componentsNames, "all-base") && name != "executor" {
+	if slices.Contains(componentsNames, "all-base") && name != "executor" {
 		return true
 	}
-	return util.StringInSlice(componentsNames, name)
+	return slices.Contains(componentsNames, name)
 }

--- a/internal/services/configstore/configstore_test.go
+++ b/internal/services/configstore/configstore_test.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"path"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -953,11 +954,8 @@ func TestGetRemoteSources(t *testing.T) {
 			// default sortdirection is asc
 
 			// reverse if sortDirection is desc
-			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == types.SortDirectionDesc {
-				for i, j := 0, len(expectedRemoteSources)-1; i < j; i, j = i+1, j-1 {
-					expectedRemoteSources[i], expectedRemoteSources[j] = expectedRemoteSources[j], expectedRemoteSources[i]
-				}
+				slices.Reverse(expectedRemoteSources)
 			}
 
 			callsNumber := 0
@@ -1059,11 +1057,8 @@ func TestGetUsers(t *testing.T) {
 			// default sortdirection is asc
 
 			// reverse if sortDirection is desc
-			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == types.SortDirectionDesc {
-				for i, j := 0, len(expectedUsers)-1; i < j; i, j = i+1, j-1 {
-					expectedUsers[i], expectedUsers[j] = expectedUsers[j], expectedUsers[i]
-				}
+				slices.Reverse(expectedUsers)
 			}
 
 			callsNumber := 0
@@ -1230,11 +1225,8 @@ func TestGetOrgs(t *testing.T) {
 			// default sortdirection is asc
 
 			// reverse if sortDirection is desc
-			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == types.SortDirectionDesc {
-				for i, j := 0, len(expectedOrgs)-1; i < j; i, j = i+1, j-1 {
-					expectedOrgs[i], expectedOrgs[j] = expectedOrgs[j], expectedOrgs[i]
-				}
+				slices.Reverse(expectedOrgs)
 			}
 
 			callsNumber := 0
@@ -1344,11 +1336,8 @@ func TestGetOrgMembers(t *testing.T) {
 			// default sortdirection is asc
 
 			// reverse if sortDirection is desc
-			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == types.SortDirectionDesc {
-				for i, j := 0, len(expectedUsers)-1; i < j; i, j = i+1, j-1 {
-					expectedUsers[i], expectedUsers[j] = expectedUsers[j], expectedUsers[i]
-				}
+				slices.Reverse(expectedUsers)
 			}
 
 			callsNumber := 0
@@ -1463,11 +1452,8 @@ func TestGetUserOrgs(t *testing.T) {
 			// default sortdirection is asc
 
 			// reverse if sortDirection is desc
-			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == types.SortDirectionDesc {
-				for i, j := 0, len(expectedOrgs)-1; i < j; i, j = i+1, j-1 {
-					expectedOrgs[i], expectedOrgs[j] = expectedOrgs[j], expectedOrgs[i]
-				}
+				slices.Reverse(expectedOrgs)
 			}
 
 			callsNumber := 0

--- a/internal/services/gateway/api/user.go
+++ b/internal/services/gateway/api/user.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"sort"
+	"slices"
 	"strconv"
 
 	"github.com/gorilla/mux"
@@ -159,7 +159,7 @@ func createPrivateUserResponse(u *cstypes.User, tokens []*cstypes.UserToken, lin
 	for _, token := range tokens {
 		user.Tokens = append(user.Tokens, token.Name)
 	}
-	sort.Strings(user.Tokens)
+	slices.Sort(user.Tokens)
 
 	for _, la := range linkedAccounts {
 		user.LinkedAccounts = append(user.LinkedAccounts, &gwapitypes.LinkedAccountResponse{

--- a/internal/services/notification/notification_test.go
+++ b/internal/services/notification/notification_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -614,7 +615,7 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 			// populate the expected run webhook deliveries
 			expectedProject01RunWebhookDeliveries := []*types.RunWebhookDelivery{}
 			for _, c := range project01RunWebhookDeliveries {
-				if len(tt.deliveryStatusFilter) > 0 && !deliveryStatusInSlice(tt.deliveryStatusFilter, c.DeliveryStatus) {
+				if len(tt.deliveryStatusFilter) > 0 && !slices.Contains(tt.deliveryStatusFilter, c.DeliveryStatus) {
 					continue
 				}
 				expectedProject01RunWebhookDeliveries = append(expectedProject01RunWebhookDeliveries, c)
@@ -622,11 +623,8 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 			// default sortdirection is asc
 
 			// reverse if sortDirection is desc
-			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == types.SortDirectionDesc {
-				for i, j := 0, len(expectedProject01RunWebhookDeliveries)-1; i < j; i, j = i+1, j-1 {
-					expectedProject01RunWebhookDeliveries[i], expectedProject01RunWebhookDeliveries[j] = expectedProject01RunWebhookDeliveries[j], expectedProject01RunWebhookDeliveries[i]
-				}
+				slices.Reverse(expectedProject01RunWebhookDeliveries)
 			}
 
 			callsNumber := 0
@@ -1038,7 +1036,7 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 			// populate the expected commit status deliveries
 			expectedProject01CommitStatusDeliveries := []*types.CommitStatusDelivery{}
 			for _, c := range project01CommitStatusDeliveries {
-				if len(tt.deliveryStatusFilter) > 0 && !deliveryStatusInSlice(tt.deliveryStatusFilter, c.DeliveryStatus) {
+				if len(tt.deliveryStatusFilter) > 0 && !slices.Contains(tt.deliveryStatusFilter, c.DeliveryStatus) {
 					continue
 				}
 				expectedProject01CommitStatusDeliveries = append(expectedProject01CommitStatusDeliveries, c)
@@ -1046,11 +1044,8 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 			// default sortdirection is asc
 
 			// reverse if sortDirection is desc
-			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == types.SortDirectionDesc {
-				for i, j := 0, len(expectedProject01CommitStatusDeliveries)-1; i < j; i, j = i+1, j-1 {
-					expectedProject01CommitStatusDeliveries[i], expectedProject01CommitStatusDeliveries[j] = expectedProject01CommitStatusDeliveries[j], expectedProject01CommitStatusDeliveries[i]
-				}
+				slices.Reverse(expectedProject01CommitStatusDeliveries)
 			}
 
 			callsNumber := 0
@@ -1083,16 +1078,6 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 			assert.Assert(t, cmp.Equal(callsNumber, tt.expectedCallsNumber))
 		})
 	}
-}
-
-// TODO(sgotti) use go 1.21 generics slices.Contains when removing support for go < 1.21
-func deliveryStatusInSlice(deliveryStatuses []types.DeliveryStatus, deliveryStatus types.DeliveryStatus) bool {
-	for _, s := range deliveryStatuses {
-		if deliveryStatus == s {
-			return true
-		}
-	}
-	return false
 }
 
 func TestProjectCommitStatusRedelivery(t *testing.T) {

--- a/internal/services/notification/runeventssender_test.go
+++ b/internal/services/notification/runeventssender_test.go
@@ -15,12 +15,13 @@
 package notification
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
-	"sort"
+	"slices"
 	"strconv"
 	"sync"
 	"testing"
@@ -171,8 +172,8 @@ func (h *runEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.runEvents.mu.Lock()
 	defer h.runEvents.mu.Unlock()
 
-	sort.Slice(h.runEvents.runEvents, func(i, j int) bool {
-		return h.runEvents.runEvents[i].Sequence < h.runEvents.runEvents[j].Sequence
+	slices.SortFunc(h.runEvents.runEvents, func(a, b *types.RunEvent) int {
+		return cmp.Compare(a.Sequence, b.Sequence)
 	})
 
 	for _, runEvent := range h.runEvents.runEvents {

--- a/internal/services/runservice/runservice_test.go
+++ b/internal/services/runservice/runservice_test.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -603,21 +604,18 @@ func TestGetGroupRuns(t *testing.T) {
 					continue
 				}
 
-				if len(tt.phaseFilter) > 0 && !phaseInSlice(tt.phaseFilter, run.Phase) {
+				if len(tt.phaseFilter) > 0 && !slices.Contains(tt.phaseFilter, run.Phase) {
 					continue
 				}
-				if len(tt.resultFilter) > 0 && !resultInSlice(tt.resultFilter, run.Result) {
+				if len(tt.resultFilter) > 0 && !slices.Contains(tt.resultFilter, run.Result) {
 					continue
 				}
 				expectedRuns = append(expectedRuns, run)
 			}
 
 			// reverse if sortDirection is desc
-			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == types.SortDirectionDesc || tt.sortDirection == "" {
-				for i, j := 0, len(expectedRuns)-1; i < j; i, j = i+1, j-1 {
-					expectedRuns[i], expectedRuns[j] = expectedRuns[j], expectedRuns[i]
-				}
+				slices.Reverse(expectedRuns)
 			}
 
 			callsNumber := 0
@@ -645,24 +643,4 @@ func TestGetGroupRuns(t *testing.T) {
 			assert.Equal(t, callsNumber, tt.expectedCallsNumber)
 		})
 	}
-}
-
-// TODO(sgotti) use go 1.21 generics slices.Contains when removing support for go < 1.21
-func phaseInSlice(phases []types.RunPhase, phase types.RunPhase) bool {
-	for _, s := range phases {
-		if phase == s {
-			return true
-		}
-	}
-	return false
-}
-
-// TODO(sgotti) use go 1.21 generics slices.Contains when removing support for go < 1.21
-func resultInSlice(results []types.RunResult, result types.RunResult) bool {
-	for _, s := range results {
-		if result == s {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/services/runservice/scheduler_test.go
+++ b/internal/services/runservice/scheduler_test.go
@@ -15,7 +15,7 @@
 package runservice
 
 import (
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -575,8 +575,8 @@ func TestGetTasksToRun(t *testing.T) {
 			for _, t := range tasks {
 				outTasks = append(outTasks, t.ID)
 			}
-			sort.Strings(tt.out)
-			sort.Strings(outTasks)
+			slices.Sort(tt.out)
+			slices.Sort(outTasks)
 
 			assert.DeepEqual(t, tt.out, outTasks)
 		})

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"bufio"
 	"bytes"
+	stdcmp "cmp"
 	"context"
 	stdsql "database/sql"
 	"encoding/json"
@@ -11,7 +12,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -702,7 +703,7 @@ func TestMigrate(t *testing.T, lastVersion uint, dataFixtures DataFixtures, setu
 						tableNames = append(tableNames, table.Name)
 					}
 
-					sort.Strings(tableNames)
+					slices.Sort(tableNames)
 
 					return tableNames
 				}
@@ -743,10 +744,10 @@ func decodeExport(t *testing.T, d manager.DB, export []byte) []any {
 	}
 
 	// sort objects by id
-	sort.Slice(objs, func(i, j int) bool {
-		o1 := objs[i].(sqlg.Object)
-		o2 := objs[j].(sqlg.Object)
-		return o1.GetID() < o2.GetID()
+	slices.SortFunc(objs, func(a, b any) int {
+		ao := a.(sqlg.Object)
+		bo := b.(sqlg.Object)
+		return stdcmp.Compare(ao.GetID(), bo.GetID())
 	})
 
 	return objs

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -57,7 +57,7 @@ func (e *Errors) Equal(e2 error) bool {
 		errs2 = append(errs2, e2.Error())
 	}
 
-	return CompareStringSliceNoOrder(errs1, errs2)
+	return EqualStringSliceNoOrder(errs1, errs2)
 }
 
 // Wrapper error is an helper error type that (optionally) wrap an error and add stack information starting at the frame where the error has been created

--- a/internal/util/slice.go
+++ b/internal/util/slice.go
@@ -14,33 +14,17 @@
 
 package util
 
-import "sort"
+import (
+	"slices"
+)
 
-func StringInSlice(s []string, e string) bool {
-	for _, v := range s {
-		if v == e {
-			return true
-		}
-	}
-	return false
+// EqualStringSlice compares two slices of strings, a nil slice is considered an empty one
+func EqualStringSlice(a []string, b []string) bool {
+	return slices.Equal(a, b)
 }
 
-// CompareStringSlice compares two slices of strings, a nil slice is considered an empty one
-func CompareStringSlice(a []string, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for i, v := range a {
-		if v != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-// CompareStringSliceNoOrder compares two slices of strings regardless of their order, a nil slice is considered an empty one
-func CompareStringSliceNoOrder(a []string, b []string) bool {
+// EqualStringSliceNoOrder compares two slices of strings regardless of their order, a nil slice is considered an empty one
+func EqualStringSliceNoOrder(a []string, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -51,22 +35,17 @@ func CompareStringSliceNoOrder(a []string, b []string) bool {
 	a = append([]string(nil), a...)
 	b = append([]string(nil), b...)
 
-	sort.Strings(a)
-	sort.Strings(b)
+	slices.Sort(a)
+	slices.Sort(b)
 
-	for i, v := range a {
-		if v != b[i] {
-			return false
-		}
-	}
-	return true
+	return slices.Equal(a, b)
 }
 
 // CommonElements return the common elements in two slices of strings
 func CommonElements(a []string, b []string) []string {
 	common := []string{}
 	for _, v := range a {
-		if StringInSlice(b, v) {
+		if slices.Contains(b, v) {
 			common = append(common, v)
 		}
 	}
@@ -77,7 +56,7 @@ func CommonElements(a []string, b []string) []string {
 func Difference(a []string, b []string) []string {
 	diff := []string{}
 	for _, v := range a {
-		if !StringInSlice(b, v) {
+		if !slices.Contains(b, v) {
 			diff = append(diff, v)
 		}
 	}

--- a/internal/util/slice_test.go
+++ b/internal/util/slice_test.go
@@ -20,7 +20,7 @@ import (
 	"gotest.tools/assert"
 )
 
-func TestCompareStringSlice(t *testing.T) {
+func TestEqualStringSlice(t *testing.T) {
 	tests := []struct {
 		a  []string
 		b  []string
@@ -39,12 +39,12 @@ func TestCompareStringSlice(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		ok := CompareStringSlice(tt.a, tt.b)
+		ok := EqualStringSlice(tt.a, tt.b)
 		assert.Equal(t, ok, tt.ok, "%d: got %t but wanted: %t a: %v, b: %v", i, ok, tt.ok, tt.a, tt.b)
 	}
 }
 
-func TestCompareStringSliceNoOrder(t *testing.T) {
+func TestEqualStringSliceNoOrder(t *testing.T) {
 	tests := []struct {
 		a  []string
 		b  []string
@@ -63,7 +63,7 @@ func TestCompareStringSliceNoOrder(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		ok := CompareStringSliceNoOrder(tt.a, tt.b)
+		ok := EqualStringSliceNoOrder(tt.a, tt.b)
 		assert.Equal(t, ok, tt.ok, "%d: got %t but wanted: %t a: %v, b: %v", i, ok, tt.ok, tt.a, tt.b)
 	}
 }
@@ -92,6 +92,6 @@ func TestDifference(t *testing.T) {
 
 	for i, tt := range tests {
 		r := Difference(tt.a, tt.b)
-		assert.Assert(t, CompareStringSliceNoOrder(r, tt.r), "%d: got %v but wanted: %v a: %v, b: %v", i, r, tt.r, tt.a, tt.b)
+		assert.Assert(t, EqualStringSliceNoOrder(r, tt.r), "%d: got %v but wanted: %v a: %v, b: %v", i, r, tt.r, tt.a, tt.b)
 	}
 }

--- a/tests/api_test.go
+++ b/tests/api_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -107,11 +108,8 @@ func TestGetRemoteSources(t *testing.T) {
 			// default sortdirection is asc
 
 			// reverse if sortDirection is desc
-			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == gwapitypes.SortDirectionDesc {
-				for i, j := 0, len(expectedRemoteSources)-1; i < j; i, j = i+1, j-1 {
-					expectedRemoteSources[i], expectedRemoteSources[j] = expectedRemoteSources[j], expectedRemoteSources[i]
-				}
+				slices.Reverse(expectedRemoteSources)
 			}
 
 			respAllRemoteSources := []*gwapitypes.RemoteSourceResponse{}
@@ -804,11 +802,8 @@ func TestGetOrgs(t *testing.T) {
 			// default sortdirection is asc
 
 			// reverse if sortDirection is desc
-			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == gwapitypes.SortDirectionDesc {
-				for i, j := 0, len(expectedOrgs)-1; i < j; i, j = i+1, j-1 {
-					expectedOrgs[i], expectedOrgs[j] = expectedOrgs[j], expectedOrgs[i]
-				}
+				slices.Reverse(expectedOrgs)
 			}
 
 			respAllOrgs := []*gwapitypes.OrgResponse{}
@@ -920,11 +915,8 @@ func TestGetOrgMembers(t *testing.T) {
 			// default sortdirection is asc
 
 			// reverse if sortDirection is desc
-			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == gwapitypes.SortDirectionDesc {
-				for i, j := 0, len(expectedOrgMembers)-1; i < j; i, j = i+1, j-1 {
-					expectedOrgMembers[i], expectedOrgMembers[j] = expectedOrgMembers[j], expectedOrgMembers[i]
-				}
+				slices.Reverse(expectedOrgMembers)
 			}
 
 			respAllOrgMembers := []*gwapitypes.OrgMemberResponse{}
@@ -1041,11 +1033,8 @@ func TestGetUserOrgs(t *testing.T) {
 			// default sortdirection is asc
 
 			// reverse if sortDirection is desc
-			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == gwapitypes.SortDirectionDesc {
-				for i, j := 0, len(expectedUserOrgs)-1; i < j; i, j = i+1, j-1 {
-					expectedUserOrgs[i], expectedUserOrgs[j] = expectedUserOrgs[j], expectedUserOrgs[i]
-				}
+				slices.Reverse(expectedUserOrgs)
 			}
 
 			respAllUserOrgs := []*gwapitypes.OrgResponse{}
@@ -1331,11 +1320,8 @@ func TestGetUsers(t *testing.T) {
 			// default sortdirection is asc
 
 			// reverse if sortDirection is desc
-			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == gwapitypes.SortDirectionDesc {
-				for i, j := 0, len(expectedUsers)-1; i < j; i, j = i+1, j-1 {
-					expectedUsers[i], expectedUsers[j] = expectedUsers[j], expectedUsers[i]
-				}
+				slices.Reverse(expectedUsers)
 			}
 
 			respAllUsers := []*gwapitypes.UserResponse{}
@@ -1735,7 +1721,7 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 			// populate the expected commit status deliveries
 			expectedProject01RunWebhookDeliveries := []*gwapitypes.RunWebhookDeliveryResponse{}
 			for _, r := range runWebhookDeliveries {
-				if len(tt.deliveryStatusFilter) > 0 && !util.StringInSlice(tt.deliveryStatusFilter, string(r.DeliveryStatus)) {
+				if len(tt.deliveryStatusFilter) > 0 && !slices.Contains(tt.deliveryStatusFilter, string(r.DeliveryStatus)) {
 					continue
 				}
 				expectedProject01RunWebhookDeliveries = append(expectedProject01RunWebhookDeliveries, r)
@@ -1743,11 +1729,8 @@ func TestGetProjectRunWebhookDeliveries(t *testing.T) {
 			// default sortdirection is asc
 
 			// reverse if sortDirection is desc
-			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == gwapitypes.SortDirectionDesc {
-				for i, j := 0, len(expectedProject01RunWebhookDeliveries)-1; i < j; i, j = i+1, j-1 {
-					expectedProject01RunWebhookDeliveries[i], expectedProject01RunWebhookDeliveries[j] = expectedProject01RunWebhookDeliveries[j], expectedProject01RunWebhookDeliveries[i]
-				}
+				slices.Reverse(expectedProject01RunWebhookDeliveries)
 			}
 
 			respAllRunWebhookDeliveries := []*gwapitypes.RunWebhookDeliveryResponse{}
@@ -2357,7 +2340,7 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 			// populate the expected commit status deliveries
 			expectedProject01CommitStatusDeliveries := []*gwapitypes.CommitStatusDeliveryResponse{}
 			for _, c := range commitStatusDeliveries {
-				if len(tt.deliveryStatusFilter) > 0 && !util.StringInSlice(tt.deliveryStatusFilter, string(c.DeliveryStatus)) {
+				if len(tt.deliveryStatusFilter) > 0 && !slices.Contains(tt.deliveryStatusFilter, string(c.DeliveryStatus)) {
 					continue
 				}
 				expectedProject01CommitStatusDeliveries = append(expectedProject01CommitStatusDeliveries, c)
@@ -2365,11 +2348,8 @@ func TestGetProjectCommitStatusDeliveries(t *testing.T) {
 			// default sortdirection is asc
 
 			// reverse if sortDirection is desc
-			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == gwapitypes.SortDirectionDesc {
-				for i, j := 0, len(expectedProject01CommitStatusDeliveries)-1; i < j; i, j = i+1, j-1 {
-					expectedProject01CommitStatusDeliveries[i], expectedProject01CommitStatusDeliveries[j] = expectedProject01CommitStatusDeliveries[j], expectedProject01CommitStatusDeliveries[i]
-				}
+				slices.Reverse(expectedProject01CommitStatusDeliveries)
 			}
 
 			respAllCommitStatusDeliveries := []*gwapitypes.CommitStatusDeliveryResponse{}
@@ -3501,10 +3481,10 @@ func testGetGroupRuns(t *testing.T, userRun bool) {
 					continue
 				}
 
-				if len(tt.phaseFilter) > 0 && !util.StringInSlice(tt.phaseFilter, string(run.Phase)) {
+				if len(tt.phaseFilter) > 0 && !slices.Contains(tt.phaseFilter, string(run.Phase)) {
 					continue
 				}
-				if len(tt.resultFilter) > 0 && !util.StringInSlice(tt.resultFilter, string(run.Result)) {
+				if len(tt.resultFilter) > 0 && !slices.Contains(tt.resultFilter, string(run.Result)) {
 					continue
 				}
 
@@ -3512,11 +3492,8 @@ func testGetGroupRuns(t *testing.T, userRun bool) {
 			}
 
 			// reverse if sortDirection is desc
-			// TODO(sgotti) use go 1.21 generics slices.Reverse when removing support for go < 1.21
 			if tt.sortDirection == gwapitypes.SortDirectionDesc || tt.sortDirection == "" {
-				for i, j := 0, len(expectedRuns)-1; i < j; i, j = i+1, j-1 {
-					expectedRuns[i], expectedRuns[j] = expectedRuns[j], expectedRuns[i]
-				}
+				slices.Reverse(expectedRuns)
 			}
 
 			respAllRuns := []*gwapitypes.RunsResponse{}


### PR DESCRIPTION
* go.mod use go 1.21 minimum version semantics.
* ci: use the current last two go versions: 1.21 and 1.22
* Dockerfile: use go 1.22 image
* replace util.StringInSlice with slices.Contains generic function.
* rename util.CompareStringSlice and util.CompareStringSliceNoOrder util util.EqualStringSlice... and use internally use slices.Equal generic function.
* use slices package sort functions instead of sort package ones.