### PR TITLE
errors: split wrapped error from APIError message

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,8 @@ linters-settings:
       - .WithMessage(
       - .WithMessagef(
       - .WithStack(
-      - .NewDetailedError(
+      - .NewAPIError(
+      - .NewAPIErrorWrap(
     ignoreSigRegexps:
       - \.New.*Error\(
     ignorePackageGlobs:

--- a/internal/objectstorage/objectstorage.go
+++ b/internal/objectstorage/objectstorage.go
@@ -42,7 +42,7 @@ type ErrNotExist struct {
 
 func NewErrNotExist(err error, format string, args ...interface{}) error {
 	return &ErrNotExist{
-		util.NewWrapperError(err, format, args...),
+		util.NewWrapperError(err, util.WithWrapperErrorMsg(format, args...)),
 	}
 }
 

--- a/internal/services/configstore/action/action.go
+++ b/internal/services/configstore/action/action.go
@@ -52,7 +52,7 @@ func (h *ActionHandler) ResolveObjectID(tx *sql.Tx, objectKind types.ObjectKind,
 			return "", errors.WithStack(err)
 		}
 		if group == nil {
-			return "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("group with ref %q doesn't exists", ref))
+			return "", util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("group with ref %q doesn't exists", ref))
 		}
 		return group.ID, nil
 
@@ -62,11 +62,11 @@ func (h *ActionHandler) ResolveObjectID(tx *sql.Tx, objectKind types.ObjectKind,
 			return "", errors.WithStack(err)
 		}
 		if project == nil {
-			return "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with ref %q doesn't exists", ref))
+			return "", util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project with ref %q doesn't exists", ref))
 		}
 		return project.ID, nil
 
 	default:
-		return "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("unknown object kind %q", objectKind))
+		return "", util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("unknown object kind %q", objectKind))
 	}
 }

--- a/internal/services/configstore/action/maintenance.go
+++ b/internal/services/configstore/action/maintenance.go
@@ -109,10 +109,10 @@ func (h *ActionHandler) SetMaintenanceEnabled(ctx context.Context, enable bool) 
 		}
 
 		if enable && enabled {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("maintenance mode already enabled"))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("maintenance mode already enabled"))
 		}
 		if !enable && !enabled {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("maintenance mode already disabled"))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("maintenance mode already disabled"))
 		}
 
 		db := sq.DeleteFrom(maintenanceTableName)
@@ -142,7 +142,7 @@ func (h *ActionHandler) Export(ctx context.Context, w io.Writer) error {
 
 func (h *ActionHandler) Import(ctx context.Context, r io.Reader) error {
 	if !h.maintenanceMode {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("not in maintenance mode"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("not in maintenance mode"))
 	}
 
 	dbm := manager.NewDBManager(h.log, h.d, h.lf)

--- a/internal/services/configstore/action/org.go
+++ b/internal/services/configstore/action/org.go
@@ -69,7 +69,7 @@ func (h *ActionHandler) GetOrgMembers(ctx context.Context, req *GetOrgMembersReq
 			return errors.WithStack(err)
 		}
 		if org == nil {
-			return util.NewAPIError(util.ErrNotExist, errors.Errorf("org %q doesn't exist", req.OrgRef))
+			return util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("org %q doesn't exist", req.OrgRef))
 		}
 
 		dbOrgMembers, err = h.d.GetOrgMembers(tx, org.ID, req.StartUserName, limit, req.SortDirection)
@@ -110,7 +110,7 @@ func (h *ActionHandler) GetOrg(ctx context.Context, orgRef string) (*types.Organ
 	}
 
 	if org == nil {
-		return nil, util.NewAPIError(util.ErrNotExist, errors.Errorf("org %q doesn't exist", orgRef))
+		return nil, util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("org %q doesn't exist", orgRef))
 	}
 
 	return org, nil
@@ -177,13 +177,13 @@ type CreateOrgRequest struct {
 
 func (h *ActionHandler) CreateOrg(ctx context.Context, req *CreateOrgRequest) (*types.Organization, error) {
 	if req.Name == "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("organization name required"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("organization name required"))
 	}
 	if !util.ValidateName(req.Name) {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid organization name %q", req.Name))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid organization name %q", req.Name))
 	}
 	if !types.IsValidVisibility(req.Visibility) {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid organization visibility"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid organization visibility"))
 	}
 
 	var org *types.Organization
@@ -195,7 +195,7 @@ func (h *ActionHandler) CreateOrg(ctx context.Context, req *CreateOrgRequest) (*
 			return errors.WithStack(err)
 		}
 		if o != nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("org %q already exists", o.Name))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("org %q already exists", o.Name))
 		}
 
 		if req.CreatorUserID != "" {
@@ -204,7 +204,7 @@ func (h *ActionHandler) CreateOrg(ctx context.Context, req *CreateOrgRequest) (*
 				return errors.WithStack(err)
 			}
 			if user == nil {
-				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("creator user %q doesn't exist", req.CreatorUserID))
+				return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("creator user %q doesn't exist", req.CreatorUserID))
 			}
 		}
 
@@ -257,7 +257,7 @@ type UpdateOrgRequest struct {
 
 func (h *ActionHandler) UpdateOrg(ctx context.Context, orgRef string, req *UpdateOrgRequest) (*types.Organization, error) {
 	if !types.IsValidVisibility(req.Visibility) {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid organization visibility"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid organization visibility"))
 	}
 
 	var org *types.Organization
@@ -269,7 +269,7 @@ func (h *ActionHandler) UpdateOrg(ctx context.Context, orgRef string, req *Updat
 			return errors.WithStack(err)
 		}
 		if org == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("org %q not exists", orgRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("org %q not exists", orgRef))
 		}
 
 		org.Visibility = req.Visibility
@@ -298,7 +298,7 @@ func (h *ActionHandler) DeleteOrg(ctx context.Context, orgRef string) error {
 			return errors.WithStack(err)
 		}
 		if org == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("org %q doesn't exist", orgRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("org %q doesn't exist", orgRef))
 		}
 
 		if err := h.d.DeleteOrgMembersByOrgID(tx, org.ID); err != nil {
@@ -350,7 +350,7 @@ func (h *ActionHandler) DeleteOrg(ctx context.Context, orgRef string) error {
 // TODO(sgotti) handle invitation when implemented
 func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string, role types.MemberRole) (*types.OrganizationMember, error) {
 	if !types.IsValidMemberRole(role) {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid role %q", role))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid role %q", role))
 	}
 
 	var orgmember *types.OrganizationMember
@@ -361,7 +361,7 @@ func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string
 			return errors.WithStack(err)
 		}
 		if org == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("org %q doesn't exists", orgRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("org %q doesn't exists", orgRef))
 		}
 		// check existing user
 		user, err := h.d.GetUser(tx, userRef)
@@ -369,7 +369,7 @@ func (h *ActionHandler) AddOrgMember(ctx context.Context, orgRef, userRef string
 			return errors.WithStack(err)
 		}
 		if user == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exists", userRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user %q doesn't exists", userRef))
 		}
 
 		// fetch org member if it already exist
@@ -425,7 +425,7 @@ func (h *ActionHandler) RemoveOrgMember(ctx context.Context, orgRef, userRef str
 			return errors.WithStack(err)
 		}
 		if org == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("org %q doesn't exists", orgRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("org %q doesn't exists", orgRef))
 		}
 		// check existing user
 		user, err := h.d.GetUser(tx, userRef)
@@ -433,7 +433,7 @@ func (h *ActionHandler) RemoveOrgMember(ctx context.Context, orgRef, userRef str
 			return errors.WithStack(err)
 		}
 		if user == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exists", userRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user %q doesn't exists", userRef))
 		}
 
 		// check that org member exists
@@ -442,7 +442,7 @@ func (h *ActionHandler) RemoveOrgMember(ctx context.Context, orgRef, userRef str
 			return errors.WithStack(err)
 		}
 		if orgmember == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("orgmember for org %q, user %q doesn't exists", orgRef, userRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("orgmember for org %q, user %q doesn't exists", orgRef, userRef))
 		}
 
 		if err := h.d.DeleteOrganizationMember(tx, orgmember.ID); err != nil {
@@ -466,7 +466,7 @@ func (h *ActionHandler) GetOrgInvitations(ctx context.Context, orgRef string) ([
 			return errors.WithStack(err)
 		}
 		if org == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("org %q doesn't exist", orgRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("org %q doesn't exist", orgRef))
 		}
 
 		orgInvitations, err = h.d.GetOrgInvitations(tx, org.ID)
@@ -492,7 +492,7 @@ func (h *ActionHandler) GetOrgInvitationByUserRef(ctx context.Context, orgRef, u
 			return errors.WithStack(err)
 		}
 		if org == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("organization %q doesn't exist", orgRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("organization %q doesn't exist", orgRef))
 		}
 		// check existing user
 		user, err := h.d.GetUser(tx, userRef)
@@ -500,7 +500,7 @@ func (h *ActionHandler) GetOrgInvitationByUserRef(ctx context.Context, orgRef, u
 			return errors.WithStack(err)
 		}
 		if user == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exists", userRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user %q doesn't exists", userRef))
 		}
 
 		orgInvitation, err = h.d.GetOrgInvitationByOrgUserID(tx, org.ID, user.ID)
@@ -515,7 +515,7 @@ func (h *ActionHandler) GetOrgInvitationByUserRef(ctx context.Context, orgRef, u
 	}
 
 	if orgInvitation == nil {
-		return nil, util.NewAPIError(util.ErrNotExist, errors.Errorf("invitation for org %q user %q doesn't exist", orgRef, userRef))
+		return nil, util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("invitation for org %q user %q doesn't exist", orgRef, userRef))
 	}
 
 	return orgInvitation, nil
@@ -529,13 +529,13 @@ type CreateOrgInvitationRequest struct {
 
 func (h *ActionHandler) CreateOrgInvitation(ctx context.Context, req *CreateOrgInvitationRequest) (*types.OrgInvitation, error) {
 	if req.OrganizationRef == "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("organization ref required"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("organization ref required"))
 	}
 	if req.UserRef == "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user ref required"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user ref required"))
 	}
 	if !types.IsValidMemberRole(req.Role) {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid role"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid role"))
 	}
 
 	var orgInvitation *types.OrgInvitation
@@ -547,7 +547,7 @@ func (h *ActionHandler) CreateOrgInvitation(ctx context.Context, req *CreateOrgI
 			return errors.WithStack(err)
 		}
 		if org == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("organization %q doesn't exist", req.OrganizationRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("organization %q doesn't exist", req.OrganizationRef))
 		}
 
 		user, err := h.d.GetUser(tx, req.UserRef)
@@ -555,7 +555,7 @@ func (h *ActionHandler) CreateOrgInvitation(ctx context.Context, req *CreateOrgI
 			return errors.WithStack(err)
 		}
 		if user == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exist", req.UserRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user %q doesn't exist", req.UserRef))
 		}
 
 		// check duplicate org invitation
@@ -564,7 +564,7 @@ func (h *ActionHandler) CreateOrgInvitation(ctx context.Context, req *CreateOrgI
 			return errors.WithStack(err)
 		}
 		if curOrgInvitation != nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invitation already exists"))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invitation already exists"))
 		}
 
 		orgInvitation = types.NewOrgInvitation(tx)
@@ -592,7 +592,7 @@ func (h *ActionHandler) DeleteOrgInvitation(ctx context.Context, orgRef string, 
 			return errors.WithStack(err)
 		}
 		if org == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("org %q doesn't exists", orgRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("org %q doesn't exists", orgRef))
 		}
 		// check existing user
 		user, err := h.d.GetUser(tx, userRef)
@@ -600,7 +600,7 @@ func (h *ActionHandler) DeleteOrgInvitation(ctx context.Context, orgRef string, 
 			return errors.WithStack(err)
 		}
 		if user == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exists", userRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user %q doesn't exists", userRef))
 		}
 
 		// check org invitation exists
@@ -609,7 +609,7 @@ func (h *ActionHandler) DeleteOrgInvitation(ctx context.Context, orgRef string, 
 			return errors.WithStack(err)
 		}
 		if orgInvitation == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invitation for org %q, user %q doesn't exists", orgRef, userRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invitation for org %q, user %q doesn't exists", orgRef, userRef))
 		}
 
 		if err := h.d.DeleteOrgInvitation(tx, orgInvitation.ID); err != nil {
@@ -642,7 +642,7 @@ func (h *ActionHandler) OrgInvitationAction(ctx context.Context, req *OrgInvitat
 			return errors.WithStack(err)
 		}
 		if org == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("org %q doesn't exists", req.OrgRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("org %q doesn't exists", req.OrgRef))
 		}
 		// check existing user
 		user, err := h.d.GetUser(tx, req.UserRef)
@@ -650,7 +650,7 @@ func (h *ActionHandler) OrgInvitationAction(ctx context.Context, req *OrgInvitat
 			return errors.WithStack(err)
 		}
 		if user == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exists", req.UserRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user %q doesn't exists", req.UserRef))
 		}
 
 		// check org invitation exists
@@ -659,7 +659,7 @@ func (h *ActionHandler) OrgInvitationAction(ctx context.Context, req *OrgInvitat
 			return errors.WithStack(err)
 		}
 		if orgInvitation == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invitation for org %q, user %q doesn't exists", req.OrgRef, req.UserRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invitation for org %q, user %q doesn't exists", req.OrgRef, req.UserRef))
 		}
 
 		if req.Action == csapitypes.Accept {

--- a/internal/services/configstore/action/project.go
+++ b/internal/services/configstore/action/project.go
@@ -66,35 +66,35 @@ func (h *ActionHandler) projectDynamicData(tx *sql.Tx, project *types.Project) (
 
 func (h *ActionHandler) ValidateProjectReq(ctx context.Context, req *CreateUpdateProjectRequest) error {
 	if req.Name == "" {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project name required"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project name required"))
 	}
 	if !util.ValidateName(req.Name) {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid project name %q", req.Name))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid project name %q", req.Name))
 	}
 	if req.Parent.ID == "" {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project parent id required"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project parent id required"))
 	}
 	if req.Parent.Kind != types.ObjectKindProjectGroup {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid project parent kind %q", req.Parent.Kind))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid project parent kind %q", req.Parent.Kind))
 	}
 	if !types.IsValidVisibility(req.Visibility) {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid project visibility"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid project visibility"))
 	}
 	if !types.IsValidRemoteRepositoryConfigType(req.RemoteRepositoryConfigType) {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid project remote repository config type %q", req.RemoteRepositoryConfigType))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid project remote repository config type %q", req.RemoteRepositoryConfigType))
 	}
 	if req.RemoteRepositoryConfigType == types.RemoteRepositoryConfigTypeRemoteSource {
 		if req.RemoteSourceID == "" {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("empty remote source id"))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("empty remote source id"))
 		}
 		if req.LinkedAccountID == "" {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("empty linked account id"))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("empty linked account id"))
 		}
 		if req.RepositoryID == "" {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("empty remote repository id"))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("empty remote repository id"))
 		}
 		if req.RepositoryPath == "" {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("empty remote repository path"))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("empty remote repository path"))
 		}
 	}
 	return nil
@@ -117,7 +117,7 @@ func (h *ActionHandler) GetProject(ctx context.Context, projectRef string) (*Get
 		}
 
 		if project == nil {
-			return util.NewAPIError(util.ErrNotExist, errors.Errorf("project %q doesn't exist", projectRef))
+			return util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("project %q doesn't exist", projectRef))
 		}
 
 		projectDynamicData, err = h.projectDynamicData(tx, project)
@@ -165,7 +165,7 @@ func (h *ActionHandler) CreateProject(ctx context.Context, req *CreateUpdateProj
 			return errors.WithStack(err)
 		}
 		if group == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project group with id %q doesn't exist", req.Parent.ID))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project group with id %q doesn't exist", req.Parent.ID))
 		}
 		req.Parent.ID = group.ID
 
@@ -174,7 +174,7 @@ func (h *ActionHandler) CreateProject(ctx context.Context, req *CreateUpdateProj
 			return errors.WithStack(err)
 		}
 		if ownerType == types.ObjectKindUser && req.MembersCanPerformRunActions {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot set MembersCanPerformRunActions on an user project."))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("cannot set MembersCanPerformRunActions on an user project."))
 		}
 
 		groupPath, err := h.d.GetProjectGroupPath(tx, group)
@@ -189,7 +189,7 @@ func (h *ActionHandler) CreateProject(ctx context.Context, req *CreateUpdateProj
 			return errors.WithStack(err)
 		}
 		if p != nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with name %q, path %q already exists", p.Name, pp))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project with name %q, path %q already exists", p.Name, pp))
 		}
 
 		if req.RemoteRepositoryConfigType == types.RemoteRepositoryConfigTypeRemoteSource {
@@ -198,7 +198,7 @@ func (h *ActionHandler) CreateProject(ctx context.Context, req *CreateUpdateProj
 				return errors.Wrapf(err, "failed to get user with linked account id %q", req.LinkedAccountID)
 			}
 			if la == nil {
-				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("linked account id %q doesn't exist", req.LinkedAccountID))
+				return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("linked account id %q doesn't exist", req.LinkedAccountID))
 			}
 
 			user, err := h.d.GetUserByID(tx, la.UserID)
