### PR TITLE
*: add detailed errors to api responses

### DIFF
--- a/internal/services/configstore/action/action.go
+++ b/internal/services/configstore/action/action.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sorintlab/errors"
 
 	"agola.io/agola/internal/services/configstore/db"
+	serrors "agola.io/agola/internal/services/errors"
 	"agola.io/agola/internal/sqlg/lock"
 	"agola.io/agola/internal/sqlg/sql"
 	"agola.io/agola/internal/util"
@@ -52,7 +53,7 @@ func (h *ActionHandler) ResolveObjectID(tx *sql.Tx, objectKind types.ObjectKind,
 			return "", errors.WithStack(err)
 		}
 		if group == nil {
-			return "", util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("group with ref %q doesn't exists", ref))
+			return "", util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("project group with ref %q doesn't exists", ref), serrors.ProjectGroupDoesNotExist())
 		}
 		return group.ID, nil
 
@@ -62,7 +63,7 @@ func (h *ActionHandler) ResolveObjectID(tx *sql.Tx, objectKind types.ObjectKind,
 			return "", errors.WithStack(err)
 		}
 		if project == nil {
-			return "", util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project with ref %q doesn't exists", ref))
+			return "", util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("project with ref %q doesn't exists", ref), serrors.ProjectDoesNotExist())
 		}
 		return project.ID, nil
 

--- a/internal/services/configstore/api/api.go
+++ b/internal/services/configstore/api/api.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	serrors "agola.io/agola/internal/services/errors"
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/configstore/types"
 )
@@ -64,11 +65,11 @@ func parseRequestOptions(r *http.Request) (*requestOptions, error) {
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse limit"))
+			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse limit"), serrors.InvalidLimit())
 		}
 	}
 	if limit < 0 {
-		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("limit must be greater or equal than 0"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("limit must be greater or equal than 0"), serrors.InvalidLimit())
 	}
 
 	sortDirection := types.SortDirection(query.Get("sortdirection"))
@@ -77,7 +78,7 @@ func parseRequestOptions(r *http.Request) (*requestOptions, error) {
 		case types.SortDirectionAsc:
 		case types.SortDirectionDesc:
 		default:
-			return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("wrong sort direction %q", sortDirection))
+			return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("wrong sort direction %q", sortDirection), serrors.InvalidSortDirection())
 		}
 	}
 

--- a/internal/services/configstore/api/org.go
+++ b/internal/services/configstore/api/org.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sorintlab/errors"
 
 	"agola.io/agola/internal/services/configstore/action"
+	serrors "agola.io/agola/internal/services/errors"
 	"agola.io/agola/internal/util"
 	csapitypes "agola.io/agola/services/configstore/api/types"
 	"agola.io/agola/services/configstore/types"
@@ -221,7 +222,7 @@ func (h *OrgsHandler) do(w http.ResponseWriter, r *http.Request) ([]*types.Organ
 	if ok {
 		for _, vs := range visibilitiesStr {
 			if !types.IsValidVisibility(types.Visibility(vs)) {
-				return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid visibility"))
+				return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid visibility"), serrors.InvalidVisibility())
 			}
 			visibilities = append(visibilities, types.Visibility(vs))
 		}

--- a/internal/services/configstore/configstore_test.go
+++ b/internal/services/configstore/configstore_test.go
@@ -34,6 +34,7 @@ import (
 
 	"agola.io/agola/internal/services/config"
 	"agola.io/agola/internal/services/configstore/action"
+	serrors "agola.io/agola/internal/services/errors"
 	"agola.io/agola/internal/sqlg"
 	"agola.io/agola/internal/sqlg/sql"
 	"agola.io/agola/internal/testutil"
@@ -341,7 +342,7 @@ func TestUser(t *testing.T) {
 	})
 
 	t.Run("create duplicated user", func(t *testing.T) {
-		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user with name %q already exists", "user01"))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user with name %q already exists", "user01"), serrors.UserAlreadyExists())
 		_, err := cs.ah.CreateUser(ctx, &action.CreateUserRequest{UserName: "user01"})
 		assert.Error(t, err, expectedErr.Error())
 	})
@@ -431,32 +432,32 @@ func TestProjectGroupsAndProjectsCreate(t *testing.T) {
 
 	t.Run("create duplicated project in user root project group", func(t *testing.T) {
 		projectName := "project01"
-		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, projectName)))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, projectName)), serrors.ProjectAlreadyExists())
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: projectName, Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		assert.Error(t, err, expectedErr.Error())
 	})
 	t.Run("create duplicated project in org root project group", func(t *testing.T) {
 		projectName := "project01"
-		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project with name %q, path %q already exists", projectName, path.Join("org", org.Name, projectName)))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project with name %q, path %q already exists", projectName, path.Join("org", org.Name, projectName)), serrors.ProjectAlreadyExists())
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: projectName, Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("org", org.Name)}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		assert.Error(t, err, expectedErr.Error())
 	})
 
 	t.Run("create duplicated project in user non root project group", func(t *testing.T) {
 		projectName := "project01"
-		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, "projectgroup01", projectName)))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, "projectgroup01", projectName)), serrors.ProjectAlreadyExists())
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: projectName, Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		assert.Error(t, err, expectedErr.Error())
 	})
 	t.Run("create duplicated project in org non root project group", func(t *testing.T) {
 		projectName := "project01"
-		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project with name %q, path %q already exists", projectName, path.Join("org", org.Name, "projectgroup01", projectName)))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project with name %q, path %q already exists", projectName, path.Join("org", org.Name, "projectgroup01", projectName)), serrors.ProjectAlreadyExists())
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: projectName, Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("org", org.Name, "projectgroup01")}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		assert.Error(t, err, expectedErr.Error())
 	})
 
 	t.Run("create project in unexistent project group", func(t *testing.T) {
-		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg(`project group with id "unexistentid" doesn't exist`))
+		expectedErr := util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg(`parent project group with id "unexistentid" doesn't exist`), serrors.ParentProjectGroupDoesNotExist())
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{Name: "project01", Parent: types.Parent{Kind: types.ObjectKindProjectGroup, ID: "unexistentid"}, Visibility: types.VisibilityPublic, RemoteRepositoryConfigType: types.RemoteRepositoryConfigTypeManual})
 		assert.Error(t, err, expectedErr.Error())
 	})
@@ -527,7 +528,7 @@ func TestProjectUpdate(t *testing.T) {
 	})
 	t.Run("move project to project group having project with same name", func(t *testing.T) {
 		projectName := "project01"
-		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, projectName)))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project with name %q, path %q already exists", projectName, path.Join("user", user.Name, projectName)), serrors.ProjectAlreadyExists())
 		p02req.Parent.ID = path.Join("user", user.Name)
 		_, err := cs.ah.UpdateProject(ctx, path.Join("user", user.Name, "projectgroup01", projectName), p02req)
 		assert.Error(t, err, expectedErr.Error())
