### PR TITLE
cmd/export: close file descriptor

### DIFF
--- a/cmd/agola/cmd/export.go
+++ b/cmd/agola/cmd/export.go
@@ -70,6 +70,7 @@ func export(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return errors.WithStack(err)
 		}
+		defer w.Close()
 	}
 
 	r := bufio.NewReader(resp.Body)


### PR DESCRIPTION
close the created file descriptor at the end of the export function.