@@ -206,12 +206,12 @@ func (h *ActionHandler) CreateProject(ctx context.Context, req *CreateUpdateProj
 				return errors.Wrapf(err, "failed to get user with linked account id %q", req.LinkedAccountID)
 			}
 			if user == nil {
-				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user for linked account %q doesn't exist", req.LinkedAccountID))
+				return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user for linked account %q doesn't exist", req.LinkedAccountID))
 			}
 
 			// check that the linked account matches the remote source
 			if la.RemoteSourceID != req.RemoteSourceID {
-				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("linked account id %q remote source %q different than project remote source %q", req.LinkedAccountID, la.RemoteSourceID, req.RemoteSourceID))
+				return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("linked account id %q remote source %q different than project remote source %q", req.LinkedAccountID, la.RemoteSourceID, req.RemoteSourceID))
 			}
 		}
 
@@ -268,7 +268,7 @@ func (h *ActionHandler) UpdateProject(ctx context.Context, curProjectRef string,
 			return errors.WithStack(err)
 		}
 		if project == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with ref %q doesn't exist", curProjectRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project with ref %q doesn't exist", curProjectRef))
 		}
 
 		// check parent project group exists
@@ -277,7 +277,7 @@ func (h *ActionHandler) UpdateProject(ctx context.Context, curProjectRef string,
 			return errors.WithStack(err)
 		}
 		if group == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project group with id %q doesn't exist", req.Parent.ID))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project group with id %q doesn't exist", req.Parent.ID))
 		}
 		req.Parent.ID = group.ID
 
@@ -286,7 +286,7 @@ func (h *ActionHandler) UpdateProject(ctx context.Context, curProjectRef string,
 			return errors.WithStack(err)
 		}
 		if ownerType == types.ObjectKindUser && req.MembersCanPerformRunActions {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot set MembersCanPerformRunActions on an user project."))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("cannot set MembersCanPerformRunActions on an user project."))
 		}
 
 		groupPath, err := h.d.GetProjectGroupPath(tx, group)
@@ -302,7 +302,7 @@ func (h *ActionHandler) UpdateProject(ctx context.Context, curProjectRef string,
 				return errors.WithStack(err)
 			}
 			if ap != nil {
-				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with name %q, path %q already exists", req.Name, pp))
+				return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project with name %q, path %q already exists", req.Name, pp))
 			}
 		}
 
@@ -313,7 +313,7 @@ func (h *ActionHandler) UpdateProject(ctx context.Context, curProjectRef string,
 				return errors.WithStack(err)
 			}
 			if curGroup == nil {
-				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project group with id %q doesn't exist", project.Parent.ID))
+				return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project group with id %q doesn't exist", project.Parent.ID))
 			}
 		}
 
@@ -323,7 +323,7 @@ func (h *ActionHandler) UpdateProject(ctx context.Context, curProjectRef string,
 				return errors.Wrapf(err, "failed to get user with linked account id %q", req.LinkedAccountID)
 			}
 			if la == nil {
-				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("linked account id %q doesn't exist", req.LinkedAccountID))
+				return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("linked account id %q doesn't exist", req.LinkedAccountID))
 			}
 
 			user, err := h.d.GetUserByID(tx, la.UserID)
@@ -331,12 +331,12 @@ func (h *ActionHandler) UpdateProject(ctx context.Context, curProjectRef string,
 				return errors.Wrapf(err, "failed to get user with linked account id %q", req.LinkedAccountID)
 			}
 			if user == nil {
-				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user for linked account %q doesn't exist", req.LinkedAccountID))
+				return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user for linked account %q doesn't exist", req.LinkedAccountID))
 			}
 
 			// check that the linked account matches the remote source
 			if la.RemoteSourceID != req.RemoteSourceID {
-				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("linked account id %q remote source %q different than project remote source %q", req.LinkedAccountID, la.RemoteSourceID, req.RemoteSourceID))
+				return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("linked account id %q remote source %q different than project remote source %q", req.LinkedAccountID, la.RemoteSourceID, req.RemoteSourceID))
 			}
 		}
 
@@ -381,7 +381,7 @@ func (h *ActionHandler) DeleteProject(ctx context.Context, projectRef string) er
 			return errors.WithStack(err)
 		}
 		if project == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("project %q doesn't exist", projectRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project %q doesn't exist", projectRef))
 		}
 
 		// TODO(sgotti) implement childs garbage collection

--- a/internal/services/configstore/action/remotesource.go
+++ b/internal/services/configstore/action/remotesource.go
@@ -36,7 +36,7 @@ func (h *ActionHandler) GetRemoteSource(ctx context.Context, remoteSourceRef str
 	}
 
 	if remoteSource == nil {
-		return nil, util.NewAPIError(util.ErrNotExist, errors.Errorf("remotesource %q doesn't exist", remoteSourceRef))
+		return nil, util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("remotesource %q doesn't exist", remoteSourceRef))
 	}
 
 	return remoteSource, nil
@@ -90,35 +90,35 @@ func (h *ActionHandler) GetRemoteSources(ctx context.Context, req *GetRemoteSour
 
 func (h *ActionHandler) ValidateRemoteSourceReq(ctx context.Context, req *CreateUpdateRemoteSourceRequest) error {
 	if req.Name == "" {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource name required"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remotesource name required"))
 	}
 	if !util.ValidateName(req.Name) {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid remotesource name %q", req.Name))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid remotesource name %q", req.Name))
 	}
 
 	if req.Name == "" {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource name required"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remotesource name required"))
 	}
 	if req.APIURL == "" {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource api url required"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remotesource api url required"))
 	}
 	if req.Type == "" {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource type required"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remotesource type required"))
 	}
 	if req.AuthType == "" {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource auth type required"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remotesource auth type required"))
 	}
 
 	// validate if the remotesource type supports the required auth type
 	if !types.SourceSupportsAuthType(types.RemoteSourceType(req.Type), types.RemoteSourceAuthType(req.AuthType)) {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource type %q doesn't support auth type %q", req.Type, req.AuthType))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remotesource type %q doesn't support auth type %q", req.Type, req.AuthType))
 	}
 	if req.AuthType == types.RemoteSourceAuthTypeOauth2 {
 		if req.Oauth2ClientID == "" {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource oauth2clientid required for auth type %q", types.RemoteSourceAuthTypeOauth2))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remotesource oauth2clientid required for auth type %q", types.RemoteSourceAuthTypeOauth2))
 		}
 		if req.Oauth2ClientSecret == "" {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource oauth2clientsecret required for auth type %q", types.RemoteSourceAuthTypeOauth2))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remotesource oauth2clientsecret required for auth type %q", types.RemoteSourceAuthTypeOauth2))
 		}
 	}
 
@@ -152,7 +152,7 @@ func (h *ActionHandler) CreateRemoteSource(ctx context.Context, req *CreateUpdat
 			return errors.WithStack(err)
 		}
 		if curRemoteSource != nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource %q already exists", req.Name))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remotesource %q already exists", req.Name))
 		}
 
 		remoteSource = types.NewRemoteSource(tx)
@@ -196,7 +196,7 @@ func (h *ActionHandler) UpdateRemoteSource(ctx context.Context, remoteSourceRef 
 			return errors.WithStack(err)
 		}
 		if remoteSource == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource with ref %q doesn't exist", remoteSourceRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remotesource with ref %q doesn't exist", remoteSourceRef))
 		}
 
 		if remoteSource.Name != req.Name {
@@ -206,7 +206,7 @@ func (h *ActionHandler) UpdateRemoteSource(ctx context.Context, remoteSourceRef 
 				return errors.WithStack(err)
 			}
 			if u != nil {
-				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource %q already exists", u.Name))
+				return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remotesource %q already exists", u.Name))
 			}
 		}
 
@@ -243,7 +243,7 @@ func (h *ActionHandler) DeleteRemoteSource(ctx context.Context, remoteSourceName
 			return errors.WithStack(err)
 		}
 		if remoteSource == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource %q doesn't exist", remoteSourceName))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remotesource %q doesn't exist", remoteSourceName))
 		}
 
 		if err := h.d.DeleteRemoteSource(tx, remoteSource.ID); err != nil {
@@ -278,7 +278,7 @@ func (h *ActionHandler) GetLinkedAccounts(ctx context.Context, req *GetLinkedAcc
 				return errors.WithStack(err)
 			}
 			if la == nil {
-				return util.NewAPIError(util.ErrNotExist, errors.Errorf("linked account with remote user %q for remote source %q token doesn't exist", remoteUserID, remoteSourceID))
+				return util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("linked account with remote user %q for remote source %q token doesn't exist", remoteUserID, remoteSourceID))
 			}
 
 			linkedAccounts = []*types.LinkedAccount{la}

--- a/internal/services/configstore/action/secret.go
+++ b/internal/services/configstore/action/secret.go
@@ -36,7 +36,7 @@ func (h *ActionHandler) GetSecret(ctx context.Context, secretID string) (*types.
 	}
 
 	if secret == nil {
-		return nil, util.NewAPIError(util.ErrNotExist, errors.Errorf("secret %q doesn't exist", secretID))
+		return nil, util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("secret %q doesn't exist", secretID))
 	}
 
 	return secret, nil
@@ -88,28 +88,28 @@ func (h *ActionHandler) GetSecrets(ctx context.Context, parentKind types.ObjectK
 
 func (h *ActionHandler) ValidateSecretReq(ctx context.Context, req *CreateUpdateSecretRequest) error {
 	if req.Name == "" {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("secret name required"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("secret name required"))
 	}
 	if !util.ValidateName(req.Name) {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid secret name %q", req.Name))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid secret name %q", req.Name))
 	}
 	if req.Type != types.SecretTypeInternal {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid secret type %q", req.Type))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid secret type %q", req.Type))
 	}
 	switch req.Type {
 	case types.SecretTypeInternal:
 		if len(req.Data) == 0 {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("empty secret data"))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("empty secret data"))
 		}
 	}
 	if req.Parent.Kind == "" {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("secret parent kind required"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("secret parent kind required"))
 	}
 	if req.Parent.ID == "" {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("secret parentid required"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("secret parentid required"))
 	}
 	if req.Parent.Kind != types.ObjectKindProject && req.Parent.Kind != types.ObjectKindProjectGroup {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid secret parent kind %q", req.Parent.Kind))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid secret parent kind %q", req.Parent.Kind))
 	}
 
 	return nil
@@ -144,7 +144,7 @@ func (h *ActionHandler) CreateSecret(ctx context.Context, req *CreateUpdateSecre
 			return errors.WithStack(err)
 		}
 		if s != nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("secret with name %q for %s with id %q already exists", req.Name, req.Parent.Kind, req.Parent.ID))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("secret with name %q for %s with id %q already exists", req.Name, req.Parent.Kind, req.Parent.ID))
 		}
 
 		secret = types.NewSecret(tx)
@@ -188,7 +188,7 @@ func (h *ActionHandler) UpdateSecret(ctx context.Context, curSecretName string, 
 			return errors.WithStack(err)
 		}
 		if secret == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("secret with name %q for %s with id %q doesn't exists", curSecretName, req.Parent.Kind, req.Parent.ID))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("secret with name %q for %s with id %q doesn't exists", curSecretName, req.Parent.Kind, req.Parent.ID))
 		}
 
 		if secret.Name != req.Name {
@@ -198,7 +198,7 @@ func (h *ActionHandler) UpdateSecret(ctx context.Context, curSecretName string, 
 				return errors.WithStack(err)
 			}
 			if s != nil {
-				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("secret with name %q for %s with id %q already exists", req.Name, req.Parent.Kind, req.Parent.ID))
+				return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("secret with name %q for %s with id %q already exists", req.Name, req.Parent.Kind, req.Parent.ID))
 			}
 		}
 
@@ -236,7 +236,7 @@ func (h *ActionHandler) DeleteSecret(ctx context.Context, parentKind types.Objec
 			return errors.WithStack(err)
 		}
 		if secret == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("secret with name %q doesn't exist", secretName))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("secret with name %q doesn't exist", secretName))
 		}
 
 		if err := h.d.DeleteSecret(tx, secret.ID); err != nil {

--- a/internal/services/configstore/action/user.go
+++ b/internal/services/configstore/action/user.go
@@ -50,7 +50,7 @@ func (h *ActionHandler) UserQuery(ctx context.Context, req *UserQueryRequest) (*
 				return errors.WithStack(err)
 			}
 			if user == nil {
-				return util.NewAPIError(util.ErrNotExist, errors.Errorf("user with required token doesn't exist"))
+				return util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("user with required token doesn't exist"))
 			}
 			return nil
 		})
@@ -66,7 +66,7 @@ func (h *ActionHandler) UserQuery(ctx context.Context, req *UserQueryRequest) (*
 				return errors.WithStack(err)
 			}
 			if user == nil {
-				return util.NewAPIError(util.ErrNotExist, errors.Errorf("user with linked account %q doesn't exist", req.LinkedAccountID))
+				return util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("user with linked account %q doesn't exist", req.LinkedAccountID))
 			}
 			return nil
 		})
@@ -81,7 +81,7 @@ func (h *ActionHandler) UserQuery(ctx context.Context, req *UserQueryRequest) (*
 				return errors.WithStack(err)
 			}
 			if la == nil {
-				return util.NewAPIError(util.ErrNotExist, errors.Errorf("linked account with remote user %q for remote source %q doesn't exist", req.RemoteUserID, req.RemoteSourceID))
+				return util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("linked account with remote user %q for remote source %q doesn't exist", req.RemoteUserID, req.RemoteSourceID))
 			}
 
 			user, err = h.d.GetUser(tx, la.UserID)
@@ -89,7 +89,7 @@ func (h *ActionHandler) UserQuery(ctx context.Context, req *UserQueryRequest) (*
 				return errors.WithStack(err)
 			}
 			if user == nil {
-				return util.NewAPIError(util.ErrNotExist, errors.Errorf("user with remote user %q for remote source %q doesn't exist", req.RemoteUserID, req.RemoteSourceID))
+				return util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("user with remote user %q for remote source %q doesn't exist", req.RemoteUserID, req.RemoteSourceID))
 			}
 			return nil
 		})
@@ -116,7 +116,7 @@ func (h *ActionHandler) GetUser(ctx context.Context, userRef string) (*types.Use
 	}
 
 	if user == nil {
-		return nil, util.NewAPIError(util.ErrNotExist, errors.Errorf("user %q doesn't exist", userRef))
+		return nil, util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("user %q doesn't exist", userRef))
 	}
 
 	return user, nil
@@ -176,10 +176,10 @@ type CreateUserRequest struct {
 
 func (h *ActionHandler) CreateUser(ctx context.Context, req *CreateUserRequest) (*types.User, error) {
 	if req.UserName == "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user name required"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user name required"))
 	}
 	if !util.ValidateName(req.UserName) {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid user name %q", req.UserName))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid user name %q", req.UserName))
 	}
 
 	var user *types.User
@@ -192,7 +192,7 @@ func (h *ActionHandler) CreateUser(ctx context.Context, req *CreateUserRequest) 
 			return errors.WithStack(err)
 		}
 		if u != nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user with name %q already exists", u.Name))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user with name %q already exists", u.Name))
 		}
 
 		var rs *types.RemoteSource
@@ -202,14 +202,14 @@ func (h *ActionHandler) CreateUser(ctx context.Context, req *CreateUserRequest) 
 				return errors.WithStack(err)
 			}
 			if rs == nil {
-				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remote source %q doesn't exist", req.CreateUserLARequest.RemoteSourceName))
+				return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remote source %q doesn't exist", req.CreateUserLARequest.RemoteSourceName))
 			}
 			la, err := h.d.GetLinkedAccountByRemoteUserIDandSource(tx, req.CreateUserLARequest.RemoteUserID, rs.ID)
 			if err != nil {
 				return errors.Wrapf(err, "failed to get linked account for remote user id %q and remote source %q", req.CreateUserLARequest.RemoteUserID, rs.ID)
 			}
 			if la != nil {
-				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("linked account for remote user id %q for remote source %q already exists", req.CreateUserLARequest.RemoteUserID, req.CreateUserLARequest.RemoteSourceName))
+				return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("linked account for remote user id %q for remote source %q already exists", req.CreateUserLARequest.RemoteUserID, req.CreateUserLARequest.RemoteSourceName))
 			}
 		}
 
@@ -269,7 +269,7 @@ func (h *ActionHandler) DeleteUser(ctx context.Context, userRef string) error {
 			return errors.WithStack(err)
 		}
 		if user == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exist", userRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user %q doesn't exist", userRef))
 		}
 
 		if err := h.d.DeleteOrgMembersByUserID(tx, user.ID); err != nil {
@@ -318,7 +318,7 @@ func (h *ActionHandler) UpdateUser(ctx context.Context, req *UpdateUserRequest) 
 			return errors.WithStack(err)
 		}
 		if user == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exist", req.UserRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user %q doesn't exist", req.UserRef))
 		}
 
 		if req.UserName != "" {
@@ -328,7 +328,7 @@ func (h *ActionHandler) UpdateUser(ctx context.Context, req *UpdateUserRequest) 
 				return errors.WithStack(err)
 			}
 			if u != nil {
-				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user with name %q already exists", u.Name))
+				return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user with name %q already exists", u.Name))
 			}
 
 			user.Name = req.UserName