@@ -540,7 +541,7 @@ func TestProjectUpdate(t *testing.T) {
 		testutil.NilError(t, err)
 	})
 	t.Run("test user project MembersCanPerformRunActions parameter", func(t *testing.T) {
-		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("cannot set MembersCanPerformRunActions on an user project."))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("cannot set MembersCanPerformRunActions on an user project."), serrors.CannotSetMembersCanPerformRunActionsOnUserProject())
 		_, err := cs.ah.CreateProject(ctx, &action.CreateUpdateProjectRequest{
 			Name:                        "project03",
 			Parent:                      types.Parent{Kind: types.ObjectKindProjectGroup, ID: path.Join("user", user.Name)},
@@ -606,7 +607,7 @@ func TestProjectGroupUpdate(t *testing.T) {
 	})
 	t.Run("move project to project group having project with same name", func(t *testing.T) {
 		projectGroupName := "pg01"
-		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project group with name %q, path %q already exists", projectGroupName, path.Join("user", user.Name, projectGroupName)))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project group with name %q, path %q already exists", projectGroupName, path.Join("user", user.Name, projectGroupName)), serrors.ProjectGroupAlreadyExists())
 		pg05req.Parent.ID = path.Join("user", user.Name)
 		_, err := cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name, "pg02", projectGroupName), pg05req)
 		assert.Error(t, err, expectedErr.Error())
@@ -661,7 +662,7 @@ func TestProjectGroupUpdate(t *testing.T) {
 
 		rootPGres.ProjectGroup.Name = "rootpgnewname"
 
-		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project group name for root project group must be empty"))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("project group name for root project group must be empty"), serrors.InvalidProjectGroupName())
 		_, err = cs.ah.UpdateProjectGroup(ctx, path.Join("user", user.Name), &action.CreateUpdateProjectGroupRequest{Name: rootPGres.ProjectGroup.Name, Parent: rootPGres.ProjectGroup.Parent, Visibility: rootPGres.ProjectGroup.Visibility})
 		assert.Error(t, err, expectedErr.Error())
 	})
@@ -1521,7 +1522,7 @@ func TestRemoteSource(t *testing.T) {
 				_, err := cs.ah.CreateRemoteSource(ctx, rsreq)
 				testutil.NilError(t, err)
 
-				expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg(`remotesource "rs01" already exists`))
+				expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg(`remotesource "rs01" already exists`), serrors.RemoteSourceAlreadyExists())
 				_, err = cs.ah.CreateRemoteSource(ctx, rsreq)
 				assert.Error(t, err, expectedErr.Error())
 			},
@@ -1589,7 +1590,7 @@ func TestRemoteSource(t *testing.T) {
 				_, err = cs.ah.CreateRemoteSource(ctx, rs02req)
 				testutil.NilError(t, err)
 
-				expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg(`remotesource "rs02" already exists`))
+				expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg(`remotesource "rs02" already exists`), serrors.RemoteSourceAlreadyExists())
 				rs01req.Name = "rs02"
 				_, err = cs.ah.UpdateRemoteSource(ctx, "rs01", rs01req)
 				assert.Error(t, err, expectedErr.Error())
@@ -1832,7 +1833,7 @@ func TestOrgInvitation(t *testing.T) {
 				_, err = cs.ah.CreateOrgInvitation(ctx, rs)
 				testutil.NilError(t, err)
 
-				expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invitation already exists"))
+				expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invitation already exists"), serrors.InvitationAlreadyExists())
 				_, err = cs.ah.CreateOrgInvitation(ctx, rs)
 				assert.Error(t, err, expectedErr.Error())
 			},

--- a/internal/services/errors/errors.go
+++ b/internal/services/errors/errors.go
@@ -1,0 +1,262 @@
+package errors
+
+import (
+	"agola.io/agola/internal/util"
+	apierrors "agola.io/agola/services/gateway/api/errors"
+)
+
+func detailedErrorOption(code util.ErrorCode) util.APIErrorOption {
+	return util.WithAPIErrorDetailedError(util.NewAPIDetailedError(code))
+}
+
+func InvalidStartSequence() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidStartSequence)
+}
+
+func InvalidLimit() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidLimit)
+}
+
+func InvalidSortDirection() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidSortDirection)
+}
+
+func InvalidVisibility() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidVisibility)
+}
+
+func InvalidRole() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidRole)
+}
+
+func UserDoesNotExist() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeUserDoesNotExist)
+}
+
+func UserAlreadyExists() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeUserAlreadyExists)
+}
+
+func InvalidUserName() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidUserName)
+}
+
+func UserTokenDoesNotExist() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeUserTokenDoesNotExist)
+}
+
+func UserTokenAlreadyExists() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeUserTokenAlreadyExists)
+}
+
+func ParentProjectGroupDoesNotExist() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeParentProjectGroupDoesNotExist)
+}
+
+func ProjectGroupDoesNotExist() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeProjectGroupDoesNotExist)
+}
+
+func ProjectGroupAlreadyExists() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeProjectGroupAlreadyExists)
+}
+
+func InvalidProjectGroupName() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidProjectGroupName)
+}
+
+func ProjectDoesNotExist() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeProjectDoesNotExist)
+}
+
+func ProjectAlreadyExists() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeProjectAlreadyExists)
+}
+
+func InvalidProjectName() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidProjectName)
+}
+
+func RemoteSourceDoesNotExist() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeRemoteSourceDoesNotExist)
+}
+
+func RemoteSourceAlreadyExists() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeRemoteSourceAlreadyExists)
+}
+
+func InvalidRemoteSourceName() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidRemoteSourceName)
+}
+
+func InvalidRemoteSourceType() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidRemoteSourceType)
+}
+
+func InvalidRemoteSourceAuthType() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidRemoteSourceAuthType)
+}
+
+func InvalidRemoteSourceAPIURL() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidRemoteSourceAPIURL)
+}
+
+func InvalidOauth2ClientID() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidOauth2ClientID)
+}
+
+func InvalidOauth2ClientSecret() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidOauth2ClientSecret)
+}
+
+func LinkedAccountDoesNotExist() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeLinkedAccountDoesNotExist)
+}
+
+func LinkedAccountAlreadyExists() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeLinkedAccountAlreadyExists)
+}
+
+func InvalidRepoPath() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidRepoPath)
+}
+
+func CannotSetMembersCanPerformRunActionsOnUserProject() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeCannotSetMembersCanPerformRunActionsOnUserProject)
+}
+
+func SecretDoesNotExist() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeSecretDoesNotExist)
+}
+
+func SecretAlreadyExists() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeSecretAlreadyExists)
+}
+
+func InvalidSecretName() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidSecretName)
+}
+
+func InvalidSecretType() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidSecretType)
+}
+
+func InvalidSecretData() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidSecretData)
+}
+
+func VariableDoesNotExist() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeVariableDoesNotExist)
+}
+
+func VariableAlreadyExists() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeVariableAlreadyExists)
+}
+
+func InvalidVariableName() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidVariableName)
+}
+
+func InvalidVariableValues() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidVariableValues)
+}
+
+func CreatorUserDoesNotExist() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeCreatorUserDoesNotExist)
+}
+
+func OrganizationDoesNotExist() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeOrganizationDoesNotExist)
+}
+
+func OrganizationAlreadyExists() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeOrganizationAlreadyExists)
+}
+
+func InvalidOrganizationName() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidOrganizationName)
+}
+
+func OrgMemberDoesNotExist() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeOrgMemberDoesNotExist)
+}
+
+func InvitationDoesNotExist() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvitationDoesNotExist)
+}
+
+func InvitationAlreadyExists() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvitationAlreadyExists)
+}
+
+func CannotAddUserToOrganization() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeCannotAddUserToOrganization)
+}
+
+func CannotCreateInvitation() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeCannotCreateInvitation)
+}
+
+func InvalidRunGroup() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidRunGroup)
+}
+
+func InvalidRunNumber() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidRunNumber)
+}
+
+func InvalidRunTaskStepNumber() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidRunTaskStepNumber)
+}
+
+func RunDoesNotExist() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeRunDoesNotExist)
+}
+
+func RunTaskDoesNotExist() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeRunTaskDoesNotExist)
+}
+
+func RunTaskStepDoesNotExist() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeRunTaskStepDoesNotExist)
+}
+
+func RunCannotBeRestarted() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeRunCannotBeRestarted)
+}
+
+func RunTaskNotWaitingApproval() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeRunTaskNotWaitingApproval)
+}
+
+func RunTaskAlreadyApproved() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeRunTaskAlreadyApproved)
+}
+
+func InvalidDeliveryStatus() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeInvalidDeliveryStatus)
+}
+
+func CommitStatusDoesNotExist() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeCommitStatusDoesNotExist)
+}
+
+func CommitStatusDeliveryDoesNotExist() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeCommitStatusDeliveryDoesNotExist)
+}
+
+func CommitStatusDeliveryAlreadyInProgress() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeCommitStatusDeliveryAlreadyInProgress)
+}
+
+func RunWebhookDoesNotExist() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeRunWebhookDoesNotExist)
+}
+
+func RunWebhookDeliveryDoesNotExist() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeRunWebhookDeliveryDoesNotExist)
+}
+
+func RunWebhookDeliveryAlreadyInProgress() util.APIErrorOption {
+	return detailedErrorOption(apierrors.ErrorCodeRunWebhookDeliveryAlreadyInProgress)
+}

