### PR TITLE
validation: add min/max length check to name validation

### DIFF
--- a/internal/util/validation.go
+++ b/internal/util/validation.go
@@ -16,11 +16,18 @@ package util
 
 import (
 	"regexp"
+	"unicode/utf8"
 
 	"github.com/gofrs/uuid"
 	"github.com/sorintlab/errors"
 )
 
+const (
+	minNameCharacters = 1
+	maxNameCharacters = 40
+)
+
+var singleCharNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9]$`)
 var nameRegexp = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9]*([-]?[a-zA-Z0-9]+)+$`)
 
 var (
@@ -33,5 +40,15 @@ func ValidateName(s string) bool {
 	if _, err := uuid.FromString(s); err == nil {
 		return false
 	}
+
+	c := utf8.RuneCountInString(s)
+	if c < minNameCharacters || c > maxNameCharacters {
+		return false
+	}
+
+	if c == 1 {
+		return singleCharNameRegexp.MatchString(s)
+	}
+
 	return nameRegexp.MatchString(s)
 }

--- a/internal/util/validation_test.go
+++ b/internal/util/validation_test.go
@@ -22,6 +22,9 @@ import (
 
 var (
 	goodNames = []string{
+		"0",
+		"a",
+		"Z",
 		"bar",
 		"foo-bar",
 		"foo-bar-baz",
@@ -36,6 +39,9 @@ var (
 	}
 	badNames = []string{
 		"",
+		"-",
+		"È",
+		"Èà",
 		"foo bar",
 		" foo bar",
 		"foo bar ",
@@ -48,10 +54,11 @@ var (
 		"foo_bar",
 		"foo#bar",
 		"1foobar",
-		"cba7b810-9dad-11d1-80b4-00c04fd430c8",
-		"{cba7b810-9dad-11d1-80b4-00c04fd430c8}",
-		"urn:uuid:cba7b810-9dad-11d1-80b4-00c04fd430c8",
-		"cba7b8109dad11d180b400c04fd430c8",
+		"cba7b810-9dad-11d1-80b4-00c04fd430c8",   // uuid
+		"{cba7b810-9dad-11d1-80b4-00c04fd430c8}", // uuid
+		"urn:uuid:cba7b810-9dad-11d1-80b4-00c04fd430c8", // uuid
+		"cba7b8109dad11d180b400c04fd430c8",              // uuid
+		"abcdefghijklmnopqrstuvwxyz0123456789abcde",     // 41 ascii chars length
 	}
 )
 


### PR DESCRIPTION
* Accept names from 1 to 40 runes (utf-8 characters) length.
* For single char names use a dedicated validation regexp that accept only one digit or ascii char.