@@ -349,7 +349,7 @@ func (h *ActionHandler) UpdateUser(ctx context.Context, req *UpdateUserRequest) 
 
 func (h *ActionHandler) GetUserLinkedAccounts(ctx context.Context, userRef string) ([]*types.LinkedAccount, error) {
 	if userRef == "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user ref required"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user ref required"))
 	}
 
 	var linkedAccounts []*types.LinkedAccount
@@ -359,7 +359,7 @@ func (h *ActionHandler) GetUserLinkedAccounts(ctx context.Context, userRef strin
 			return errors.WithStack(err)
 		}
 		if user == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exist", userRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user %q doesn't exist", userRef))
 		}
 
 		linkedAccounts, err = h.d.GetUserLinkedAccounts(tx, user.ID)
@@ -390,10 +390,10 @@ type CreateUserLARequest struct {
 
 func (h *ActionHandler) CreateUserLA(ctx context.Context, req *CreateUserLARequest) (*types.LinkedAccount, error) {
 	if req.UserRef == "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user ref required"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user ref required"))
 	}
 	if req.RemoteSourceName == "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("remote source name required"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remote source name required"))
 	}
 
 	var la *types.LinkedAccount
@@ -403,7 +403,7 @@ func (h *ActionHandler) CreateUserLA(ctx context.Context, req *CreateUserLAReque
 			return errors.WithStack(err)
 		}
 		if user == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exist", req.UserRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user %q doesn't exist", req.UserRef))
 		}
 
 		rs, err := h.d.GetRemoteSourceByName(tx, req.RemoteSourceName)
@@ -411,7 +411,7 @@ func (h *ActionHandler) CreateUserLA(ctx context.Context, req *CreateUserLAReque
 			return errors.WithStack(err)
 		}
 		if rs == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remote source %q doesn't exist", req.RemoteSourceName))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remote source %q doesn't exist", req.RemoteSourceName))
 		}
 
 		la, err = h.d.GetLinkedAccountByRemoteUserIDandSource(tx, req.RemoteUserID, rs.ID)
@@ -419,7 +419,7 @@ func (h *ActionHandler) CreateUserLA(ctx context.Context, req *CreateUserLAReque
 			return errors.Wrapf(err, "failed to get linked account for remote user id %q and remote source %q", req.RemoteUserID, rs.ID)
 		}
 		if la != nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("linked account for remote user id %q for remote source %q already exists", req.RemoteUserID, req.RemoteSourceName))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("linked account for remote user id %q for remote source %q already exists", req.RemoteUserID, req.RemoteSourceName))
 		}
 
 		la = types.NewLinkedAccount(tx)
@@ -447,10 +447,10 @@ func (h *ActionHandler) CreateUserLA(ctx context.Context, req *CreateUserLAReque
 
 func (h *ActionHandler) DeleteUserLA(ctx context.Context, userRef, laID string) error {
 	if userRef == "" {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user ref  required"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user ref  required"))
 	}
 	if laID == "" {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user linked account id required"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user linked account id required"))
 	}
 
 	var user *types.User
@@ -462,7 +462,7 @@ func (h *ActionHandler) DeleteUserLA(ctx context.Context, userRef, laID string) 
 			return errors.WithStack(err)
 		}
 		if user == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exist", userRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user %q doesn't exist", userRef))
 		}
 
 		la, err := h.d.GetLinkedAccount(tx, laID)
@@ -470,12 +470,12 @@ func (h *ActionHandler) DeleteUserLA(ctx context.Context, userRef, laID string) 
 			return errors.WithStack(err)
 		}
 		if la == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("linked account id %q for user %q doesn't exist", laID, userRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("linked account id %q for user %q doesn't exist", laID, userRef))
 		}
 
 		// check that the linked account belongs to the right user
 		if user.ID != la.UserID {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("linked account id %q for user %q doesn't exist", laID, userRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("linked account id %q for user %q doesn't exist", laID, userRef))
 		}
 
 		if err := h.d.DeleteLinkedAccount(tx, la.ID); err != nil {
@@ -505,7 +505,7 @@ type UpdateUserLARequest struct {
 
 func (h *ActionHandler) UpdateUserLA(ctx context.Context, req *UpdateUserLARequest) (*types.LinkedAccount, error) {
 	if req.UserRef == "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user ref required"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user ref required"))
 	}
 
 	var la *types.LinkedAccount
@@ -515,7 +515,7 @@ func (h *ActionHandler) UpdateUserLA(ctx context.Context, req *UpdateUserLAReque
 			return errors.WithStack(err)
 		}
 		if user == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exist", req.UserRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user %q doesn't exist", req.UserRef))
 		}
 
 		la, err = h.d.GetLinkedAccount(tx, req.LinkedAccountID)
@@ -523,12 +523,12 @@ func (h *ActionHandler) UpdateUserLA(ctx context.Context, req *UpdateUserLAReque
 			return errors.WithStack(err)
 		}
 		if la == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("linked account id %q for user %q doesn't exist", req.LinkedAccountID, req.UserRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("linked account id %q for user %q doesn't exist", req.LinkedAccountID, req.UserRef))
 		}
 
 		// check that the linked account belongs to the right user
 		if user.ID != la.UserID {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("linked account id %q for user %q doesn't exist", req.LinkedAccountID, req.UserRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("linked account id %q for user %q doesn't exist", req.LinkedAccountID, req.UserRef))
 		}
 
 		rs, err := h.d.GetRemoteSource(tx, la.RemoteSourceID)
@@ -536,7 +536,7 @@ func (h *ActionHandler) UpdateUserLA(ctx context.Context, req *UpdateUserLAReque
 			return errors.WithStack(err)
 		}
 		if rs == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("remote source with id %q doesn't exist", la.RemoteSourceID))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remote source with id %q doesn't exist", la.RemoteSourceID))
 		}
 
 		la.RemoteUserID = req.RemoteUserID
@@ -561,7 +561,7 @@ func (h *ActionHandler) UpdateUserLA(ctx context.Context, req *UpdateUserLAReque
 
 func (h *ActionHandler) GetUserTokens(ctx context.Context, userRef string) ([]*types.UserToken, error) {
 	if userRef == "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user ref required"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user ref required"))
 	}
 
 	var tokens []*types.UserToken
@@ -571,7 +571,7 @@ func (h *ActionHandler) GetUserTokens(ctx context.Context, userRef string) ([]*t
 			return errors.WithStack(err)
 		}
 		if user == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exist", userRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user %q doesn't exist", userRef))
 		}
 
 		tokens, err = h.d.GetUserTokens(tx, user.ID)
@@ -590,10 +590,10 @@ func (h *ActionHandler) GetUserTokens(ctx context.Context, userRef string) ([]*t
 
 func (h *ActionHandler) CreateUserToken(ctx context.Context, userRef, tokenName string) (*types.UserToken, error) {
 	if userRef == "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user ref required"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user ref required"))
 	}
 	if tokenName == "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("token name required"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("token name required"))
 	}
 
 	var token *types.UserToken
@@ -603,7 +603,7 @@ func (h *ActionHandler) CreateUserToken(ctx context.Context, userRef, tokenName 
 			return errors.WithStack(err)
 		}
 		if user == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exist", userRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user %q doesn't exist", userRef))
 		}
 
 		userToken, err := h.d.GetUserToken(tx, user.ID, tokenName)
@@ -612,7 +612,7 @@ func (h *ActionHandler) CreateUserToken(ctx context.Context, userRef, tokenName 
 		}
 
 		if userToken != nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("token %q for user %q already exists", tokenName, userRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("token %q for user %q already exists", tokenName, userRef))
 		}
 
 		token = types.NewUserToken(tx)
@@ -635,10 +635,10 @@ func (h *ActionHandler) CreateUserToken(ctx context.Context, userRef, tokenName 
 
 func (h *ActionHandler) DeleteUserToken(ctx context.Context, userRef, tokenName string) error {
 	if userRef == "" {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user ref required"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user ref required"))
 	}
 	if tokenName == "" {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("token name required"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("token name required"))
 	}
 
 	err := h.d.Do(ctx, func(tx *sql.Tx) error {
@@ -647,7 +647,7 @@ func (h *ActionHandler) DeleteUserToken(ctx context.Context, userRef, tokenName 
 			return errors.WithStack(err)
 		}
 		if user == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exist", userRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user %q doesn't exist", userRef))
 		}
 
 		userToken, err := h.d.GetUserToken(tx, user.ID, tokenName)
@@ -656,7 +656,7 @@ func (h *ActionHandler) DeleteUserToken(ctx context.Context, userRef, tokenName 
 		}
 
 		if userToken == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("token %q for user %q doesn't exist", tokenName, userRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("token %q for user %q doesn't exist", tokenName, userRef))
 		}
 
 		if err := h.d.DeleteUserToken(tx, userToken.ID); err != nil {
@@ -694,14 +694,14 @@ func (h *ActionHandler) GetUserOrg(ctx context.Context, userRef, orgRef string) 
 			return errors.WithStack(err)
 		}
 		if user == nil {
-			return util.NewAPIError(util.ErrNotExist, errors.Errorf("user %q doesn't exist", userRef))
+			return util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("user %q doesn't exist", userRef))
 		}
 		org, err := h.d.GetOrg(tx, orgRef)
 		if err != nil {
 			return errors.WithStack(err)
 		}
 		if org == nil {
-			return util.NewAPIError(util.ErrNotExist, errors.Errorf("org %q doesn't exist", orgRef))
+			return util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("org %q doesn't exist", orgRef))
 		}
 
 		dbUserOrg, err = h.d.GetUserOrg(tx, user.ID, org.ID)
@@ -712,7 +712,7 @@ func (h *ActionHandler) GetUserOrg(ctx context.Context, userRef, orgRef string) 
 	}
 
 	if dbUserOrg == nil {
-		return nil, util.NewAPIError(util.ErrNotExist, errors.Errorf("user %q is not member of org %q", userRef, orgRef))
+		return nil, util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("user %q is not member of org %q", userRef, orgRef))
 	}
 
 	userOrg := userOrgResponse(dbUserOrg)
@@ -751,7 +751,7 @@ func (h *ActionHandler) GetUserOrgs(ctx context.Context, req *GetUserOrgsRequest
 			return errors.WithStack(err)
 		}
 		if user == nil {
-			return util.NewAPIError(util.ErrNotExist, errors.Errorf("user %q doesn't exist", req.UserRef))
+			return util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("user %q doesn't exist", req.UserRef))
 		}
 
 		dbUserOrgs, err = h.d.GetUserOrgs(tx, user.ID, req.StartOrgName, limit, req.SortDirection)
@@ -788,7 +788,7 @@ func (h *ActionHandler) GetUserOrgInvitations(ctx context.Context, userRef strin
 			return errors.WithStack(err)
 		}
 		if user == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("user %q doesn't exist", userRef))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user %q doesn't exist", userRef))
 		}
 
 		orgInvitations, err = h.d.GetOrgInvitationByUserID(tx, user.ID)

--- a/internal/services/configstore/action/variable.go
+++ b/internal/services/configstore/action/variable.go
@@ -70,22 +70,22 @@ func (h *ActionHandler) GetVariables(ctx context.Context, parentKind types.Objec
 
 func (h *ActionHandler) ValidateVariableReq(ctx context.Context, req *CreateUpdateVariableRequest) error {
 	if req.Name == "" {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("variable name required"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("variable name required"))
 	}
 	if !util.ValidateName(req.Name) {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid variable name %q", req.Name))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid variable name %q", req.Name))
 	}
 	if len(req.Values) == 0 {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("variable values required"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("variable values required"))
 	}
 	if req.Parent.Kind == "" {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("variable parent kind required"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("variable parent kind required"))
 	}
 	if req.Parent.ID == "" {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("variable parent id required"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("variable parent id required"))
 	}
 	if req.Parent.Kind != types.ObjectKindProject && req.Parent.Kind != types.ObjectKindProjectGroup {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid variable parent kind %q", req.Parent.Kind))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid variable parent kind %q", req.Parent.Kind))
 	}
 
 	return nil
@@ -116,7 +116,7 @@ func (h *ActionHandler) CreateVariable(ctx context.Context, req *CreateUpdateVar
 			return errors.WithStack(err)
 		}
 		if s != nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("variable with name %q for %s with id %q already exists", req.Name, req.Parent.Kind, req.Parent.ID))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("variable with name %q for %s with id %q already exists", req.Name, req.Parent.Kind, req.Parent.ID))
 		}
 
 		variable = types.NewVariable(tx)
@@ -156,7 +156,7 @@ func (h *ActionHandler) UpdateVariable(ctx context.Context, curVariableName stri
 			return errors.WithStack(err)
 		}
 		if variable == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("variable with name %q for %s with id %q doesn't exists", curVariableName, req.Parent.Kind, req.Parent.ID))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("variable with name %q for %s with id %q doesn't exists", curVariableName, req.Parent.Kind, req.Parent.ID))
 		}
 
 		if variable.Name != req.Name {
@@ -166,7 +166,7 @@ func (h *ActionHandler) UpdateVariable(ctx context.Context, curVariableName stri
 				return errors.WithStack(err)
 			}
 			if u != nil {
-				return util.NewAPIError(util.ErrBadRequest, errors.Errorf("variable with name %q for %s with id %q already exists", req.Name, req.Parent.Kind, req.Parent.ID))
+				return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("variable with name %q for %s with id %q already exists", req.Name, req.Parent.Kind, req.Parent.ID))
 			}
 		}
 
@@ -201,7 +201,7 @@ func (h *ActionHandler) DeleteVariable(ctx context.Context, parentKind types.Obj
 			return errors.WithStack(err)
 		}
 		if variable == nil {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("variable with name %q doesn't exist", variableName))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("variable with name %q doesn't exist", variableName))
 		}
 
 		if err := h.d.DeleteVariable(tx, variable.ID); err != nil {

--- a/internal/services/configstore/api/api.go
+++ b/internal/services/configstore/api/api.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 
 	"github.com/gorilla/mux"
-	"github.com/sorintlab/errors"
 
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/configstore/types"
@@ -34,7 +33,7 @@ func GetObjectKindRef(r *http.Request) (types.ObjectKind, string, error) {
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		return "", "", util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "wrong projectref %q", vars["projectref"]))
+		return "", "", util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("wrong projectref %q", vars["projectref"]))
 	}
 	if projectRef != "" {
 		return types.ObjectKindProject, projectRef, nil
@@ -42,13 +41,13 @@ func GetObjectKindRef(r *http.Request) (types.ObjectKind, string, error) {
 
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		return "", "", util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "wrong projectgroupref %q", vars["projectgroupref"]))
+		return "", "", util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("wrong projectgroupref %q", vars["projectgroupref"]))
 	}
 	if projectGroupRef != "" {
 		return types.ObjectKindProjectGroup, projectGroupRef, nil
 	}
 
-	return "", "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot get project or projectgroup ref"))
+	return "", "", util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("cannot get project or projectgroup ref"))
 }
 
 type requestOptions struct {
@@ -65,11 +64,11 @@ func parseRequestOptions(r *http.Request) (*requestOptions, error) {
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			return nil, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse limit"))
+			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse limit"))
 		}
 	}
 	if limit < 0 {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("limit must be greater or equal than 0"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("limit must be greater or equal than 0"))
 	}
 
 	sortDirection := types.SortDirection(query.Get("sortdirection"))
@@ -78,7 +77,7 @@ func parseRequestOptions(r *http.Request) (*requestOptions, error) {
 		case types.SortDirectionAsc:
 		case types.SortDirectionDesc:
 		default:
-			return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("wrong sort direction %q", sortDirection))
+			return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("wrong sort direction %q", sortDirection))
 		}
 	}
 