--- a/internal/services/gateway/action/action.go
+++ b/internal/services/gateway/action/action.go
@@ -34,7 +34,10 @@ func APIErrorFromRemoteError(err error, options ...util.APIErrorOption) error {
 	}
 
 	// assume remote error from internal services can be propagated from the gateway
-	opts = append(opts, util.WithAPIErrorUserCode(util.ErrorCode(rerr.Code)), util.WithAPIErrorUserMessage(rerr.Message))
+	for _, detailedError := range rerr.DetailedErrors {
+		opts = append(opts, util.WithAPIErrorDetailedError(util.NewAPIDetailedError(util.ErrorCode(detailedError.Code), util.WithAPIDetailedErrorDetails(detailedError.Details))))
+	}
+
 	return util.NewAPIErrorWrap(util.KindFromRemoteError(err), err, opts...)
 }
 

--- a/internal/services/gateway/action/secret.go
+++ b/internal/services/gateway/action/secret.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sorintlab/errors"
 
 	"agola.io/agola/internal/services/common"
+	serrors "agola.io/agola/internal/services/errors"
 	"agola.io/agola/internal/util"
 	csapitypes "agola.io/agola/services/configstore/api/types"
 	cstypes "agola.io/agola/services/configstore/types"
@@ -80,7 +81,7 @@ func (h *ActionHandler) CreateSecret(ctx context.Context, req *CreateSecretReque
 	}
 
 	if !util.ValidateName(req.Name) {
-		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid secret name %q", req.Name))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid secret name %q", req.Name), serrors.InvalidSecretName())
 	}
 
 	creq := &csapitypes.CreateUpdateSecretRequest{
@@ -134,7 +135,7 @@ func (h *ActionHandler) UpdateSecret(ctx context.Context, req *UpdateSecretReque
 	}
 
 	if !util.ValidateName(req.Name) {
-		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid secret name %q", req.Name))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid secret name %q", req.Name), serrors.InvalidSecretName())
 	}
 
 	creq := &csapitypes.CreateUpdateSecretRequest{

--- a/internal/services/gateway/action/variable.go
+++ b/internal/services/gateway/action/variable.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sorintlab/errors"
 
 	"agola.io/agola/internal/services/common"
+	serrors "agola.io/agola/internal/services/errors"
 	"agola.io/agola/internal/util"
 	csapitypes "agola.io/agola/services/configstore/api/types"
 	cstypes "agola.io/agola/services/configstore/types"
@@ -87,11 +88,11 @@ func (h *ActionHandler) CreateVariable(ctx context.Context, req *CreateVariableR
 	}
 
 	if !util.ValidateName(req.Name) {
-		return nil, nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid variable name %q", req.Name))
+		return nil, nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid variable name %q", req.Name), serrors.InvalidVariableName())
 	}
 
 	if len(req.Values) == 0 {
-		return nil, nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("empty variable values"))
+		return nil, nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("empty variable values"), serrors.InvalidVariableValues())
 	}
 
 	creq := &csapitypes.CreateUpdateVariableRequest{
@@ -154,11 +155,11 @@ func (h *ActionHandler) UpdateVariable(ctx context.Context, req *UpdateVariableR
 	}
 
 	if !util.ValidateName(req.Name) {
-		return nil, nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid variable name %q", req.Name))
+		return nil, nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("invalid variable name %q", req.Name), serrors.InvalidVariableName())
 	}
 
 	if len(req.Values) == 0 {
-		return nil, nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("empty variable values"))
+		return nil, nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("empty variable values"), serrors.InvalidVariableValues())
 	}
 
 	creq := &csapitypes.CreateUpdateVariableRequest{

--- a/internal/services/gateway/api/api.go
+++ b/internal/services/gateway/api/api.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/sorintlab/errors"
 
+	serrors "agola.io/agola/internal/services/errors"
 	util "agola.io/agola/internal/util"
 	cstypes "agola.io/agola/services/configstore/types"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
@@ -75,11 +76,11 @@ func parseRequestOptions(r *http.Request) (*requestOptions, error) {
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse limit"))
+			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse limit"), serrors.InvalidLimit())
 		}
 	}
 	if limit < 0 {
-		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("limit must be greater or equal than 0"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("limit must be greater or equal than 0"), serrors.InvalidLimit())
 	}
 	if limit > MaxLimit {
 		limit = MaxLimit
@@ -91,7 +92,7 @@ func parseRequestOptions(r *http.Request) (*requestOptions, error) {
 		case gwapitypes.SortDirectionAsc:
 		case gwapitypes.SortDirectionDesc:
 		default:
-			return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("wrong sort direction %q", sortDirection))
+			return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("wrong sort direction %q", sortDirection), serrors.InvalidSortDirection())
 		}
 	}
 