--- a/internal/services/configstore/api/org.go
+++ b/internal/services/configstore/api/org.go
@@ -68,7 +68,7 @@ func (h *CreateOrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req *csapitypes.CreateOrgRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -106,7 +106,7 @@ func (h *UpdateOrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req *csapitypes.UpdateOrgRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -187,7 +187,7 @@ func (h *OrgsHandler) do(w http.ResponseWriter, r *http.Request) ([]*types.Organ
 	if ok {
 		for _, vs := range visibilitiesStr {
 			if !types.IsValidVisibility(types.Visibility(vs)) {
-				return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid visibility"))
+				return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid visibility"))
 			}
 			visibilities = append(visibilities, types.Visibility(vs))
 		}
@@ -222,7 +222,7 @@ func (h *AddOrgMemberHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	var req *csapitypes.AddOrgMemberRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 

--- a/internal/services/configstore/api/project.go
+++ b/internal/services/configstore/api/project.go
@@ -71,7 +71,7 @@ func (h *ProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -107,7 +107,7 @@ func (h *CreateProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	var req *csapitypes.CreateUpdateProjectRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -159,14 +159,14 @@ func (h *UpdateProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
 	var req *csapitypes.CreateUpdateProjectRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -218,7 +218,7 @@ func (h *DeleteProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 

--- a/internal/services/configstore/api/projectgroup.go
+++ b/internal/services/configstore/api/projectgroup.go
@@ -71,7 +71,7 @@ func (h *ProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -107,7 +107,7 @@ func (h *ProjectGroupProjectsHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -142,7 +142,7 @@ func (h *ProjectGroupSubgroupsHandler) ServeHTTP(w http.ResponseWriter, r *http.
 	vars := mux.Vars(r)
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -178,7 +178,7 @@ func (h *CreateProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	var req *csapitypes.CreateUpdateProjectGroupRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -220,14 +220,14 @@ func (h *UpdateProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	vars := mux.Vars(r)
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
 	var req *csapitypes.CreateUpdateProjectGroupRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -269,7 +269,7 @@ func (h *DeleteProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	vars := mux.Vars(r)
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 

--- a/internal/services/configstore/api/remotesource.go
+++ b/internal/services/configstore/api/remotesource.go
@@ -68,7 +68,7 @@ func (h *CreateRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	var req *csapitypes.CreateUpdateRemoteSourceRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -115,7 +115,7 @@ func (h *UpdateRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	var req *csapitypes.CreateUpdateRemoteSourceRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 

--- a/internal/services/configstore/api/secret.go
+++ b/internal/services/configstore/api/secret.go
@@ -108,7 +108,7 @@ func (h *CreateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	var req *csapitypes.CreateUpdateSecretRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -158,7 +158,7 @@ func (h *UpdateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	var req *csapitypes.CreateUpdateSecretRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 

--- a/internal/services/configstore/api/user.go
+++ b/internal/services/configstore/api/user.go
@@ -68,7 +68,7 @@ func (h *CreateUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req *csapitypes.CreateUserRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -116,7 +116,7 @@ func (h *UpdateUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req *csapitypes.UpdateUserRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -270,7 +270,7 @@ func (h *CreateUserLAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	var req csapitypes.CreateUserLARequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -337,7 +337,7 @@ func (h *UpdateUserLAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	var req csapitypes.UpdateUserLARequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -404,7 +404,7 @@ func (h *CreateUserTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	var req csapitypes.CreateUserTokenRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 

--- a/internal/services/configstore/api/variable.go
+++ b/internal/services/configstore/api/variable.go
@@ -83,7 +83,7 @@ func (h *CreateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	var req *csapitypes.CreateUpdateVariableRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -130,7 +130,7 @@ func (h *UpdateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	var req *csapitypes.CreateUpdateVariableRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 

--- a/internal/services/configstore/configstore_test.go
+++ b/internal/services/configstore/configstore_test.go
@@ -341,7 +341,7 @@ func TestUser(t *testing.T) {
 	})
 
 	t.Run("create duplicated user", func(t *testing.T) {
-		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("user with name %q already exists", "user01"))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user with name %q already exists", "user01"))
 		_, err := cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: "user01"})
 		assert.Error(t, err, expectedErr.Error())
 	})
@@ -431,37 +431,37 @@ func TestProjectGroupsAndProjectsCreate(t *testing.T) {
 
 	t.Run("create duplicated project in user root project group", func(t *testing.T) {
 		projectName := "project01"
-		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, projectName)))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, projectName)))
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: projectName, Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		assert.Error(t, err, expectedErr.Error())
 	})
 	t.Run("create duplicated project in org root project group", func(t *testing.T) {
 		projectName := "project01"
-		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with name %q, path %q already exists", projectName, path.Join("org", org.Name, projectName)))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project with name %q, path %q already exists", projectName, path.Join("org", org.Name, projectName)))
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: projectName, Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		assert.Error(t, err, expectedErr.Error())
 	})
 
 	t.Run("create duplicated project in user non root project group", func(t *testing.T) {
 		projectName := "project01"
-		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, "projectgroup01", projectName)))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, "projectgroup01", projectName)))
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: projectName, Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		assert.Error(t, err, expectedErr.Error())
 	})
 	t.Run("create duplicated project in org non root project group", func(t *testing.T) {
 		projectName := "project01"
-		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with name %q, path %q already exists", projectName, path.Join("org", org.Name, "projectgroup01", projectName)))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project with name %q, path %q already exists", projectName, path.Join("org", org.Name, "projectgroup01", projectName)))
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: projectName, Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("org", org.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		assert.Error(t, err, expectedErr.Error())
 	})
 
 	t.Run("create project in unexistent project group", func(t *testing.T) {
-		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf(`project group with id "unexistentid" doesn't exist`))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg(`project group with id "unexistentid" doesn't exist`))
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: "unexistentid"}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		assert.Error(t, err, expectedErr.Error())
 	})
 	t.Run("create project without parent id specified", func(t *testing.T) {
-		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("project parent id required"))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project parent id required"))
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		assert.Error(t, err, expectedErr.Error())
 	})
@@ -527,7 +527,7 @@ func TestProjectUpdate(t *testing.T) {
 	})
 	t.Run("move project to project group having project with same name", func(t *testing.T) {
 		projectName := "project01"
-		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, projectName)))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, projectName)))
 		p02req.Parent.ID = path.Join("user", user.Name)
 		_, err := cs.ah.UpdateProject(ctx, path.Join("user", user.Name, "projectgroup01", projectName), p02req)
 		assert.Error(t, err, expectedErr.Error())
@@ -540,7 +540,7 @@ func TestProjectUpdate(t *testing.T) {
 		testutil.NilError(t, err)
 	})
 	t.Run("test user project MembersCanPerformRunActions parameter", func(t *testing.T) {
-		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot set MembersCanPerformRunActions on an user project."))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("cannot set MembersCanPerformRunActions on an user project."))
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{
 			Name:                        "project03",
 			Parent:                      types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name)},
@@ -606,7 +606,7 @@ func TestProjectGroupUpdate(t *testing.T) {
 	})
 	t.Run("move project to project group having project with same name", func(t *testing.T) {
 		projectGroupName := "pg01"
-		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("project group with name %q, path %q already exists", projectGroupName, path.Join("user", user.Name, projectGroupName)))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project group with name %q, path %q already exists", projectGroupName, path.Join("user", user.Name, projectGroupName)))
 		pg05req.Parent.ID = path.Join("user", user.Name)
 		_, err := cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name, "pg02", projectGroupName), pg05req)
 		assert.Error(t, err, expectedErr.Error())
@@ -622,14 +622,14 @@ func TestProjectGroupUpdate(t *testing.T) {
 	})
 	t.Run("move project group inside itself", func(t *testing.T) {
 		projectGroupName := "pg02"
-		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot move project group inside itself or child project group"))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("cannot move project group inside itself or child project group"))
 		pg02req.Parent.ID = path.Join("user", user.Name, "pg02")
 		_, err := cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name, projectGroupName), pg02req)
 		assert.Error(t, err, expectedErr.Error())
 	})
 	t.Run("move project group to child project group", func(t *testing.T) {
 		projectGroupName := "pg01"
-		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot move project group inside itself or child project group"))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("cannot move project group inside itself or child project group"))
 		pg01req.Parent.ID = path.Join("user", user.Name, "pg01", "pg01")
 		_, err := cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name, projectGroupName), pg01req)
 		assert.Error(t, err, expectedErr.Error())
@@ -641,7 +641,7 @@ func TestProjectGroupUpdate(t *testing.T) {
 		rootPGres.ProjectGroup.Parent.Kind = types.ObjectKindProjectGroup
 		rootPGres.ProjectGroup.Name = "rootpg"
 
-		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("changing project group parent kind isn't supported"))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("changing project group parent kind isn't supported"))
 		_, err = cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name), &action.CreateUpdateProjectGroupRequest{Name: rootPGres.ProjectGroup.Name, Parent: rootPGres.ProjectGroup.Parent, Visibility: rootPGres.ProjectGroup.Visibility})
 		assert.Error(t, err, expectedErr.Error())
 	})
@@ -651,7 +651,7 @@ func TestProjectGroupUpdate(t *testing.T) {
 
 		rootPGres.ProjectGroup.Parent.ID = path.Join("user", user.Name, "pg01")
 
-		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot change root project group parent kind or id"))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("cannot change root project group parent kind or id"))
 		_, err = cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name), &action.CreateUpdateProjectGroupRequest{Name: rootPGres.ProjectGroup.Name, Parent: rootPGres.ProjectGroup.Parent, Visibility: rootPGres.ProjectGroup.Visibility})
 		assert.Error(t, err, expectedErr.Error())
 	})
@@ -661,7 +661,7 @@ func TestProjectGroupUpdate(t *testing.T) {
 
 		rootPGres.ProjectGroup.Name = "rootpgnewname"
 
-		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("project group name for root project group must be empty"))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project group name for root project group must be empty"))
 		_, err = cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name), &action.CreateUpdateProjectGroupRequest{Name: rootPGres.ProjectGroup.Name, Parent: rootPGres.ProjectGroup.Parent, Visibility: rootPGres.ProjectGroup.Visibility})
 		assert.Error(t, err, expectedErr.Error())
 	})
@@ -707,7 +707,7 @@ func TestProjectGroupDelete(t *testing.T) {
 	testutil.NilError(t, err)
 
 	t.Run("delete root project group", func(t *testing.T) {
-		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot delete root project group"))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("cannot delete root project group"))
 		err := cs.ah.DeleteProjectGroup(ctx, path.Join("org", org.Name))
 		assert.Error(t, err, expectedErr.Error())
 	})
@@ -1521,7 +1521,7 @@ func TestRemoteSource(t *testing.T) {
 				_, err := cs.ah.CreateRemoteSource(ctx, rsreq)
 				testutil.NilError(t, err)
 
-				expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf(`remotesource "rs01" already exists`))
+				expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg(`remotesource "rs01" already exists`))
 				_, err = cs.ah.CreateRemoteSource(ctx, rsreq)
 				assert.Error(t, err, expectedErr.Error())
 			},
@@ -1589,7 +1589,7 @@ func TestRemoteSource(t *testing.T) {
 				_, err = cs.ah.CreateRemoteSource(ctx, rs02req)
 				testutil.NilError(t, err)
 
-				expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf(`remotesource "rs02" already exists`))
+				expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg(`remotesource "rs02" already exists`))
 				rs01req.Name = "rs02"
 				_, err = cs.ah.UpdateRemoteSource(ctx, "rs01", rs01req)
 				assert.Error(t, err, expectedErr.Error())
@@ -1832,7 +1832,7 @@ func TestOrgInvitation(t *testing.T) {
 				_, err = cs.ah.CreateOrgInvitation(ctx, rs)
 				testutil.NilError(t, err)
 
-				expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("invitation already exists"))
+				expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invitation already exists"))
 				_, err = cs.ah.CreateOrgInvitation(ctx, rs)
 				assert.Error(t, err, expectedErr.Error())
 			},

--- a/internal/services/gateway/action/auth.go
+++ b/internal/services/gateway/action/auth.go
@@ -42,7 +42,7 @@ func (h *ActionHandler) IsAuthUserOrgOwner(ctx context.Context, orgID string) (b
 		if util.RemoteErrorIs(err, util.ErrNotExist) {
 			return false, nil
 		}
-		return false, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get user org"))
+		return false, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get user org"))
 	}
 
 	if userOrg.Role == cstypes.MemberRoleOwner {
@@ -75,7 +75,7 @@ func (h *ActionHandler) IsAuthUserProjectOwner(ctx context.Context, ownerType cs
 			if util.RemoteErrorIs(err, util.ErrNotExist) {
 				return false, nil
 			}
-			return false, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get user org"))
+			return false, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get user org"))
 		}
 
 		if userOrg.Role == cstypes.MemberRoleOwner {
@@ -106,7 +106,7 @@ func (h *ActionHandler) IsAuthUserMember(ctx context.Context, ownerType cstypes.
 	if ownerType == cstypes.ObjectKindOrg {
 		userOrg, _, err := h.configstoreClient.GetUserOrg(ctx, userID, ownerID)
 		if err != nil {
-			return false, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get user orgs"))
+			return false, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get user orgs"))
 		}
 
 		if userOrg == nil {
@@ -126,14 +126,14 @@ func (h *ActionHandler) IsAuthUserVariableOwner(ctx context.Context, parentType 
 	case cstypes.ObjectKindProjectGroup:
 		pg, _, err := h.configstoreClient.GetProjectGroup(ctx, parentRef)
 		if err != nil {
-			return false, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project group %q", parentRef))
+			return false, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get project group %q", parentRef))
 		}
 		ownerType = pg.OwnerType
 		ownerID = pg.OwnerID
 	case cstypes.ObjectKindProject:
 		p, _, err := h.configstoreClient.GetProject(ctx, parentRef)
 		if err != nil {
-			return false, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project  %q", parentRef))
+			return false, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get project  %q", parentRef))
 		}
 		ownerType = p.OwnerType
 		ownerID = p.OwnerID
@@ -151,7 +151,7 @@ func (h *ActionHandler) CanAuthUserGetRun(ctx context.Context, groupType scommon
 	case scommon.GroupTypeProject:
 		p, _, err := h.configstoreClient.GetProject(ctx, ref)
 		if err != nil {
-			return false, "", util.NewAPIError(util.KindFromRemoteError(err), err)
+			return false, "", util.NewAPIErrorWrap(util.KindFromRemoteError(err), err)
 		}
 		refID = p.ID
 		ownerID = p.OwnerID
@@ -160,7 +160,7 @@ func (h *ActionHandler) CanAuthUserGetRun(ctx context.Context, groupType scommon
 	case scommon.GroupTypeUser:
 		u, _, err := h.configstoreClient.GetUser(ctx, ref)
 		if err != nil {
-			return false, "", util.NewAPIError(util.KindFromRemoteError(err), err)
+			return false, "", util.NewAPIErrorWrap(util.KindFromRemoteError(err), err)
 		}
 
 		// user direct runs
@@ -201,7 +201,7 @@ func (h *ActionHandler) CanAuthUserDoRunActions(ctx context.Context, groupType s
 		var err error
 		p, _, err = h.configstoreClient.GetProject(ctx, ref)
 		if err != nil {
-			return false, "", util.NewAPIError(util.KindFromRemoteError(err), err)
+			return false, "", util.NewAPIErrorWrap(util.KindFromRemoteError(err), err)
 		}
 		refID = p.ID
 		ownerType = p.OwnerType
@@ -209,7 +209,7 @@ func (h *ActionHandler) CanAuthUserDoRunActions(ctx context.Context, groupType s
 	case scommon.GroupTypeUser:
 		u, _, err := h.configstoreClient.GetUser(ctx, ref)
 		if err != nil {
-			return false, "", util.NewAPIError(util.KindFromRemoteError(err), err)
+			return false, "", util.NewAPIErrorWrap(util.KindFromRemoteError(err), err)
 		}
 
 		// user direct runs

--- a/internal/services/gateway/action/badge.go
+++ b/internal/services/gateway/action/badge.go
@@ -29,14 +29,14 @@ import (
 func (h *ActionHandler) GetBadge(ctx context.Context, projectRef, branch string) (string, error) {
 	project, _, err := h.configstoreClient.GetProject(ctx, projectRef)
 	if err != nil {
-		return "", util.NewAPIError(util.KindFromRemoteError(err), err)
+		return "", util.NewAPIErrorWrap(util.KindFromRemoteError(err), err)
 	}
 
 	// if branch is empty we get the latest run for every branch.
 	group := path.Join("/", string(common.GroupTypeProject), project.ID, string(common.GroupTypeBranch), url.PathEscape(branch))
 	runResp, _, err := h.runserviceClient.GetGroupLastRun(ctx, group, nil)
 	if err != nil {
-		return "", util.NewAPIError(util.KindFromRemoteError(err), err)
+		return "", util.NewAPIErrorWrap(util.KindFromRemoteError(err), err)
 	}
 	if len(runResp.Runs) == 0 {
 		return badgeUnknown, nil

--- a/internal/services/gateway/action/commitstatusdelivery.go
+++ b/internal/services/gateway/action/commitstatusdelivery.go
@@ -42,14 +42,14 @@ type GetProjectCommitStatusDeliveriesResponse struct {
 func (h *ActionHandler) GetProjectCommitStatusDeliveries(ctx context.Context, req *GetProjectCommitStatusDeliveriesRequest) (*GetProjectCommitStatusDeliveriesResponse, error) {
 	project, _, err := h.configstoreClient.GetProject(ctx, req.ProjectRef)
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
+		return nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err)
 	}
 	isUserOwner, err := h.IsAuthUserProjectOwner(ctx, project.OwnerType, project.OwnerID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine permissions")
 	}
 	if !isUserOwner {
-		return nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
+		return nil, util.NewAPIError(util.ErrForbidden, util.WithAPIErrorMsg("user not authorized"))
 	}
 
 	inCursor := &DeliveryCursor{}
@@ -68,7 +68,7 @@ func (h *ActionHandler) GetProjectCommitStatusDeliveries(ctx context.Context, re
 
 	commitStatusDeliveries, resp, err := h.notificationClient.GetProjectCommitStatusDeliveries(ctx, project.ID, &client.GetProjectCommitStatusDeliveriesOptions{ListOptions: &client.ListOptions{Limit: req.Limit, SortDirection: nstypes.SortDirection(sortDirection)}, StartSequence: inCursor.StartSequence, DeliveryStatusFilter: deliveryStatusFilter})
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
+		return nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err)
 	}
 
 	var outCursor string
@@ -101,19 +101,19 @@ type ProjectCommitStatusRedeliveryRequest struct {
 func (h *ActionHandler) ProjectCommitStatusRedelivery(ctx context.Context, req *ProjectCommitStatusRedeliveryRequest) error {
 	project, _, err := h.configstoreClient.GetProject(ctx, req.ProjectRef)
 	if err != nil {
-		return util.NewAPIError(util.KindFromRemoteError(err), err)
+		return util.NewAPIErrorWrap(util.KindFromRemoteError(err), err)
 	}
 	isUserOwner, err := h.IsAuthUserProjectOwner(ctx, project.OwnerType, project.OwnerID)
 	if err != nil {
 		return errors.Wrapf(err, "failed to determine permissions")
 	}
 	if !isUserOwner {
-		return util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
+		return util.NewAPIError(util.ErrForbidden, util.WithAPIErrorMsg("user not authorized"))
 	}
 
 	_, err = h.notificationClient.CommitStatusRedelivery(ctx, project.ID, req.CommitStatusDeliveryID)
 	if err != nil {
-		return util.NewAPIError(util.KindFromRemoteError(err), err)
+		return util.NewAPIErrorWrap(util.KindFromRemoteError(err), err)
 	}
 
 	return nil

--- a/internal/services/gateway/action/cursor.go
+++ b/internal/services/gateway/action/cursor.go
@@ -21,11 +21,11 @@ func MarshalCursor(c any) (string, error) {
 func UnmarshalCursor(cs string, c any) error {
 	cj, err := base64.StdEncoding.DecodeString(cs)
 	if err != nil {
-		return util.NewAPIError(util.ErrBadRequest, err)
+		return util.NewAPIErrorWrap(util.ErrBadRequest, err)
 	}
 
 	if err := json.Unmarshal(cj, c); err != nil {
-		return util.NewAPIError(util.ErrBadRequest, err)
+		return util.NewAPIErrorWrap(util.ErrBadRequest, err)
 	}
 
 	return nil

--- a/internal/services/gateway/action/maintenance.go
+++ b/internal/services/gateway/action/maintenance.go
@@ -39,32 +39,32 @@ type MaintenanceStatusResponse struct {
 
 func (h *ActionHandler) IsMaintenanceEnabled(ctx context.Context, serviceName string) (*MaintenanceStatusResponse, error) {
 	if !common.IsUserAdmin(ctx) {
-		return nil, util.NewAPIError(util.ErrUnauthorized, errors.Errorf("user not admin"))
+		return nil, util.NewAPIError(util.ErrUnauthorized, util.WithAPIErrorMsg("user not admin"))
 	}
 
 	switch serviceName {
 	case ConfigstoreService:
 		csresp, _, err := h.configstoreClient.GetMaintenanceStatus(ctx)
 		if err != nil {
-			return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
+			return nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err)
 		}
 
 		return &MaintenanceStatusResponse{RequestedStatus: csresp.RequestedStatus, CurrentStatus: csresp.CurrentStatus}, nil
 	case RunserviceService:
 		rsresp, _, err := h.runserviceClient.GetMaintenanceStatus(ctx)
 		if err != nil {
-			return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
+			return nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err)
 		}
 
 		return &MaintenanceStatusResponse{RequestedStatus: rsresp.RequestedStatus, CurrentStatus: rsresp.CurrentStatus}, nil
 	default:
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid service name %q", serviceName))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid service name %q", serviceName))
 	}
 }
 
 func (h *ActionHandler) MaintenanceMode(ctx context.Context, serviceName string, enable bool) error {
 	if !common.IsUserAdmin(ctx) {
-		return util.NewAPIError(util.ErrUnauthorized, errors.Errorf("user not admin"))
+		return util.NewAPIError(util.ErrUnauthorized, util.WithAPIErrorMsg("user not admin"))
 	}
 
 	var err error
@@ -82,18 +82,18 @@ func (h *ActionHandler) MaintenanceMode(ctx context.Context, serviceName string,
 			_, err = h.runserviceClient.DisableMaintenance(ctx)
 		}
 	default:
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid service name %q", serviceName))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid service name %q", serviceName))
 	}
 
 	if err != nil {
-		return util.NewAPIError(util.KindFromRemoteError(err), err)
+		return util.NewAPIErrorWrap(util.KindFromRemoteError(err), err)
 	}
 	return nil
 }
 
 func (h *ActionHandler) Export(ctx context.Context, serviceName string) (*http.Response, error) {
 	if !common.IsUserAdmin(ctx) {
-		return nil, util.NewAPIError(util.ErrUnauthorized, errors.Errorf("user not admin"))
+		return nil, util.NewAPIError(util.ErrUnauthorized, util.WithAPIErrorMsg("user not admin"))
 	}
 
 	var err error
@@ -108,7 +108,7 @@ func (h *ActionHandler) Export(ctx context.Context, serviceName string) (*http.R
 		resp, err = h.runserviceClient.Export(ctx)
 		res = resp.Response
 	default:
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid service name %q", serviceName))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid service name %q", serviceName))
 	}
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -119,7 +119,7 @@ func (h *ActionHandler) Export(ctx context.Context, serviceName string) (*http.R
 
 func (h *ActionHandler) Import(ctx context.Context, r io.Reader, serviceName string) error {
 	if !common.IsUserAdmin(ctx) {
-		return util.NewAPIError(util.ErrUnauthorized, errors.Errorf("user not admin"))
+		return util.NewAPIError(util.ErrUnauthorized, util.WithAPIErrorMsg("user not admin"))
 	}
 
 	var err error
@@ -129,7 +129,7 @@ func (h *ActionHandler) Import(ctx context.Context, r io.Reader, serviceName str
 	case RunserviceService:
 		_, err = h.runserviceClient.Import(ctx, r)
 	default:
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid service name %q", serviceName))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid service name %q", serviceName))
 	}
 	if err != nil {
 		return errors.WithStack(err)

--- a/internal/services/gateway/action/project.go
+++ b/internal/services/gateway/action/project.go
@@ -45,7 +45,7 @@ func (h *ActionHandler) GetProject(ctx context.Context, projectRef string) (*csa
 		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isMember {
-		return nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
+		return nil, util.NewAPIError(util.ErrForbidden, util.WithAPIErrorMsg("user not authorized"))
 	}
 
 	return project, nil
@@ -67,7 +67,7 @@ func (h *ActionHandler) CreateProject(ctx context.Context, req *CreateProjectReq
 
 	user, _, err := h.configstoreClient.GetUser(ctx, curUserID)
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get user %q", curUserID))
+		return nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get user %q", curUserID))
 	}
 	parentRef := req.ParentRef
 	if parentRef == "" {
@@ -77,7 +77,7 @@ func (h *ActionHandler) CreateProject(ctx context.Context, req *CreateProjectReq
 
 	pg, _, err := h.configstoreClient.GetProjectGroup(ctx, parentRef)
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project group %q", parentRef))
+		return nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get project group %q", parentRef))
 	}
 
 	isProjectOwner, err := h.IsAuthUserProjectOwner(ctx, pg.OwnerType, pg.OwnerID)
@@ -85,26 +85,26 @@ func (h *ActionHandler) CreateProject(ctx context.Context, req *CreateProjectReq
 		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isProjectOwner {
-		return nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
+		return nil, util.NewAPIError(util.ErrForbidden, util.WithAPIErrorMsg("user not authorized"))
 	}
 
 	if !util.ValidateName(req.Name) {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid project name %q", req.Name))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid project name %q", req.Name))
 	}
 	if req.RemoteSourceName == "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("empty remote source name"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("empty remote source name"))
 	}
 	if req.RepoPath == "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("empty remote repo path"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("empty remote repo path"))
 	}
 
 	projectPath := path.Join(pg.Path, req.Name)
 	if _, _, err = h.configstoreClient.GetProject(ctx, projectPath); err != nil {
 		if !util.RemoteErrorIs(err, util.ErrNotExist) {
-			return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project %q", req.Name))
+			return nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get project %q", req.Name))
 		}
 	} else {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("project %q already exists", projectPath))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project %q already exists", projectPath))
 	}
 
 	gitSource, rs, la, err := h.GetUserGitSource(ctx, req.RemoteSourceName, curUserID)
@@ -145,7 +145,7 @@ func (h *ActionHandler) CreateProject(ctx context.Context, req *CreateProjectReq
 	h.log.Info().Msgf("creating project")
 	rp, _, err := h.configstoreClient.CreateProject(ctx, creq)
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create project"))
+		return nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to create project"))
 	}
 	h.log.Info().Msgf("project %s created, ID: %s", rp.Name, rp.ID)
 
@@ -180,7 +180,7 @@ type UpdateProjectRequest struct {
 func (h *ActionHandler) UpdateProject(ctx context.Context, projectRef string, req *UpdateProjectRequest) (*csapitypes.Project, error) {
 	p, _, err := h.configstoreClient.GetProject(ctx, projectRef)
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project %q", projectRef))
+		return nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get project %q", projectRef))
 	}
 
 	isProjectOwner, err := h.IsAuthUserProjectOwner(ctx, p.OwnerType, p.OwnerID)
@@ -188,7 +188,7 @@ func (h *ActionHandler) UpdateProject(ctx context.Context, projectRef string, re
 		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isProjectOwner {
-		return nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
+		return nil, util.NewAPIError(util.ErrForbidden, util.WithAPIErrorMsg("user not authorized"))
 	}
 
 	if req.Name != nil {
@@ -226,7 +226,7 @@ func (h *ActionHandler) UpdateProject(ctx context.Context, projectRef string, re
 	h.log.Info().Msgf("updating project")
 	rp, _, err := h.configstoreClient.UpdateProject(ctx, p.ID, creq)
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to update project"))
+		return nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to update project"))
 	}
 	h.log.Info().Msgf("project %s updated, ID: %s", p.Name, p.ID)
 
@@ -238,7 +238,7 @@ func (h *ActionHandler) ProjectUpdateRepoLinkedAccount(ctx context.Context, proj
 
 	p, _, err := h.configstoreClient.GetProject(ctx, projectRef)
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project %q", projectRef))
+		return nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get project %q", projectRef))
 	}
 
 	isProjectOwner, err := h.IsAuthUserProjectOwner(ctx, p.OwnerType, p.OwnerID)
@@ -246,7 +246,7 @@ func (h *ActionHandler) ProjectUpdateRepoLinkedAccount(ctx context.Context, proj
 		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isProjectOwner {
-		return nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
+		return nil, util.NewAPIError(util.ErrForbidden, util.WithAPIErrorMsg("user not authorized"))
 	}
 
 	gitsource, _, la, err := h.GetUserGitSource(ctx, p.RemoteSourceID, curUserID)
@@ -280,7 +280,7 @@ func (h *ActionHandler) ProjectUpdateRepoLinkedAccount(ctx context.Context, proj
 	h.log.Info().Msgf("updating project")
 	rp, _, err := h.configstoreClient.UpdateProject(ctx, p.ID, creq)
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to update project"))
+		return nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to update project"))
 	}
 	h.log.Info().Msgf("project %s updated, ID: %s", p.Name, p.ID)
 
@@ -367,7 +367,7 @@ func (h *ActionHandler) genWebhookURL(project *csapitypes.Project) (string, erro
 func (h *ActionHandler) ReconfigProject(ctx context.Context, projectRef string) error {
 	p, _, err := h.configstoreClient.GetProject(ctx, projectRef)
 	if err != nil {
-		return util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project %q", projectRef))
+		return util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get project %q", projectRef))
 	}
 
 	isProjectOwner, err := h.IsAuthUserProjectOwner(ctx, p.OwnerType, p.OwnerID)
@@ -375,7 +375,7 @@ func (h *ActionHandler) ReconfigProject(ctx context.Context, projectRef string) 
 		return errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isProjectOwner {
-		return util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
+		return util.NewAPIError(util.ErrForbidden, util.WithAPIErrorMsg("user not authorized"))
 	}
 
 	user, rs, la, err := h.getRemoteRepoAccessData(ctx, p.LinkedAccountID)
@@ -391,7 +391,7 @@ func (h *ActionHandler) ReconfigProject(ctx context.Context, projectRef string) 
 func (h *ActionHandler) DeleteProject(ctx context.Context, projectRef string) error {
 	p, _, err := h.configstoreClient.GetProject(ctx, projectRef)
 	if err != nil {
-		return util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project %q", projectRef))
+		return util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get project %q", projectRef))
 	}
 
 	isProjectOwner, err := h.IsAuthUserProjectOwner(ctx, p.OwnerType, p.OwnerID)
@@ -399,7 +399,7 @@ func (h *ActionHandler) DeleteProject(ctx context.Context, projectRef string) er
 		return errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isProjectOwner {
-		return util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
+		return util.NewAPIError(util.ErrForbidden, util.WithAPIErrorMsg("user not authorized"))
 	}
 
 	// get data needed for repo cleanup
@@ -413,7 +413,7 @@ func (h *ActionHandler) DeleteProject(ctx context.Context, projectRef string) er
 
 	h.log.Info().Msgf("deleting project with ID: %q", p.ID)
 	if _, err = h.configstoreClient.DeleteProject(ctx, projectRef); err != nil {
-		return util.NewAPIError(util.KindFromRemoteError(err), err)
+		return util.NewAPIErrorWrap(util.KindFromRemoteError(err), err)
 	}
 
 	// try to cleanup gitsource configs
@@ -433,7 +433,7 @@ func (h *ActionHandler) ProjectCreateRun(ctx context.Context, projectRef, branch
 
 	p, _, err := h.configstoreClient.GetProject(ctx, projectRef)
 	if err != nil {
-		return util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project %q", projectRef))
+		return util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get project %q", projectRef))
 	}
 
 	isProjectOwner, err := h.IsAuthUserProjectOwner(ctx, p.OwnerType, p.OwnerID)
@@ -441,7 +441,7 @@ func (h *ActionHandler) ProjectCreateRun(ctx context.Context, projectRef, branch
 		return errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isProjectOwner {
-		return util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
+		return util.NewAPIError(util.ErrForbidden, util.WithAPIErrorMsg("user not authorized"))
 	}
 
 	gitSource, rs, _, err := h.GetUserGitSource(ctx, p.RemoteSourceID, curUserID)
@@ -466,10 +466,10 @@ func (h *ActionHandler) ProjectCreateRun(ctx context.Context, projectRef, branch
 		set++
 	}
 	if set == 0 {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("one of branch, tag or ref is required"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("one of branch, tag or ref is required"))
 	}
 	if set > 1 {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("only one of branch, tag or ref can be provided"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("only one of branch, tag or ref can be provided"))
 	}
 
 	var refType types.RunRefType
@@ -488,7 +488,7 @@ func (h *ActionHandler) ProjectCreateRun(ctx context.Context, projectRef, branch
 
 	gitRefType, name, err := gitSource.RefType(refName)
 	if err != nil {
-		return util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "failed to get refType for ref %q", refName))
+		return util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("failed to get refType for ref %q", refName))
 	}
 	ref, err := gitSource.GetRef(p.RepositoryPath, refName)
 	if err != nil {
@@ -569,12 +569,12 @@ func (h *ActionHandler) ProjectCreateRun(ctx context.Context, projectRef, branch
 func (h *ActionHandler) getRemoteRepoAccessData(ctx context.Context, linkedAccountID string) (*cstypes.User, *cstypes.RemoteSource, *cstypes.LinkedAccount, error) {
 	user, _, err := h.configstoreClient.GetUserByLinkedAccount(ctx, linkedAccountID)
 	if err != nil {
-		return nil, nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get user with linked account id %q", linkedAccountID))
+		return nil, nil, nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get user with linked account id %q", linkedAccountID))
 	}
 
 	linkedAccounts, _, err := h.configstoreClient.GetUserLinkedAccounts(ctx, user.ID)
 	if err != nil {
-		return nil, nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get user %q linked accounts", user.ID))
+		return nil, nil, nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get user %q linked accounts", user.ID))
 	}
 
 	var la *cstypes.LinkedAccount
@@ -591,7 +591,7 @@ func (h *ActionHandler) getRemoteRepoAccessData(ctx context.Context, linkedAccou
 
 	rs, _, err := h.configstoreClient.GetRemoteSource(ctx, la.RemoteSourceID)
 	if err != nil {
-		return nil, nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get remote source %q", la.RemoteSourceID))
+		return nil, nil, nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get remote source %q", la.RemoteSourceID))
 	}
 
 	return user, rs, la, nil
@@ -600,7 +600,7 @@ func (h *ActionHandler) getRemoteRepoAccessData(ctx context.Context, linkedAccou
 func (h *ActionHandler) RefreshRemoteRepositoryInfo(ctx context.Context, projectRef string) (*csapitypes.Project, error) {
 	p, err := h.GetProject(ctx, projectRef)
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project %q", projectRef))
+		return nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get project %q", projectRef))
 	}
 
 	isProjectOwner, err := h.IsAuthUserProjectOwner(ctx, p.OwnerType, p.OwnerID)
@@ -608,12 +608,12 @@ func (h *ActionHandler) RefreshRemoteRepositoryInfo(ctx context.Context, project
 		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isProjectOwner {
-		return nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
+		return nil, util.NewAPIError(util.ErrForbidden, util.WithAPIErrorMsg("user not authorized"))
 	}
 
 	gitSource, _, _, err := h.GetUserGitSource(ctx, p.RemoteSourceID, common.CurrentUserID(ctx))
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get remote source %q", p.RemoteSourceID))
+		return nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get remote source %q", p.RemoteSourceID))
 	}
 
 	repoInfo, err := gitSource.GetRepoInfo(p.RepositoryPath)
@@ -639,7 +639,7 @@ func (h *ActionHandler) RefreshRemoteRepositoryInfo(ctx context.Context, project
 	h.log.Info().Msgf("updating project")
 	rp, _, err := h.configstoreClient.UpdateProject(ctx, p.ID, creq)
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to update project"))
+		return nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to update project"))
 	}
 	h.log.Info().Msgf("project %s updated, ID: %s", p.Name, p.ID)
 

--- a/internal/services/gateway/action/remotesource.go
+++ b/internal/services/gateway/action/remotesource.go
@@ -104,33 +104,33 @@ func (h *ActionHandler) CreateRemoteSource(ctx context.Context, req *CreateRemot
 	}
 
 	if !util.ValidateName(req.Name) {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid remotesource name %q", req.Name))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid remotesource name %q", req.Name))
 	}
 
 	if req.Name == "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource name required"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remotesource name required"))
 	}
 	if req.APIURL == "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource api url required"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remotesource api url required"))
 	}
 	if req.Type == "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource type required"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remotesource type required"))
 	}
 	if req.AuthType == "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource auth type required"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remotesource auth type required"))
 	}
 
 	// validate if the remote source type supports the required auth type
 	if !cstypes.SourceSupportsAuthType(cstypes.RemoteSourceType(req.Type), cstypes.RemoteSourceAuthType(req.AuthType)) {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource type %q doesn't support auth type %q", req.Type, req.AuthType))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remotesource type %q doesn't support auth type %q", req.Type, req.AuthType))
 	}
 
 	if req.AuthType == string(cstypes.RemoteSourceAuthTypeOauth2) {
 		if req.Oauth2ClientID == "" {
-			return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource oauth2 clientid required"))
+			return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remotesource oauth2 clientid required"))
 		}
 		if req.Oauth2ClientSecret == "" {
-			return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("remotesource oauth2 client secret required"))
+			return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("remotesource oauth2 client secret required"))
 		}
 	}
 

--- a/internal/services/gateway/action/secret.go
+++ b/internal/services/gateway/action/secret.go
@@ -43,7 +43,7 @@ func (h *ActionHandler) GetSecrets(ctx context.Context, req *GetSecretsRequest) 
 		cssecrets, _, err = h.configstoreClient.GetProjectSecrets(ctx, req.ParentRef, req.Tree)
 	}
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), err)
+		return nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err)
 	}
 
 	if req.RemoveOverridden {
@@ -76,11 +76,11 @@ func (h *ActionHandler) CreateSecret(ctx context.Context, req *CreateSecretReque
 		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isVariableOwner {
-		return nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
+		return nil, util.NewAPIError(util.ErrForbidden, util.WithAPIErrorMsg("user not authorized"))
 	}
 
 	if !util.ValidateName(req.Name) {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid secret name %q", req.Name))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid secret name %q", req.Name))
 	}
 
 	creq := &csapitypes.CreateUpdateSecretRequest{
@@ -99,7 +99,7 @@ func (h *ActionHandler) CreateSecret(ctx context.Context, req *CreateSecretReque
 		rs, _, err = h.configstoreClient.CreateProjectSecret(ctx, req.ParentRef, creq)
 	}
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create secret"))
+		return nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to create secret"))
 	}
 	h.log.Info().Msgf("secret %s created, ID: %s", rs.Name, rs.ID)
 
@@ -130,11 +130,11 @@ func (h *ActionHandler) UpdateSecret(ctx context.Context, req *UpdateSecretReque
 		return nil, errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isVariableOwner {
-		return nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
+		return nil, util.NewAPIError(util.ErrForbidden, util.WithAPIErrorMsg("user not authorized"))
 	}
 
 	if !util.ValidateName(req.Name) {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid secret name %q", req.Name))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid secret name %q", req.Name))
 	}
 
 	creq := &csapitypes.CreateUpdateSecretRequest{
@@ -153,7 +153,7 @@ func (h *ActionHandler) UpdateSecret(ctx context.Context, req *UpdateSecretReque
 		rs, _, err = h.configstoreClient.UpdateProjectSecret(ctx, req.ParentRef, req.SecretName, creq)
 	}
 	if err != nil {
-		return nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to update secret"))
+		return nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to update secret"))
 	}
 	h.log.Info().Msgf("secret %s updated, ID: %s", rs.Name, rs.ID)
 
@@ -166,7 +166,7 @@ func (h *ActionHandler) DeleteSecret(ctx context.Context, parentType cstypes.Obj
 		return errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isVariableOwner {
-		return util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
+		return util.NewAPIError(util.ErrForbidden, util.WithAPIErrorMsg("user not authorized"))
 	}
 
 	switch parentType {
@@ -178,7 +178,7 @@ func (h *ActionHandler) DeleteSecret(ctx context.Context, parentType cstypes.Obj
 		_, err = h.configstoreClient.DeleteProjectSecret(ctx, parentRef, name)
 	}
 	if err != nil {
-		return util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to delete secret"))
+		return util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to delete secret"))
 	}
 	return nil
 }

--- a/internal/services/gateway/action/variable.go
+++ b/internal/services/gateway/action/variable.go
@@ -42,21 +42,21 @@ func (h *ActionHandler) GetVariables(ctx context.Context, req *GetVariablesReque
 		var err error
 		csvars, _, err = h.configstoreClient.GetProjectGroupVariables(ctx, req.ParentRef, req.Tree)
 		if err != nil {
-			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), err)
+			return nil, nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err)
 		}
 		cssecrets, _, err = h.configstoreClient.GetProjectGroupSecrets(ctx, req.ParentRef, true)
 		if err != nil {
-			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), err)
+			return nil, nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err)
 		}
 	case cstypes.ObjectKindProject:
 		var err error
 		csvars, _, err = h.configstoreClient.GetProjectVariables(ctx, req.ParentRef, req.Tree)
 		if err != nil {
-			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), err)
+			return nil, nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err)
 		}
 		cssecrets, _, err = h.configstoreClient.GetProjectSecrets(ctx, req.ParentRef, true)
 		if err != nil {
-			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), err)
+			return nil, nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err)
 		}
 	}
 