@@ -135,7 +136,7 @@ func parseGroupRunsRequestOptions(r *http.Request) (*groupRunsRequestOptions, er
 		var err error
 		startRunCounter, err = strconv.ParseUint(startRunCounterStr, 10, 64)
 		if err != nil {
-			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run counter"))
+			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run counter"), serrors.InvalidRunNumber())
 		}
 	}
 

--- a/internal/services/gateway/api/org.go
+++ b/internal/services/gateway/api/org.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/sorintlab/errors"
 
+	serrors "agola.io/agola/internal/services/errors"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
@@ -480,11 +481,11 @@ func (h *OrgInvitationsHandler) do(r *http.Request) ([]*cstypes.OrgInvitation, e
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse limit"))
+			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse limit"), serrors.InvalidLimit())
 		}
 	}
 	if limit < 0 {
-		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("limit must be greater or equal than 0"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("limit must be greater or equal than 0"), serrors.InvalidLimit())
 	}
 	if limit > MaxOrgInvitationsLimit {
 		limit = MaxOrgInvitationsLimit

--- a/internal/services/gateway/api/run.go
+++ b/internal/services/gateway/api/run.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sorintlab/errors"
 
 	"agola.io/agola/internal/services/common"
+	serrors "agola.io/agola/internal/services/errors"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/util"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
@@ -212,7 +213,7 @@ func (h *GroupRunHandler) do(r *http.Request) (*gwapitypes.RunResponse, error) {
 		var err error
 		runNumber, err = strconv.ParseUint(runNumberStr, 10, 64)
 		if err != nil {
-			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run number"))
+			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run number"), serrors.InvalidRunNumber())
 		}
 	}
 
@@ -271,7 +272,7 @@ func (h *RuntaskHandler) do(r *http.Request) (*gwapitypes.RunTaskResponse, error
 		var err error
 		runNumber, err = strconv.ParseUint(runNumberStr, 10, 64)
 		if err != nil {
-			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run number"))
+			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run number"), serrors.InvalidRunNumber())
 		}
 	}
 
@@ -431,7 +432,7 @@ func (h *RunActionsHandler) do(r *http.Request) (*gwapitypes.RunResponse, error)
 		var err error
 		runNumber, err = strconv.ParseUint(runNumberStr, 10, 64)
 		if err != nil {
-			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run number"))
+			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run number"), serrors.InvalidRunNumber())
 		}
 	}
 
@@ -501,7 +502,7 @@ func (h *RunTaskActionsHandler) do(r *http.Request) error {
 		var err error
 		runNumber, err = strconv.ParseUint(runNumberStr, 10, 64)
 		if err != nil {
-			return util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run number"))
+			return util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run number"), serrors.InvalidRunNumber())
 		}
 	}
 	taskID := vars["taskid"]
@@ -571,7 +572,7 @@ func (h *LogsHandler) do(w http.ResponseWriter, r *http.Request) error {
 		var err error
 		runNumber, err = strconv.ParseUint(runNumberStr, 10, 64)
 		if err != nil {
-			return util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run number"))
+			return util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run number"), serrors.InvalidRunNumber())
 		}
 	}
 
@@ -591,7 +592,7 @@ func (h *LogsHandler) do(w http.ResponseWriter, r *http.Request) error {
 		var err error
 		step, err = strconv.Atoi(stepStr)
 		if err != nil {
-			return util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse step number"))
+			return util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse step number"), serrors.InvalidRunTaskStepNumber())
 		}
 	}
 
@@ -715,7 +716,7 @@ func (h *LogsDeleteHandler) do(r *http.Request) error {
 		var err error
 		runNumber, err = strconv.ParseUint(runNumberStr, 10, 64)
 		if err != nil {
-			return util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run number"))
+			return util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse run number"), serrors.InvalidRunNumber())
 		}
 	}
 
@@ -735,7 +736,7 @@ func (h *LogsDeleteHandler) do(r *http.Request) error {
 		var err error
 		step, err = strconv.Atoi(stepStr)
 		if err != nil {
-			return util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse step number"))
+			return util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse step number"), serrors.InvalidRunTaskStepNumber())
 		}
 	}
 

--- a/internal/services/gateway/api/user.go
+++ b/internal/services/gateway/api/user.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/sorintlab/errors"
 
+	serrors "agola.io/agola/internal/services/errors"
 	"agola.io/agola/internal/services/gateway/action"
 	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
@@ -805,11 +806,11 @@ func (h *UserOrgInvitationsHandler) do(r *http.Request) ([]*gwapitypes.OrgInvita
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse limit"))
+			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse limit"), serrors.InvalidLimit())
 		}
 	}
 	if limit < 0 {
-		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("limit must be greater or equal than 0"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("limit must be greater or equal than 0"), serrors.InvalidLimit())
 	}
 	if limit > MaxOrgInvitationsLimit {
 		limit = MaxOrgInvitationsLimit

--- a/internal/services/notification/api/api.go
+++ b/internal/services/notification/api/api.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"strconv"
 
+	serrors "agola.io/agola/internal/services/errors"
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/notification/types"
 )
@@ -40,11 +41,11 @@ func parseRequestOptions(r *http.Request) (*requestOptions, error) {
 		var err error
 		limit, err = strconv.Atoi(limitS)
 		if err != nil {
-			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse limit"))
+			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse limit"), serrors.InvalidLimit())
 		}
 	}
 	if limit < 0 {
-		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("limit must be greater or equal than 0"))
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("limit must be greater or equal than 0"), serrors.InvalidLimit())
 	}
 
 	sortDirection := types.SortDirection(query.Get("sortdirection"))
@@ -53,7 +54,7 @@ func parseRequestOptions(r *http.Request) (*requestOptions, error) {
 		case types.SortDirectionAsc:
 		case types.SortDirectionDesc:
 		default:
-			return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("wrong sort direction %q", sortDirection))
+			return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("wrong sort direction %q", sortDirection), serrors.InvalidSortDirection())
 		}
 	}
 