@@ -83,15 +83,15 @@ func (h *ActionHandler) CreateVariable(ctx context.Context, req *CreateVariableR
 		return nil, nil, errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isVariableOwner {
-		return nil, nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
+		return nil, nil, util.NewAPIError(util.ErrForbidden, util.WithAPIErrorMsg("user not authorized"))
 	}
 
 	if !util.ValidateName(req.Name) {
-		return nil, nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid variable name %q", req.Name))
+		return nil, nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid variable name %q", req.Name))
 	}
 
 	if len(req.Values) == 0 {
-		return nil, nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("empty variable values"))
+		return nil, nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("empty variable values"))
 	}
 
 	creq := &csapitypes.CreateUpdateVariableRequest{
@@ -107,25 +107,25 @@ func (h *ActionHandler) CreateVariable(ctx context.Context, req *CreateVariableR
 		var err error
 		cssecrets, _, err = h.configstoreClient.GetProjectGroupSecrets(ctx, req.ParentRef, true)
 		if err != nil {
-			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project group %q secrets", req.ParentRef))
+			return nil, nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get project group %q secrets", req.ParentRef))
 		}
 
 		h.log.Info().Msgf("creating project group variable")
 		rv, _, err = h.configstoreClient.CreateProjectGroupVariable(ctx, req.ParentRef, creq)
 		if err != nil {
-			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create variable"))
+			return nil, nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to create variable"))
 		}
 	case cstypes.ObjectKindProject:
 		var err error
 		cssecrets, _, err = h.configstoreClient.GetProjectSecrets(ctx, req.ParentRef, true)
 		if err != nil {
-			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project %q secrets", req.ParentRef))
+			return nil, nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get project %q secrets", req.ParentRef))
 		}
 
 		h.log.Info().Msgf("creating project variable")
 		rv, _, err = h.configstoreClient.CreateProjectVariable(ctx, req.ParentRef, creq)
 		if err != nil {
-			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create variable"))
+			return nil, nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to create variable"))
 		}
 	}
 	h.log.Info().Msgf("variable %s created, ID: %s", rv.Name, rv.ID)
@@ -150,15 +150,15 @@ func (h *ActionHandler) UpdateVariable(ctx context.Context, req *UpdateVariableR
 		return nil, nil, errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isVariableOwner {
-		return nil, nil, util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
+		return nil, nil, util.NewAPIError(util.ErrForbidden, util.WithAPIErrorMsg("user not authorized"))
 	}
 
 	if !util.ValidateName(req.Name) {
-		return nil, nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("invalid variable name %q", req.Name))
+		return nil, nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid variable name %q", req.Name))
 	}
 
 	if len(req.Values) == 0 {
-		return nil, nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("empty variable values"))
+		return nil, nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("empty variable values"))
 	}
 
 	creq := &csapitypes.CreateUpdateVariableRequest{
@@ -174,25 +174,25 @@ func (h *ActionHandler) UpdateVariable(ctx context.Context, req *UpdateVariableR
 		var err error
 		cssecrets, _, err = h.configstoreClient.GetProjectGroupSecrets(ctx, req.ParentRef, true)
 		if err != nil {
-			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project group %q secrets", req.ParentRef))
+			return nil, nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get project group %q secrets", req.ParentRef))
 		}
 
 		h.log.Info().Msgf("creating project group variable")
 		rv, _, err = h.configstoreClient.UpdateProjectGroupVariable(ctx, req.ParentRef, req.VariableName, creq)
 		if err != nil {
-			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create variable"))
+			return nil, nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to create variable"))
 		}
 	case cstypes.ObjectKindProject:
 		var err error
 		cssecrets, _, err = h.configstoreClient.GetProjectSecrets(ctx, req.ParentRef, true)
 		if err != nil {
-			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to get project %q secrets", req.ParentRef))
+			return nil, nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to get project %q secrets", req.ParentRef))
 		}
 
 		h.log.Info().Msgf("creating project variable")
 		rv, _, err = h.configstoreClient.UpdateProjectVariable(ctx, req.ParentRef, req.VariableName, creq)
 		if err != nil {
-			return nil, nil, util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to create variable"))
+			return nil, nil, util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to create variable"))
 		}
 	}
 	h.log.Info().Msgf("variable %s created, ID: %s", rv.Name, rv.ID)
@@ -206,7 +206,7 @@ func (h *ActionHandler) DeleteVariable(ctx context.Context, parentType cstypes.O
 		return errors.Wrapf(err, "failed to determine ownership")
 	}
 	if !isVariableOwner {
-		return util.NewAPIError(util.ErrForbidden, errors.Errorf("user not authorized"))
+		return util.NewAPIError(util.ErrForbidden, util.WithAPIErrorMsg("user not authorized"))
 	}
 
 	switch parentType {
@@ -218,7 +218,7 @@ func (h *ActionHandler) DeleteVariable(ctx context.Context, parentType cstypes.O
 		_, err = h.configstoreClient.DeleteProjectVariable(ctx, parentRef, name)
 	}
 	if err != nil {
-		return util.NewAPIError(util.KindFromRemoteError(err), errors.Wrapf(err, "failed to delete variable"))
+		return util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, util.WithAPIErrorMsg("failed to delete variable"))
 	}
 	return nil
 }

--- a/internal/services/gateway/api/api.go
+++ b/internal/services/gateway/api/api.go
@@ -40,7 +40,7 @@ func GetConfigTypeRef(r *http.Request) (cstypes.ObjectKind, string, error) {
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		return "", "", util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "wrong projectref %q", vars["projectref"]))
+		return "", "", util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("wrong projectref %q", vars["projectref"]))
 	}
 	if projectRef != "" {
 		return cstypes.ObjectKindProject, projectRef, nil
@@ -48,13 +48,13 @@ func GetConfigTypeRef(r *http.Request) (cstypes.ObjectKind, string, error) {
 
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		return "", "", util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "wrong projectgroupref %q", vars["projectgroupref"]))
+		return "", "", util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("wrong projectgroupref %q", vars["projectgroupref"]))
 	}
 	if projectGroupRef != "" {
 		return cstypes.ObjectKindProjectGroup, projectGroupRef, nil
 	}
 
-	return "", "", util.NewAPIError(util.ErrBadRequest, errors.Errorf("cannot get project or projectgroup ref"))
+	return "", "", util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("cannot get project or projectgroup ref"))
 }
 
 type requestOptions struct {
@@ -75,11 +75,11 @@ func parseRequestOptions(r *http.Request) (*requestOptions, error) {
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			return nil, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse limit"))
+			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse limit"))
 		}
 	}
 	if limit < 0 {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("limit must be greater or equal than 0"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("limit must be greater or equal than 0"))
 	}
 	if limit > MaxLimit {
 		limit = MaxLimit
@@ -91,12 +91,12 @@ func parseRequestOptions(r *http.Request) (*requestOptions, error) {
 		case gwapitypes.SortDirectionAsc:
 		case gwapitypes.SortDirectionDesc:
 		default:
-			return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("wrong sort direction %q", sortDirection))
+			return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("wrong sort direction %q", sortDirection))
 		}
 	}
 
 	if cursor != "" && sortDirection != "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("only one of cursor or sortdirection should be provided"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("only one of cursor or sortdirection should be provided"))
 	}
 
 	return &requestOptions{
@@ -135,7 +135,7 @@ func parseGroupRunsRequestOptions(r *http.Request) (*groupRunsRequestOptions, er
 		var err error
 		startRunCounter, err = strconv.ParseUint(startRunCounterStr, 10, 64)
 		if err != nil {
-			return nil, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse run counter"))
+			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run counter"))
 		}
 	}
 
@@ -145,16 +145,16 @@ func parseGroupRunsRequestOptions(r *http.Request) (*groupRunsRequestOptions, er
 
 	if ropts.Cursor != "" {
 		if hasStartRunCounter {
-			return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("only one of cursor or start should be provided"))
+			return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("only one of cursor or start should be provided"))
 		}
 		if subGroup != "" {
-			return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("only one of cursor or subgroup should be provided"))
+			return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("only one of cursor or subgroup should be provided"))
 		}
 		if len(phaseFilter) > 0 {
-			return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("only one of cursor or phaseFilter should be provided"))
+			return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("only one of cursor or phaseFilter should be provided"))
 		}
 		if len(resultFilter) > 0 {
-			return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("only one of cursor or resultFilter should be provided"))
+			return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("only one of cursor or resultFilter should be provided"))
 		}
 	}
 

--- a/internal/services/gateway/api/badge.go
+++ b/internal/services/gateway/api/badge.go
@@ -41,7 +41,7 @@ func (h *BadgeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 	branch := query.Get("branch")

--- a/internal/services/gateway/api/commitstatusdelivery.go
+++ b/internal/services/gateway/api/commitstatusdelivery.go
@@ -73,7 +73,7 @@ func (h *ProjectCommitStatusDeliveries) do(w http.ResponseWriter, r *http.Reques
 	deliveryStatusFilter := query["deliverystatus"]
 
 	if ropts.Cursor != "" && len(deliveryStatusFilter) > 0 {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("only one of cursor or deliverystatus should be provided"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("only one of cursor or deliverystatus should be provided"))
 	}
 
 	areq := &action.GetProjectCommitStatusDeliveriesRequest{

--- a/internal/services/gateway/api/oauth2.go
+++ b/internal/services/gateway/api/oauth2.go
@@ -42,7 +42,7 @@ func (h *OAuth2CallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	cresp, err := h.ah.HandleOauth2Callback(ctx, code, state)
 	if err != nil {
 		h.log.Err(err).Send()
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 

--- a/internal/services/gateway/api/org.go
+++ b/internal/services/gateway/api/org.go
@@ -47,7 +47,7 @@ func (h *CreateOrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req gwapitypes.CreateOrgRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -86,7 +86,7 @@ func (h *UpdateOrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req gwapitypes.UpdateOrgRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -300,7 +300,7 @@ func (h *AddOrgMemberHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	var req gwapitypes.AddOrgMemberRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -360,7 +360,7 @@ func (h *CreateOrgInvitationHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 	var req gwapitypes.CreateOrgInvitationRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -404,12 +404,12 @@ func (h *OrgInvitationsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse limit")))
+			util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse limit")))
 			return
 		}
 	}
 	if limit < 0 {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("limit must be greater or equal than 0")))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("limit must be greater or equal than 0")))
 		return
 	}
 	if limit > MaxOrgInvitationsLimit {
@@ -471,7 +471,7 @@ func (h *UserOrgInvitationActionHandler) ServeHTTP(w http.ResponseWriter, r *htt
 	var req gwapitypes.OrgInvitationActionRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 

--- a/internal/services/gateway/api/project.go
+++ b/internal/services/gateway/api/project.go
@@ -44,7 +44,7 @@ func (h *CreateProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	var req gwapitypes.CreateProjectRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -85,14 +85,14 @@ func (h *UpdateProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
 	var req gwapitypes.UpdateProjectRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -135,7 +135,7 @@ func (h *ProjectReconfigHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -162,7 +162,7 @@ func (h *ProjectUpdateRepoLinkedAccountHandler) ServeHTTP(w http.ResponseWriter,
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -192,7 +192,7 @@ func (h *DeleteProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -221,7 +221,7 @@ func (h *ProjectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -267,14 +267,14 @@ func (h *ProjectCreateRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
 	var req gwapitypes.ProjectCreateRunRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -303,7 +303,7 @@ func (h *RefreshRemoteRepositoryInfoHandler) ServeHTTP(w http.ResponseWriter, r 
 	vars := mux.Vars(r)
 	projectRef, err := url.PathUnescape(vars["projectref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 

--- a/internal/services/gateway/api/projectgroup.go
+++ b/internal/services/gateway/api/projectgroup.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
-	"github.com/sorintlab/errors"
 
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/services/gateway/common"
@@ -46,13 +45,13 @@ func (h *CreateProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	var req gwapitypes.CreateProjectGroupRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
 	userID := common.CurrentUserID(ctx)
 	if userID == "" {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user not authenticated")))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user not authenticated")))
 		return
 	}
 
@@ -89,14 +88,14 @@ func (h *UpdateProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	vars := mux.Vars(r)
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
 	var req gwapitypes.UpdateProjectGroupRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -137,7 +136,7 @@ func (h *DeleteProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	vars := mux.Vars(r)
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -166,7 +165,7 @@ func (h *ProjectGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	vars := mux.Vars(r)
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -196,7 +195,7 @@ func (h *ProjectGroupProjectsHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 	vars := mux.Vars(r)
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -230,7 +229,7 @@ func (h *ProjectGroupSubgroupsHandler) ServeHTTP(w http.ResponseWriter, r *http.
 	vars := mux.Vars(r)
 	projectGroupRef, err := url.PathUnescape(vars["projectgroupref"])
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 

--- a/internal/services/gateway/api/remoterepo.go
+++ b/internal/services/gateway/api/remoterepo.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
-	"github.com/sorintlab/errors"
 
 	gitsource "agola.io/agola/internal/gitsources"
 	"agola.io/agola/internal/services/gateway/action"
@@ -55,7 +54,7 @@ func (h *UserRemoteReposHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	userID := common.CurrentUserID(ctx)
 	if userID == "" {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user not authenticated")))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user not authenticated")))
 		return
 	}
 
@@ -68,7 +67,7 @@ func (h *UserRemoteReposHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	remoteRepos, err := gitsource.ListUserRepos()
 	if err != nil {
-		err := util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "failed to get user repositories from git source"))
+		err := util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("failed to get user repositories from git source"))
 		util.HTTPError(w, err)
 		h.log.Err(err).Send()
 		return

--- a/internal/services/gateway/api/remotesource.go
+++ b/internal/services/gateway/api/remotesource.go
@@ -43,7 +43,7 @@ func (h *CreateRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	var req gwapitypes.CreateRemoteSourceRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -89,7 +89,7 @@ func (h *UpdateRemoteSourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	var req gwapitypes.UpdateRemoteSourceRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 

--- a/internal/services/gateway/api/run.go
+++ b/internal/services/gateway/api/run.go
@@ -187,7 +187,7 @@ func (h *GroupRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case common.GroupTypeProject:
 		ref, err = url.PathUnescape(vars["projectref"])
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("projectref is empty")))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("projectref is empty")))
 			return
 		}
 	case common.GroupTypeUser:
@@ -201,7 +201,7 @@ func (h *GroupRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		runNumber, err = strconv.ParseUint(runNumberStr, 10, 64)
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse run number")))
+			util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run number")))
 			return
 		}
 	}
@@ -238,7 +238,7 @@ func (h *RuntaskHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case common.GroupTypeProject:
 		ref, err = url.PathUnescape(vars["projectref"])
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("projectref is empty")))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("projectref is empty")))
 			return
 		}
 	case common.GroupTypeUser:
@@ -252,7 +252,7 @@ func (h *RuntaskHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		runNumber, err = strconv.ParseUint(runNumberStr, 10, 64)
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse run number")))
+			util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run number")))
 			return
 		}
 	}
@@ -270,7 +270,7 @@ func (h *RuntaskHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	rt, ok := run.Tasks[taskID]
 	if !ok {
-		util.HTTPError(w, util.NewAPIError(util.ErrNotExist, errors.Errorf("run %q task %q not found", runNumber, taskID)))
+		util.HTTPError(w, util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("run %q task %q not found", runNumber, taskID)))
 		return
 	}
 	rct := rc.Tasks[rt.ID]
@@ -335,7 +335,7 @@ func (h *GroupRunsHandler) do(w http.ResponseWriter, r *http.Request) ([]*gwapit
 	case common.GroupTypeProject:
 		ref, err = url.PathUnescape(vars["projectref"])
 		if err != nil {
-			return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("projectref is empty"))
+			return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("projectref is empty"))
 		}
 	case common.GroupTypeUser:
 		ref = vars["userref"]
@@ -391,7 +391,7 @@ func (h *RunActionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case common.GroupTypeProject:
 		ref, err = url.PathUnescape(vars["projectref"])
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("projectref is empty")))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("projectref is empty")))
 			return
 		}
 	case common.GroupTypeUser:
@@ -405,7 +405,7 @@ func (h *RunActionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		runNumber, err = strconv.ParseUint(runNumberStr, 10, 64)
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse run number")))
+			util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run number")))
 			return
 		}
 	}
@@ -413,7 +413,7 @@ func (h *RunActionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req gwapitypes.RunActionsRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -457,7 +457,7 @@ func (h *RunTaskActionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	case common.GroupTypeProject:
 		ref, err = url.PathUnescape(vars["projectref"])
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("projectref is empty")))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("projectref is empty")))
 			return
 		}
 	case common.GroupTypeUser:
@@ -471,7 +471,7 @@ func (h *RunTaskActionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		var err error
 		runNumber, err = strconv.ParseUint(runNumberStr, 10, 64)
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse run number")))
+			util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run number")))
 			return
 		}
 	}
@@ -480,7 +480,7 @@ func (h *RunTaskActionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	var req gwapitypes.RunTaskActionsRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -521,7 +521,7 @@ func (h *LogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case common.GroupTypeProject:
 		ref, err = url.PathUnescape(vars["projectref"])
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("projectref is empty")))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("projectref is empty")))
 			return
 		}
 	case common.GroupTypeUser:
@@ -535,7 +535,7 @@ func (h *LogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		runNumber, err = strconv.ParseUint(runNumberStr, 10, 64)
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse run number")))
+			util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run number")))
 			return
 		}
 	}
@@ -545,11 +545,11 @@ func (h *LogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, setup := q["setup"]
 	stepStr := q.Get("step")
 	if !setup && stepStr == "" {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("no setup or step number provided")))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("no setup or step number provided")))
 		return
 	}
 	if setup && stepStr != "" {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("both setup and step number provided")))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("both setup and step number provided")))
 		return
 	}
 
@@ -558,7 +558,7 @@ func (h *LogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		step, err = strconv.Atoi(stepStr)
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse step number")))
+			util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse step number")))
 			return
 		}
 	}
@@ -658,7 +658,7 @@ func (h *LogsDeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case common.GroupTypeProject:
 		ref, err = url.PathUnescape(vars["projectref"])
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("projectref is empty")))
+			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("projectref is empty")))
 			return
 		}
 	case common.GroupTypeUser:
@@ -672,7 +672,7 @@ func (h *LogsDeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		runNumber, err = strconv.ParseUint(runNumberStr, 10, 64)
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse run number")))
+			util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run number")))
 			return
 		}
 	}
@@ -682,11 +682,11 @@ func (h *LogsDeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, setup := q["setup"]
 	stepStr := q.Get("step")
 	if !setup && stepStr == "" {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("no setup or step number provided")))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("no setup or step number provided")))
 		return
 	}
 	if setup && stepStr != "" {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("both setup and step number provided")))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("both setup and step number provided")))
 		return
 	}
 
@@ -695,7 +695,7 @@ func (h *LogsDeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		step, err = strconv.Atoi(stepStr)
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse step number")))
+			util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse step number")))
 			return
 		}
 	}

--- a/internal/services/gateway/api/runwebhookdelivery.go
+++ b/internal/services/gateway/api/runwebhookdelivery.go
@@ -74,7 +74,7 @@ func (h *ProjectRunWebhookDeliveries) do(w http.ResponseWriter, r *http.Request)
 	deliveryStatusFilter := query["deliverystatus"]
 
 	if ropts.Cursor != "" && len(deliveryStatusFilter) > 0 {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("only one of cursor or deliverystatus should be provided"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("only one of cursor or deliverystatus should be provided"))
 	}
 
 	areq := &action.GetProjectRunWebhookDeliveriesRequest{

--- a/internal/services/gateway/api/secret.go
+++ b/internal/services/gateway/api/secret.go
@@ -98,7 +98,7 @@ func (h *CreateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	var req gwapitypes.CreateSecretRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -146,7 +146,7 @@ func (h *UpdateSecretHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	var req gwapitypes.UpdateSecretRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 	areq := &action.UpdateSecretRequest{

--- a/internal/services/gateway/api/user.go
+++ b/internal/services/gateway/api/user.go
@@ -48,7 +48,7 @@ func (h *CreateUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req gwapitypes.CreateUserRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -107,7 +107,7 @@ func (h *CurrentUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	userID := common.CurrentUserID(ctx)
 	if userID == "" {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user not authenticated")))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user not authenticated")))
 		return
 	}
 
@@ -235,7 +235,7 @@ func (h *UsersHandler) do(w http.ResponseWriter, r *http.Request) ([]*gwapitypes
 		ausers = ares.Users
 		addCursorHeader(w, ares.Cursor)
 	default:
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("unknown query_type: %q", queryType))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("unknown query_type: %q", queryType))
 	}
 
 	users := make([]*gwapitypes.PrivateUserResponse, len(ausers))
@@ -263,7 +263,7 @@ func (h *CreateUserLAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	var req *gwapitypes.CreateUserLARequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -352,7 +352,7 @@ func (h *CreateUserTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	var req gwapitypes.CreateUserTokenRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -418,7 +418,7 @@ func (h *RegisterUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	var req *gwapitypes.RegisterUserRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -471,7 +471,7 @@ func (h *AuthorizeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req *gwapitypes.LoginUserRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -528,7 +528,7 @@ func (h *LoginUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req *gwapitypes.LoginUserRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -585,7 +585,7 @@ func (h *UserCreateRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	var req gwapitypes.UserCreateRunRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 
@@ -637,7 +637,7 @@ func (h *UserOrgsHandler) do(w http.ResponseWriter, r *http.Request) ([]*gwapity
 
 	userID := common.CurrentUserID(ctx)
 	if userID == "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user not authenticated"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user not authenticated"))
 	}
 
 	ropts, err := parseRequestOptions(r)
@@ -683,7 +683,7 @@ func (h *UserOrgInvitationsHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 
 	userID := common.CurrentUserID(ctx)
 	if userID == "" {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("user not authenticated")))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user not authenticated")))
 		return
 	}
 
@@ -701,12 +701,12 @@ func (h *UserOrgInvitationsHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse limit")))
+			util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse limit")))
 			return
 		}
 	}
 	if limit < 0 {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("limit must be greater or equal than 0")))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("limit must be greater or equal than 0")))
 		return
 	}
 	if limit > MaxOrgInvitationsLimit {

--- a/internal/services/gateway/api/variable.go
+++ b/internal/services/gateway/api/variable.go
@@ -116,7 +116,7 @@ func (h *CreateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	var req gwapitypes.CreateVariableRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 	areq := &action.CreateVariableRequest{
@@ -160,7 +160,7 @@ func (h *UpdateVariableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	var req gwapitypes.UpdateVariableRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 

--- a/internal/services/gateway/handlers/authchecker.go
+++ b/internal/services/gateway/handlers/authchecker.go
@@ -182,7 +182,7 @@ func (h *AuthChecker) do(ctx context.Context, w http.ResponseWriter, r *http.Req
 	}
 
 	if h.required {
-		return util.NewAPIError(util.ErrUnauthorized, errors.Errorf("auth required but no auth data"))
+		return util.NewAPIError(util.ErrUnauthorized, util.WithAPIErrorMsg("auth required but no auth data"))
 	}
 
 	h.doNext(ctx, w, r)
@@ -194,9 +194,9 @@ func (h *AuthChecker) checkAuthResponse(name string, res *checkerResponse) (bool
 
 	if res.failAuth {
 		if res.authErr != nil {
-			return false, util.NewAPIError(util.ErrUnauthorized, errors.Wrapf(res.authErr, "checker %s: auth failed", name))
+			return false, util.NewAPIErrorWrap(util.ErrUnauthorized, res.authErr, util.WithAPIErrorMsg("checker %s: auth failed", name))
 		}
-		return false, util.NewAPIError(util.ErrUnauthorized, errors.Errorf("checker %s: auth failed (no auth err reported by checker)", name))
+		return false, util.NewAPIError(util.ErrUnauthorized, util.WithAPIErrorMsg("checker %s: auth failed (no auth err reported by checker)", name))
 	}
 
 	if res.authErr != nil {

--- a/internal/services/handlers/auth.go
+++ b/internal/services/handlers/auth.go
@@ -17,7 +17,6 @@ import (
 	"net/http"
 
 	"github.com/rs/zerolog"
-	"github.com/sorintlab/errors"
 
 	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
@@ -53,11 +52,11 @@ func (h *InternalAuthChecker) do(w http.ResponseWriter, r *http.Request) error {
 		tokenString := common.ExtractToken(r.Header, "Authorization", "Token")
 
 		if tokenString == "" {
-			return util.NewAPIError(util.ErrUnauthorized, errors.Errorf("no api token provided"))
+			return util.NewAPIError(util.ErrUnauthorized, util.WithAPIErrorMsg("no api token provided"))
 		}
 
 		if tokenString != h.apiToken {
-			return util.NewAPIError(util.ErrUnauthorized, errors.Errorf("wrong api token"))
+			return util.NewAPIError(util.ErrUnauthorized, util.WithAPIErrorMsg("wrong api token"))
 		}
 	}
 

--- a/internal/services/notification/action/commitstatusdelivery.go
+++ b/internal/services/notification/action/commitstatusdelivery.go
@@ -85,7 +85,7 @@ func (h *ActionHandler) CommitStatusRedelivery(ctx context.Context, projectID st
 			return errors.WithStack(err)
 		}
 		if commitStatusDelivery == nil {
-			return util.NewAPIError(util.ErrNotExist, errors.Errorf("commitStatusDelivery %q doesn't exist", commitStatusDeliveryID))
+			return util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("commitStatusDelivery %q doesn't exist", commitStatusDeliveryID))
 		}
 
 		commitStatus, err := h.d.GetCommitStatusByID(tx, commitStatusDelivery.CommitStatusID)
@@ -93,10 +93,10 @@ func (h *ActionHandler) CommitStatusRedelivery(ctx context.Context, projectID st
 			return errors.WithStack(err)
 		}
 		if commitStatus == nil {
-			return util.NewAPIError(util.ErrNotExist, errors.Errorf("commitStatus %q doesn't exist", commitStatusDelivery.CommitStatusID))
+			return util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("commitStatus %q doesn't exist", commitStatusDelivery.CommitStatusID))
 		}
 		if commitStatus.ProjectID != projectID {
-			return util.NewAPIError(util.ErrNotExist, errors.Errorf("commitStatusDelivery %q doesn't belong to project %q", commitStatusDeliveryID, projectID))
+			return util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("commitStatusDelivery %q doesn't belong to project %q", commitStatusDeliveryID, projectID))
 		}
 
 		commitStatusDeliveries, err := h.d.GetCommitStatusDeliveriesByCommitStatusID(tx, commitStatusDelivery.CommitStatusID, []types.DeliveryStatus{types.DeliveryStatusNotDelivered}, 1, types.SortDirectionDesc)
@@ -105,7 +105,7 @@ func (h *ActionHandler) CommitStatusRedelivery(ctx context.Context, projectID st
 		}
 		// check if commitStatus has delivery not delivered
 		if len(commitStatusDeliveries) != 0 {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("the previous delivery of commit status %q hasn't already been delivered", commitStatusDelivery.CommitStatusID))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("the previous delivery of commit status %q hasn't already been delivered", commitStatusDelivery.CommitStatusID))
 		}
 
 		newCommitStatusDelivery := types.NewCommitStatusDelivery(tx)

--- a/internal/services/notification/action/runwebhookdelivery.go
+++ b/internal/services/notification/action/runwebhookdelivery.go
@@ -85,7 +85,7 @@ func (h *ActionHandler) RunWebhookRedelivery(ctx context.Context, projectID stri
 			return errors.WithStack(err)
 		}
 		if runWebhookDelivery == nil {
-			return util.NewAPIError(util.ErrNotExist, errors.Errorf("runWebhookDelivery %q doesn't exist", runWebhookDeliveryID))
+			return util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("runWebhookDelivery %q doesn't exist", runWebhookDeliveryID))
 		}
 
 		runWebhook, err := h.d.GetRunWebhookByID(tx, runWebhookDelivery.RunWebhookID)
@@ -93,10 +93,10 @@ func (h *ActionHandler) RunWebhookRedelivery(ctx context.Context, projectID stri
 			return errors.WithStack(err)
 		}
 		if runWebhook == nil {
-			return util.NewAPIError(util.ErrNotExist, errors.Errorf("runWebhook %q doesn't exist", runWebhookDelivery.RunWebhookID))
+			return util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("runWebhook %q doesn't exist", runWebhookDelivery.RunWebhookID))
 		}
 		if runWebhook.ProjectID != projectID {
-			return util.NewAPIError(util.ErrNotExist, errors.Errorf("runWebhookDelivery %q doesn't belong to project %q", runWebhookDeliveryID, projectID))
+			return util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("runWebhookDelivery %q doesn't belong to project %q", runWebhookDeliveryID, projectID))
 		}
 
 		runWebhookDeliveries, err := h.d.GetRunWebhookDeliveriesByRunWebhookID(tx, runWebhookDelivery.RunWebhookID, []types.DeliveryStatus{types.DeliveryStatusNotDelivered}, 1, types.SortDirectionDesc)