--- a/internal/services/notification/api/commitstatusdelivery.go
+++ b/internal/services/notification/api/commitstatusdelivery.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 
+	serrors "agola.io/agola/internal/services/errors"
 	"agola.io/agola/internal/services/notification/action"
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/notification/types"
@@ -62,7 +63,7 @@ func (h *CommitStatusDeliveriesHandler) do(w http.ResponseWriter, r *http.Reques
 
 	deliveryStatusFilter, err := types.DeliveryStatusFromStringSlice(query["deliverystatus"])
 	if err != nil {
-		return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("wrong deliverystatus"))
+		return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("wrong deliverystatus"), serrors.InvalidDeliveryStatus())
 	}
 
 	startSequenceStr := query.Get("startsequence")
@@ -71,7 +72,7 @@ func (h *CommitStatusDeliveriesHandler) do(w http.ResponseWriter, r *http.Reques
 		var err error
 		startSequence, err = strconv.ParseUint(startSequenceStr, 10, 64)
 		if err != nil {
-			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse startsequence"))
+			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse startsequence"), serrors.InvalidStartSequence())
 		}
 	}
 

--- a/internal/services/notification/api/runwebhookdelivery.go
+++ b/internal/services/notification/api/runwebhookdelivery.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 
+	serrors "agola.io/agola/internal/services/errors"
 	"agola.io/agola/internal/services/notification/action"
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/notification/types"
@@ -62,7 +63,7 @@ func (h *RunWebhookDeliveriesHandler) do(w http.ResponseWriter, r *http.Request)
 
 	deliveryStatusFilter, err := types.DeliveryStatusFromStringSlice(query["deliverystatus"])
 	if err != nil {
-		return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("wrong deliverystatus"))
+		return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("wrong deliverystatus"), serrors.InvalidDeliveryStatus())
 	}
 
 	startSequenceStr := query.Get("startsequence")
@@ -71,7 +72,7 @@ func (h *RunWebhookDeliveriesHandler) do(w http.ResponseWriter, r *http.Request)
 		var err error
 		startSequence, err = strconv.ParseUint(startSequenceStr, 10, 64)
 		if err != nil {
-			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse startsequence"))
+			return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse startsequence"), serrors.InvalidStartSequence())
 		}
 	}
 

--- a/internal/services/notification/notification_test.go
+++ b/internal/services/notification/notification_test.go
@@ -33,6 +33,7 @@ import (
 	"gotest.tools/assert/cmp"
 
 	"agola.io/agola/internal/services/config"
+	serrors "agola.io/agola/internal/services/errors"
 	"agola.io/agola/internal/services/notification/action"
 	"agola.io/agola/internal/sqlg"
 	"agola.io/agola/internal/sqlg/sql"
@@ -822,7 +823,7 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 
 		runWebhook := createRunWebhook(t, ctx, ns, project01)
 
-		expectedErr := util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("runWebhookDelivery %q doesn't exist", runWebhookDelivery01))
+		expectedErr := util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("runWebhookDelivery %q doesn't exist", runWebhookDelivery01), serrors.RunWebhookDeliveryDoesNotExist())
 		err := ns.ah.RunWebhookRedelivery(ctx, runWebhook.ProjectID, runWebhookDelivery01)
 		assert.Error(t, err, expectedErr.Error())
 	})
@@ -842,7 +843,7 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		runWebhook = createRunWebhook(t, ctx, ns, project02)
 		createRunWebhookDelivery(t, ctx, ns, runWebhook.ID, types.DeliveryStatusDelivered)
 
-		expectedErr := util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("runWebhookDelivery %q doesn't belong to project %q", runWebhookDelivery.ID, project02))
+		expectedErr := util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("runWebhookDelivery %q doesn't belong to project %q", runWebhookDelivery.ID, project02), serrors.RunWebhookDeliveryDoesNotExist())
 
 		err := ns.ah.RunWebhookRedelivery(ctx, project02, runWebhookDelivery.ID)
 		assert.Error(t, err, expectedErr.Error())
@@ -868,7 +869,7 @@ func TestProjectRunWebhookRedelivery(t *testing.T) {
 		ns.c.WebhookSecret = webhookSecret
 		ns.c.WebhookURL = fmt.Sprintf("%s/%s", wr.exposedURL, "webhooks")
 
-		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("the previous delivery of run webhook %q hasn't already been delivered", runWebhookDelivery.RunWebhookID))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("the previous delivery of run webhook %q hasn't already been delivered", runWebhookDelivery.RunWebhookID), serrors.RunWebhookDeliveryAlreadyInProgress())
 
 		err := ns.ah.RunWebhookRedelivery(ctx, runWebhook.ProjectID, runWebhookDelivery.ID)
 		assert.Error(t, err, expectedErr.Error())