@@ -105,7 +105,7 @@ func (h *ActionHandler) RunWebhookRedelivery(ctx context.Context, projectID stri
 		}
 		// check if runWebhook has delivery not delivered
 		if len(runWebhookDeliveries) != 0 {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("the previous delivery of run webhook %q hasn't already been delivered", runWebhookDelivery.RunWebhookID))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("the previous delivery of run webhook %q hasn't already been delivered", runWebhookDelivery.RunWebhookID))
 		}
 
 		newRunWebhookDelivery := types.NewRunWebhookDelivery(tx)

--- a/internal/services/notification/api/api.go
+++ b/internal/services/notification/api/api.go
@@ -18,8 +18,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/pkg/errors"
-
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/notification/types"
 )
@@ -42,11 +40,11 @@ func parseRequestOptions(r *http.Request) (*requestOptions, error) {
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			return nil, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse limit"))
+			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse limit"))
 		}
 	}
 	if limit < 0 {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("limit must be greater or equal than 0"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("limit must be greater or equal than 0"))
 	}
 
 	sortDirection := types.SortDirection(query.Get("sortdirection"))
@@ -55,7 +53,7 @@ func parseRequestOptions(r *http.Request) (*requestOptions, error) {
 		case types.SortDirectionAsc:
 		case types.SortDirectionDesc:
 		default:
-			return nil, util.NewAPIError(util.ErrBadRequest, errors.Errorf("wrong sort direction %q", sortDirection))
+			return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("wrong sort direction %q", sortDirection))
 		}
 	}
 

--- a/internal/services/notification/api/commitstatusdelivery.go
+++ b/internal/services/notification/api/commitstatusdelivery.go
@@ -62,7 +62,7 @@ func (h *CommitStatusDeliveriesHandler) do(w http.ResponseWriter, r *http.Reques
 
 	deliveryStatusFilter, err := types.DeliveryStatusFromStringSlice(query["deliverystatus"])
 	if err != nil {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "wrong deliverystatus"))
+		return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("wrong deliverystatus"))
 	}
 
 	startSequenceStr := query.Get("startsequence")
@@ -71,7 +71,7 @@ func (h *CommitStatusDeliveriesHandler) do(w http.ResponseWriter, r *http.Reques
 		var err error
 		startSequence, err = strconv.ParseUint(startSequenceStr, 10, 64)
 		if err != nil {
-			return nil, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse startsequence"))
+			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse startsequence"))
 		}
 	}
 

--- a/internal/services/notification/api/runwebhookdelivery.go
+++ b/internal/services/notification/api/runwebhookdelivery.go
@@ -62,7 +62,7 @@ func (h *RunWebhookDeliveriesHandler) do(w http.ResponseWriter, r *http.Request)
 
 	deliveryStatusFilter, err := types.DeliveryStatusFromStringSlice(query["deliverystatus"])
 	if err != nil {
-		return nil, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "wrong deliverystatus"))
+		return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("wrong deliverystatus"))
 	}
 
 	startSequenceStr := query.Get("startsequence")
@@ -71,7 +71,7 @@ func (h *RunWebhookDeliveriesHandler) do(w http.ResponseWriter, r *http.Request)
 		var err error
 		startSequence, err = strconv.ParseUint(startSequenceStr, 10, 64)
 		if err != nil {
-			return nil, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse startsequence"))
+			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse startsequence"))
 		}
 	}
 

--- a/internal/services/notification/notification_test.go
+++ b/internal/services/notification/notification_test.go
@@ -822,7 +822,7 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 
 		runWebhook := createRunWebhook(t, ctx, ns, project01)
 
-		expectedErr := util.NewAPIError(util.ErrNotExist, errors.Errorf("runWebhookDelivery %q doesn't exist", runWebhookDelivery01))
+		expectedErr := util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("runWebhookDelivery %q doesn't exist", runWebhookDelivery01))
 		err := ns.ah.RunWebhookRedelivery(ctx, runWebhook.ProjectID, runWebhookDelivery01)
 		assert.Error(t, err, expectedErr.Error())
 	})
@@ -842,7 +842,7 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		runWebhook = createRunWebhook(t, ctx, ns, project02)
 		createRunWebhookDelivery(t, ctx, ns, runWebhook.ID, types.DeliveryStatusDelivered)
 
-		expectedErr := util.NewAPIError(util.ErrNotExist, errors.Errorf("runWebhookDelivery %q doesn't belong to project %q", runWebhookDelivery.ID, project02))
+		expectedErr := util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("runWebhookDelivery %q doesn't belong to project %q", runWebhookDelivery.ID, project02))
 
 		err := ns.ah.RunWebhookRedelivery(ctx, project02, runWebhookDelivery.ID)
 		assert.Error(t, err, expectedErr.Error())
@@ -868,7 +868,7 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		ns.c.WebhookSecret = webhookSecret
 		ns.c.WebhookURL = fmt.Sprintf("%s/%s", wr.exposedURL, "webhooks")
 
-		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("the previous delivery of run webhook %q hasn't already been delivered", runWebhookDelivery.RunWebhookID))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("the previous delivery of run webhook %q hasn't already been delivered", runWebhookDelivery.RunWebhookID))
 
 		err := ns.ah.RunWebhookRedelivery(ctx, runWebhook.ProjectID, runWebhookDelivery.ID)
 		assert.Error(t, err, expectedErr.Error())
@@ -1176,7 +1176,7 @@ func TestProjectCommitStatusRedelivery(t *testing.T) {
 
 		commitStatus := createCommitStatus(t, ctx, ns, 1, project01)
 
-		expectedErr := util.NewAPIError(util.ErrNotExist, errors.Errorf("commitStatusDelivery %q doesn't exist", commitStatusDelivery01))
+		expectedErr := util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("commitStatusDelivery %q doesn't exist", commitStatusDelivery01))
 		err := ns.ah.CommitStatusRedelivery(ctx, commitStatus.ProjectID, commitStatusDelivery01)
 		if err == nil {
 			t.Fatalf("expected error %v, got nil err", expectedErr)
@@ -1201,7 +1201,7 @@ func TestProjectCommitStatusRedelivery(t *testing.T) {
 		commitStatus = createCommitStatus(t, ctx, ns, 1, project02)
 		createCommitStatusDelivery(t, ctx, ns, commitStatus.ID, types.DeliveryStatusDelivered)
 
-		expectedErr := util.NewAPIError(util.ErrNotExist, errors.Errorf("commitStatusDelivery %q doesn't belong to project %q", commitStatusDelivery.ID, project02))
+		expectedErr := util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("commitStatusDelivery %q doesn't belong to project %q", commitStatusDelivery.ID, project02))
 
 		err := ns.ah.CommitStatusRedelivery(ctx, project02, commitStatusDelivery.ID)
 		if err == nil {
@@ -1229,7 +1229,7 @@ func TestProjectCommitStatusRedelivery(t *testing.T) {
 		cs := setupStubCommitStatusUpdater()
 		ns.u = cs
 
-		expectedErr := util.NewAPIError(util.ErrBadRequest, errors.Errorf("the previous delivery of commit status %q hasn't already been delivered", commitStatusDelivery.CommitStatusID))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("the previous delivery of commit status %q hasn't already been delivered", commitStatusDelivery.CommitStatusID))
 
 		err := ns.ah.CommitStatusRedelivery(ctx, commitStatus.ProjectID, commitStatusDelivery.ID)
 		if err == nil {

--- a/internal/services/notification/runeventssender_test.go
+++ b/internal/services/notification/runeventssender_test.go
@@ -164,7 +164,7 @@ func (h *runEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		afterRunEventSequence, err = strconv.ParseUint(afterRunEventSequenceStr, 10, 64)
 		if err != nil {
-			util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Wrapf(err, "cannot parse afterSequence")))
+			util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse afterSequence")))
 			return
 		}
 	}

--- a/internal/services/notification/webhooksreceiver_test.go
+++ b/internal/services/notification/webhooksreceiver_test.go
@@ -182,7 +182,7 @@ func newHandleWebhookHandler(log zerolog.Logger, webhooks *webhooks) *handleWebh
 func (h *handleWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, err))
+		util.HTTPError(w, util.NewAPIErrorWrap(util.ErrBadRequest, err))
 		return
 	}
 

--- a/internal/services/runservice/action/maintenance.go
+++ b/internal/services/runservice/action/maintenance.go
@@ -109,10 +109,10 @@ func (h *ActionHandler) SetMaintenanceEnabled(ctx context.Context, enable bool) 
 		}
 
 		if enable && enabled {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("maintenance mode already enabled"))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("maintenance mode already enabled"))
 		}
 		if !enable && !enabled {
-			return util.NewAPIError(util.ErrBadRequest, errors.Errorf("maintenance mode already disabled"))
+			return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("maintenance mode already disabled"))
 		}
 
 		db := sq.DeleteFrom(maintenanceTableName)
@@ -142,7 +142,7 @@ func (h *ActionHandler) Export(ctx context.Context, w io.Writer) error {
 
 func (h *ActionHandler) Import(ctx context.Context, r io.Reader) error {
 	if !h.maintenanceMode {
-		return util.NewAPIError(util.ErrBadRequest, errors.Errorf("not in maintenance mode"))
+		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("not in maintenance mode"))
 	}
 
 	dbm := manager.NewDBManager(h.log, h.d, h.lf)

--- a/internal/services/runservice/api/executor.go
+++ b/internal/services/runservice/api/executor.go
@@ -275,7 +275,7 @@ func (h *ExecutorTaskHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	// TODO(sgotti) Check authorized call from executors
 	etID := vars["taskid"]
 	if etID == "" {
-		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, errors.Errorf("taskid is empty")))
+		util.HTTPError(w, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("taskid is empty")))
 		return
 	}
 
@@ -380,7 +380,7 @@ func (h *ArchivesHandler) readArchive(rtID string, step int, w io.Writer) error 
 	f, err := h.ost.ReadObject(archivePath)
 	if err != nil {
 		if objectstorage.IsNotExist(err) {
-			return util.NewAPIError(util.ErrNotExist, err)
+			return util.NewAPIErrorWrap(util.ErrNotExist, err)
 		}
 		return errors.WithStack(err)
 	}
@@ -489,7 +489,7 @@ func (h *CacheHandler) readCache(key string, w io.Writer) error {
 	f, err := h.ost.ReadObject(cachePath)
 	if err != nil {
 		if objectstorage.IsNotExist(err) {
-			return util.NewAPIError(util.ErrNotExist, err)
+			return util.NewAPIErrorWrap(util.ErrNotExist, err)
 		}
 		return errors.WithStack(err)
 	}
@@ -586,7 +586,7 @@ func (h *ExecutorDeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 			return errors.WithStack(err)
 		}
 		if executor == nil {
-			return util.NewAPIError(util.ErrNotExist, errors.Errorf("executor with executor id %s doesn't exist", executorID))
+			return util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("executor with executor id %s doesn't exist", executorID))
 		}
 
 		if err := h.d.DeleteExecutor(tx, executor.ID); err != nil {

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -178,38 +178,69 @@ type APIError struct {
 	Kind    ErrorKind
 	Code    ErrorCode
 	Message string
+
+	msg string
 }
 
-func NewAPIError(kind ErrorKind, err error, options ...APIErrorOption) error {
+func NewAPIErrorWrap(kind ErrorKind, err error, options ...APIErrorOption) error {
 	aerr := &APIError{Kind: kind}
 
 	for _, opt := range options {
 		opt(aerr)
 	}
 
-	msg := fmt.Sprintf("apiError (kind: %s", kind)
-	if aerr.Code != "" {
-		msg += fmt.Sprintf(", code: %s", aerr.Code)
-	}
-	if aerr.Message != "" {
-		msg += fmt.Sprintf(", message: %s", aerr.Message)
-	}
-	msg += ")"
-
-	aerr.WrapperError = NewWrapperError(err, WithWrapperErrorMsg(msg))
+	aerr.WrapperError = NewWrapperError(err, WithWrapperErrorMsg(aerr.message()))
 
 	return aerr
 }
 
+func NewAPIError(kind ErrorKind, options ...APIErrorOption) error {
+	aerr := &APIError{Kind: kind}
+
+	for _, opt := range options {
+		opt(aerr)
+	}
+
+	aerr.WrapperError = NewWrapperError(nil, WithWrapperErrorMsg(aerr.message()))
+
+	return aerr
+}
+
+func (e *APIError) message() string {
+	msg := e.msg
+	if msg != "" {
+		msg += ", "
+	}
+	msg += fmt.Sprintf("apiError (kind: %s", e.Kind)
+	if e.Code != "" {
+		msg += fmt.Sprintf(", code: %s", e.Code)
+	}
+	if e.Message != "" {
+		msg += fmt.Sprintf(", message: %s", e.Message)
+	}
+	msg += ")"
+
+	return msg
+}
+
 type APIErrorOption func(e *APIError)
 
-func WithCode(code ErrorCode) APIErrorOption {
+// WithAPIErrorMsg adds an internal message to the error. This message could
+// contain sensitive data so it's just for internal logging and will not be sent
+// to the api caller.
+func WithAPIErrorMsg(format string, args ...interface{}) APIErrorOption {
+	return func(e *APIError) {
+		e.msg = fmt.Sprintf(format, args...)
+	}
+}
+
+func WithAPIErrorUserCode(code ErrorCode) APIErrorOption {
 	return func(e *APIError) {
 		e.Code = code
 	}
 }
 
-func WithMessage(message string) APIErrorOption {
+func WithAPIErrorUserMessage(message string) APIErrorOption {
 	return func(e *APIError) {
 		e.Message = message
 	}

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -71,7 +71,7 @@ func (e *Errors) Equal(e2 error) bool {
 //
 //	func NewCustomError(err error) error {
 //		return &CustomError{
-//			util.NewWrapperError(err, "connection error"),
+//			util.NewWrapperError(err, util.WithWrapperErrorMsg("connection error")),
 //		}
 //	}
 //
@@ -98,12 +98,32 @@ type WrapperError struct {
 	stack *errors.Stack
 }
 
-func NewWrapperError(err error, format string, args ...interface{}) *WrapperError {
-	return &WrapperError{
-		err: err,
-		msg: fmt.Sprintf(format, args...),
+func NewWrapperError(err error, options ...WrapperErrorOption) *WrapperError {
+	werr := &WrapperError{err: err}
+
+	for _, opt := range options {
+		opt(werr)
+	}
+
+	if werr.stack == nil {
 		// skip one frame by default if the error is used as in the example
-		stack: errors.Callers(1),
+		werr.stack = errors.Callers(1)
+	}
+
+	return werr
+}
+
+type WrapperErrorOption func(e *WrapperError)
+
+func WithWrapperErrorMsg(format string, args ...interface{}) WrapperErrorOption {
+	return func(e *WrapperError) {
+		e.msg = fmt.Sprintf(format, args...)
+	}
+}
+
+func WithWrapperErrorCallerDepth(depth int) WrapperErrorOption {
+	return func(e *WrapperError) {
+		e.stack = errors.Callers(depth + 1)
 	}
 }
 
@@ -176,7 +196,7 @@ func NewAPIError(kind ErrorKind, err error, options ...APIErrorOption) error {
 	}
 	msg += ")"
 
-	aerr.WrapperError = NewWrapperError(err, msg)
+	aerr.WrapperError = NewWrapperError(err, WithWrapperErrorMsg(msg))
 
 	return aerr
 }


### PR DESCRIPTION
Now, to add a message to an APIError, we had to wrap the starting error
with errors.Wrap or, in case of no starting error, we had to create a
new error with errors.Errorf.

This way isn't really clean since we are creating an intermediary
wrapping error.

With this patch NewAPIError could be used when there's no error to wrap
or the wrapped error can be provided using NewAPIErrorWrap. An optional
message could be added using the WithAPIErrorMsg option.