@@ -1176,7 +1177,7 @@ func TestProjectCommitStatusRedelivery(t *testing.T) {
 
 		commitStatus := createCommitStatus(t, ctx, ns, 1, project01)
 
-		expectedErr := util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("commitStatusDelivery %q doesn't exist", commitStatusDelivery01))
+		expectedErr := util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("commitStatusDelivery %q doesn't exist", commitStatusDelivery01), serrors.CommitStatusDeliveryDoesNotExist())
 		err := ns.ah.CommitStatusRedelivery(ctx, commitStatus.ProjectID, commitStatusDelivery01)
 		if err == nil {
 			t.Fatalf("expected error %v, got nil err", expectedErr)
@@ -1201,7 +1202,7 @@ func TestProjectCommitStatusRedelivery(t *testing.T) {
 		commitStatus = createCommitStatus(t, ctx, ns, 1, project02)
 		createCommitStatusDelivery(t, ctx, ns, commitStatus.ID, types.DeliveryStatusDelivered)
 
-		expectedErr := util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("commitStatusDelivery %q doesn't belong to project %q", commitStatusDelivery.ID, project02))
+		expectedErr := util.NewAPIError(util.ErrNotExist, util.WithAPIErrorMsg("commitStatusDelivery %q doesn't belong to project %q", commitStatusDelivery.ID, project02), serrors.CommitStatusDeliveryDoesNotExist())
 
 		err := ns.ah.CommitStatusRedelivery(ctx, project02, commitStatusDelivery.ID)
 		if err == nil {
@@ -1229,7 +1230,7 @@ func TestProjectCommitStatusRedelivery(t *testing.T) {
 		cs := setupStubCommitStatusUpdater()
 		ns.u = cs
 
-		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("the previous delivery of commit status %q hasn't already been delivered", commitStatusDelivery.CommitStatusID))
+		expectedErr := util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("the previous delivery of commit status %q hasn't already been delivered", commitStatusDelivery.CommitStatusID), serrors.CommitStatusDeliveryAlreadyInProgress())
 
 		err := ns.ah.CommitStatusRedelivery(ctx, commitStatus.ProjectID, commitStatusDelivery.ID)
 		if err == nil {

--- a/internal/services/notification/runeventssender_test.go
+++ b/internal/services/notification/runeventssender_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/sorintlab/errors"
 
+	serrors "agola.io/agola/internal/services/errors"
 	"agola.io/agola/internal/testutil"
 	"agola.io/agola/internal/util"
 	"agola.io/agola/services/runservice/types"
@@ -172,7 +173,7 @@ func (h *runEventsHandler) do(w http.ResponseWriter, r *http.Request) error {
 		var err error
 		afterRunEventSequence, err = strconv.ParseUint(afterRunEventSequenceStr, 10, 64)
 		if err != nil {
-			return util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse afterSequence"))
+			return util.NewAPIErrorWrap(util.ErrBadRequest, err, util.WithAPIErrorMsg("cannot parse afterSequence"), serrors.InvalidStartSequence())
 		}
 	}
 

--- a/services/gateway/api/errors/errors.go
+++ b/services/gateway/api/errors/errors.go
@@ -1,0 +1,90 @@
+package errors
+
+import "agola.io/agola/internal/util"
+
+const (
+	ErrorCodeInvalidStartSequence util.ErrorCode = "invalidStartSequence"
+	ErrorCodeInvalidLimit         util.ErrorCode = "invalidLimit"
+	ErrorCodeInvalidSortDirection util.ErrorCode = "invalidSortDirection"
+
+	ErrorCodeInvalidVisibility util.ErrorCode = "invalidVisibility"
+
+	ErrorCodeInvalidRole util.ErrorCode = "invalidRole"
+
+	ErrorCodeUserDoesNotExist  util.ErrorCode = "userDoesNotExist"
+	ErrorCodeUserAlreadyExists util.ErrorCode = "userAlreadyExists"
+	ErrorCodeInvalidUserName   util.ErrorCode = "invalidUserName"
+
+	ErrorCodeUserTokenDoesNotExist  util.ErrorCode = "userTokenDoesNotExist"
+	ErrorCodeUserTokenAlreadyExists util.ErrorCode = "userTokenAlreadyExists"
+
+	ErrorCodeParentProjectGroupDoesNotExist util.ErrorCode = "parentProjectGroupDoesNotExist"
+
+	ErrorCodeProjectGroupDoesNotExist  util.ErrorCode = "projectGroupDoesNotExist"
+	ErrorCodeProjectGroupAlreadyExists util.ErrorCode = "projectGroupAlreadyExists"
+	ErrorCodeInvalidProjectGroupName   util.ErrorCode = "invalidProjectGroupName"
+
+	ErrorCodeProjectDoesNotExist                               util.ErrorCode = "projectDoesNotExist"
+	ErrorCodeProjectAlreadyExists                              util.ErrorCode = "projectAlreadyExists"
+	ErrorCodeInvalidProjectName                                util.ErrorCode = "invalidProjectName"
+	ErrorCodeCannotSetMembersCanPerformRunActionsOnUserProject util.ErrorCode = "cannotSetMembersCanPerformRunActionsOnUserProject"
+
+	ErrorCodeRemoteSourceDoesNotExist    util.ErrorCode = "remoteSourceDoesNotExist"
+	ErrorCodeRemoteSourceAlreadyExists   util.ErrorCode = "remoteSourceAlreadyExists"
+	ErrorCodeInvalidRemoteSourceName     util.ErrorCode = "invalidRemoteSourceName"
+	ErrorCodeInvalidRemoteSourceType     util.ErrorCode = "invalidRemoteSourceType"
+	ErrorCodeInvalidRemoteSourceAuthType util.ErrorCode = "invalidRemoteSourceAuthType"
+	ErrorCodeInvalidRemoteSourceAPIURL   util.ErrorCode = "invalidRemoteSourceAPIURL"
+	ErrorCodeInvalidOauth2ClientID       util.ErrorCode = "invalidOauth2ClientID"
+	ErrorCodeInvalidOauth2ClientSecret   util.ErrorCode = "invalidOauth2ClientSecret"
+
+	ErrorCodeLinkedAccountDoesNotExist  util.ErrorCode = "linkedAccountDoesNotExist"
+	ErrorCodeLinkedAccountAlreadyExists util.ErrorCode = "linkedAccountAlreadyExists"
+
+	ErrorCodeInvalidRepoPath util.ErrorCode = "invalidRepoPath"
+
+	ErrorCodeSecretDoesNotExist  util.ErrorCode = "secretDoesNotExist"
+	ErrorCodeSecretAlreadyExists util.ErrorCode = "secretAlreadyExists"
+	ErrorCodeInvalidSecretName   util.ErrorCode = "invalidSecretName"
+	ErrorCodeInvalidSecretType   util.ErrorCode = "invalidSecretType"
+	ErrorCodeInvalidSecretData   util.ErrorCode = "invalidSecretData"
+
+	ErrorCodeVariableDoesNotExist  util.ErrorCode = "variableDoesNotExist"
+	ErrorCodeVariableAlreadyExists util.ErrorCode = "variableAlreadyExists"
+	ErrorCodeInvalidVariableName   util.ErrorCode = "invalidVariableName"
+	ErrorCodeInvalidVariableValues util.ErrorCode = "invalidVariableValues"
+
+	ErrorCodeCreatorUserDoesNotExist util.ErrorCode = "creatorUserDoesNotExist"
+
+	ErrorCodeOrganizationDoesNotExist  util.ErrorCode = "organizationDoesNotExist"
+	ErrorCodeOrganizationAlreadyExists util.ErrorCode = "organizationAlreadyExists"
+	ErrorCodeInvalidOrganizationName   util.ErrorCode = "invalidOrganizationName"
+
+	ErrorCodeOrgMemberDoesNotExist util.ErrorCode = "orgMemberDoesNotExist"
+
+	ErrorCodeInvitationDoesNotExist  util.ErrorCode = "invitationDoesNotExist"
+	ErrorCodeInvitationAlreadyExists util.ErrorCode = "invitationAlreadyExists"
+
+	ErrorCodeCannotAddUserToOrganization util.ErrorCode = "cannotAddUserToOrganization"
+	ErrorCodeCannotCreateInvitation      util.ErrorCode = "cannotCreateInvitation"
+
+	ErrorCodeInvalidRunGroup           util.ErrorCode = "invalidRunGroup"
+	ErrorCodeInvalidRunNumber          util.ErrorCode = "invalidRunNumber"
+	ErrorCodeInvalidRunTaskStepNumber  util.ErrorCode = "invalidRunTaskStepNumber"
+	ErrorCodeRunDoesNotExist           util.ErrorCode = "runDoesNotExist"
+	ErrorCodeRunTaskDoesNotExist       util.ErrorCode = "runTaskDoesNotExist"
+	ErrorCodeRunTaskStepDoesNotExist   util.ErrorCode = "runTaskStepDoesNotExist"
+	ErrorCodeRunCannotBeRestarted      util.ErrorCode = "runCannotBeRestarted"
+	ErrorCodeRunTaskNotWaitingApproval util.ErrorCode = "runTaskNotWaitingApproval"
+	ErrorCodeRunTaskAlreadyApproved    util.ErrorCode = "runTaskAlreadyApproved"
+
+	ErrorCodeInvalidDeliveryStatus util.ErrorCode = "invalidDeliveryStatus"
+
+	ErrorCodeCommitStatusDoesNotExist              util.ErrorCode = "commitStatusDoesNotExist"
+	ErrorCodeCommitStatusDeliveryDoesNotExist      util.ErrorCode = "commitStatusDeliveryDoesNotExist"
+	ErrorCodeCommitStatusDeliveryAlreadyInProgress util.ErrorCode = "commitStatusDeliveryAlreadyInProgress"
+
+	ErrorCodeRunWebhookDoesNotExist              util.ErrorCode = "runWebhookDoesNotExist"
+	ErrorCodeRunWebhookDeliveryDoesNotExist      util.ErrorCode = "runWebhookDeliveryDoesNotExist"
+	ErrorCodeRunWebhookDeliveryAlreadyInProgress util.ErrorCode = "runWebhookDeliveryAlreadyInProgress"
+)

--- a/services/gateway/api/types/runwebhookdelivery.go
+++ b/services/gateway/api/types/runwebhookdelivery.go
@@ -24,14 +24,6 @@ const (
 	DeliveryStatusDeliveryError DeliveryStatus = "deliveryError"
 )
 
-func DeliveryStatusFromStringSlice(slice []string) []DeliveryStatus {
-	dss := make([]DeliveryStatus, len(slice))
-	for i, s := range slice {
-		dss[i] = DeliveryStatus(s)
-	}
-	return dss
-}
-
 type RunWebhookDeliveryResponse struct {
 	ID             string         `json:"id"`
 	Sequence       uint64         `json:"sequence"`

--- a/tests/project_test.go
+++ b/tests/project_test.go
@@ -13,6 +13,7 @@ import (
 
 	"agola.io/agola/internal/testutil"
 	"agola.io/agola/internal/util"
+	gwapierrors "agola.io/agola/services/gateway/api/errors"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
 	gwclient "agola.io/agola/services/gateway/client"
 	rstypes "agola.io/agola/services/runservice/types"
@@ -92,7 +93,7 @@ func TestGetProjectGroup(t *testing.T) {
 		name   string
 		client *gwclient.Client
 		pg     *gwapitypes.ProjectGroupResponse
-		err    string
+		err    error
 	}{
 		{
 			name:   "user owner get pub org pub pg",
@@ -123,7 +124,7 @@ func TestGetProjectGroup(t *testing.T) {
 			name:   "user not member get pub org priv pg",
 			client: gwClientUser03,
 			pg:     pubOrgPrivPG,
-			err:    remoteErrorNotExist,
+			err:    util.NewRemoteError(util.ErrNotExist, util.WithRemoteErrorDetailedError(&util.RemoteDetailedError{Code: gwapierrors.ErrorCodeOrganizationDoesNotExist})),
 		},
 		{
 			name:   "user owner get priv org pub pg",
@@ -139,7 +140,7 @@ func TestGetProjectGroup(t *testing.T) {
 			name:   "user not member get priv org pub pg",
 			client: gwClientUser03,
 			pg:     privOrgPubPG,
-			err:    remoteErrorNotExist,
+			err:    util.NewRemoteError(util.ErrNotExist, util.WithRemoteErrorDetailedError(&util.RemoteDetailedError{Code: gwapierrors.ErrorCodeOrganizationDoesNotExist})),
 		},
 		{
 			name:   "user owner get priv org priv pg",
@@ -155,7 +156,7 @@ func TestGetProjectGroup(t *testing.T) {
 			name:   "user not member get priv org priv pg",
 			client: gwClientUser03,
 			pg:     privOrgPrivPG,
-			err:    remoteErrorNotExist,
+			err:    util.NewRemoteError(util.ErrNotExist, util.WithRemoteErrorDetailedError(&util.RemoteDetailedError{Code: gwapierrors.ErrorCodeOrganizationDoesNotExist})),
 		},
 	}
 
@@ -164,8 +165,8 @@ func TestGetProjectGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			pg, _, err := tt.client.GetProjectGroup(ctx, tt.pg.ID)
 
-			if tt.err != "" {
-				assert.Error(t, err, tt.err)
+			if tt.err != nil {
+				assert.Error(t, err, tt.err.Error())
 			} else {
 				testutil.NilError(t, err)
 
@@ -284,7 +285,7 @@ func TestGetProject(t *testing.T) {
 		name   string
 		client *gwclient.Client
 		proj   *gwapitypes.ProjectResponse
-		err    string
+		err    error
 	}{
 		{
 			name:   "user owner get pub org pub pg pub proj",
@@ -315,7 +316,7 @@ func TestGetProject(t *testing.T) {
 			name:   "user not member get pub org pub pg priv proj",
 			client: gwClientUser03,
 			proj:   pubOrgPubPGPrivProj,
-			err:    remoteErrorNotExist,
+			err:    util.NewRemoteError(util.ErrNotExist, util.WithRemoteErrorDetailedError(&util.RemoteDetailedError{Code: gwapierrors.ErrorCodeOrganizationDoesNotExist})),
 		},
 		{
 			name:   "user owner get pub org priv pg pub proj",
@@ -331,7 +332,7 @@ func TestGetProject(t *testing.T) {
 			name:   "user not member get pub org priv pg pub proj",
 			client: gwClientUser03,
 			proj:   pubOrgPrivPGPubProj,
-			err:    remoteErrorNotExist,
+			err:    util.NewRemoteError(util.ErrNotExist, util.WithRemoteErrorDetailedError(&util.RemoteDetailedError{Code: gwapierrors.ErrorCodeOrganizationDoesNotExist})),
 		},
 		{
 			name:   "user owner get pub org priv pg priv proj",
@@ -347,7 +348,7 @@ func TestGetProject(t *testing.T) {
 			name:   "user not member get pub org priv pg priv proj",
 			client: gwClientUser03,
 			proj:   pubOrgPrivPGPrivProj,
-			err:    remoteErrorNotExist,
+			err:    util.NewRemoteError(util.ErrNotExist, util.WithRemoteErrorDetailedError(&util.RemoteDetailedError{Code: gwapierrors.ErrorCodeOrganizationDoesNotExist})),
 		},
 		{
 			name:   "user owner get priv org pub pg pub proj",
@@ -363,7 +364,7 @@ func TestGetProject(t *testing.T) {
 			name:   "user not member get priv org pub pg pub proj",
 			client: gwClientUser03,
 			proj:   privOrgPubPGPubProj,
-			err:    remoteErrorNotExist,
+			err:    util.NewRemoteError(util.ErrNotExist, util.WithRemoteErrorDetailedError(&util.RemoteDetailedError{Code: gwapierrors.ErrorCodeOrganizationDoesNotExist})),
 		},
 		{
 			name:   "user owner get priv org pub pg priv proj",
@@ -379,7 +380,7 @@ func TestGetProject(t *testing.T) {
 			name:   "user not member get priv org pub pg priv proj",
 			client: gwClientUser03,
 			proj:   privOrgPubPGPrivProj,
-			err:    remoteErrorNotExist,
+			err:    util.NewRemoteError(util.ErrNotExist, util.WithRemoteErrorDetailedError(&util.RemoteDetailedError{Code: gwapierrors.ErrorCodeOrganizationDoesNotExist})),
 		},
 		{
 			name:   "user owner get priv org priv pg pub proj",
@@ -395,7 +396,7 @@ func TestGetProject(t *testing.T) {
 			name:   "user not member get priv org priv pg pub proj",
 			client: gwClientUser03,
 			proj:   privOrgPrivPGPubProj,
-			err:    remoteErrorNotExist,
+			err:    util.NewRemoteError(util.ErrNotExist, util.WithRemoteErrorDetailedError(&util.RemoteDetailedError{Code: gwapierrors.ErrorCodeOrganizationDoesNotExist})),
 		},
 		{
 			name:   "user owner get priv org priv pg priv proj",
@@ -411,7 +412,7 @@ func TestGetProject(t *testing.T) {
 			name:   "user not member get priv org priv pg priv proj",
 			client: gwClientUser03,
 			proj:   privOrgPrivPGPrivProj,
-			err:    remoteErrorNotExist,
+			err:    util.NewRemoteError(util.ErrNotExist, util.WithRemoteErrorDetailedError(&util.RemoteDetailedError{Code: gwapierrors.ErrorCodeOrganizationDoesNotExist})),
 		},
 	}
 
@@ -420,8 +421,8 @@ func TestGetProject(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			pg, _, err := tt.client.GetProject(ctx, tt.proj.ID)
 
-			if tt.err != "" {
-				assert.Error(t, err, tt.err)
+			if tt.err != nil {
+				assert.Error(t, err, tt.err.Error())
 			} else {
 				testutil.NilError(t, err)
 
@@ -528,7 +529,8 @@ func TestUpdateProject(t *testing.T) {
 		}
 
 		_, _, err = gwClient.CreateProject(ctx, req)
-		assert.Error(t, err, remoteErrorBadRequest)
+		expectedErr := util.NewRemoteError(util.ErrBadRequest, util.WithRemoteErrorDetailedError(&util.RemoteDetailedError{Code: gwapierrors.ErrorCodeCannotSetMembersCanPerformRunActionsOnUserProject}))
+		assert.Error(t, err, expectedErr.Error())
 	})
 
 	t.Run("update users's project with MembersCanPerformRunActions true", func(t *testing.T) {
@@ -556,7 +558,8 @@ func TestUpdateProject(t *testing.T) {
 			Name:                        &project.Name,
 			MembersCanPerformRunActions: util.BoolP(true),
 		})
-		assert.Error(t, err, remoteErrorBadRequest)
+		expectedErr := util.NewRemoteError(util.ErrBadRequest, util.WithRemoteErrorDetailedError(&util.RemoteDetailedError{Code: gwapierrors.ErrorCodeCannotSetMembersCanPerformRunActionsOnUserProject}))
+		assert.Error(t, err, expectedErr.Error())
 	})
 
 	t.Run("create/update orgs's project", func(t *testing.T) {
@@ -679,7 +682,8 @@ func TestGetProjectRun(t *testing.T) {
 		_, project := createProject(ctx, t, giteaClient, gwClient)
 
 		_, _, err = gwClient.GetProjectRun(ctx, project.ID, 1)
-		assert.Error(t, err, remoteErrorNotExist)
+		expectedErr := util.NewRemoteError(util.ErrNotExist, util.WithRemoteErrorDetailedError(&util.RemoteDetailedError{Code: gwapierrors.ErrorCodeRunDoesNotExist}))
+		assert.Error(t, err, expectedErr.Error())
 	})
 }
 
@@ -782,7 +786,7 @@ func TestProjectRunActions(t *testing.T) {
 			ActionType: gwapitypes.RunActionTypeRestart,
 			FromStart:  true,
 		})
-		assert.Error(t, err, expectedErr)
+		assert.Error(t, err, expectedErr.Error())
 
 		// test org run actions executed by an organization member type with MembersCanPerformRunActions false
 
@@ -795,7 +799,7 @@ func TestProjectRunActions(t *testing.T) {
 			ActionType: gwapitypes.RunActionTypeRestart,
 			FromStart:  true,
 		})
-		assert.Error(t, err, expectedErr)
+		assert.Error(t, err, expectedErr.Error())
 	})
 
 	t.Run("run actions on user's project", func(t *testing.T) {
@@ -868,6 +872,6 @@ func TestProjectRunActions(t *testing.T) {
 			ActionType: gwapitypes.RunActionTypeRestart,
 			FromStart:  true,
 		})
-		assert.Error(t, err, expectedErr)
+		assert.Error(t, err, expectedErr.Error())
 	})
 }

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -84,12 +84,11 @@ const (
 	ConfigFormatStarlark ConfigFormat = "starlark"
 )
 
-const (
-	remoteErrorInternal     = "remote error internal"
-	remoteErrorNotExist     = "remote error notexist"
-	remoteErrorBadRequest   = "remote error badrequest"
-	remoteErrorUnauthorized = "remote error unauthorized"
-	remoteErrorForbidden    = "remote error forbidden"
+var (
+	remoteErrorInternal     = util.NewRemoteError(util.ErrInternal)
+	remoteErrorBadRequest   = util.NewRemoteError(util.ErrBadRequest)
+	remoteErrorUnauthorized = util.NewRemoteError(util.ErrUnauthorized)
+	remoteErrorForbidden    = util.NewRemoteError(util.ErrForbidden)
 )
 
 const MaxLimit = 30


### PR DESCRIPTION
In addition to the standard http error codes also report a detailed
error that contains an error code and an optional error detail. This is
required to better explain the reason of the reported error.

Since, by default if not handled in another way, an error returned by
an internal service is propagated by the gateway to the client, also
internal services returns detailed errors with exported error codes.

This patch adds an initial round of detailed errors. They are not stable
and will change in future.