### PR TITLE
gateway: move remaining get of current user from api to action

### DIFF
--- a/internal/services/gateway/api/org.go
+++ b/internal/services/gateway/api/org.go
@@ -25,7 +25,6 @@ import (
 
 	serrors "agola.io/agola/internal/services/errors"
 	"agola.io/agola/internal/services/gateway/action"
-	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
 	cstypes "agola.io/agola/services/configstore/types"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
@@ -55,8 +54,6 @@ func (h *CreateOrgHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *CreateOrgHandler) do(r *http.Request) (*gwapitypes.OrgResponse, error) {
 	ctx := r.Context()
 
-	userID := common.CurrentUserID(ctx)
-
 	var req gwapitypes.CreateOrgRequest
 	d := json.NewDecoder(r.Body)
 	if err := d.Decode(&req); err != nil {
@@ -64,9 +61,8 @@ func (h *CreateOrgHandler) do(r *http.Request) (*gwapitypes.OrgResponse, error) 
 	}
 
 	creq := &action.CreateOrgRequest{
-		Name:          req.Name,
-		Visibility:    cstypes.Visibility(req.Visibility),
-		CreatorUserID: userID,
+		Name:       req.Name,
+		Visibility: cstypes.Visibility(req.Visibility),
 	}
 
 	org, err := h.ah.CreateOrg(ctx, creq)

--- a/internal/services/gateway/api/projectgroup.go
+++ b/internal/services/gateway/api/projectgroup.go
@@ -24,7 +24,6 @@ import (
 	"github.com/sorintlab/errors"
 
 	"agola.io/agola/internal/services/gateway/action"
-	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
 	csapitypes "agola.io/agola/services/configstore/api/types"
 	cstypes "agola.io/agola/services/configstore/types"
@@ -61,16 +60,10 @@ func (h *CreateProjectGroupHandler) do(r *http.Request) (*gwapitypes.ProjectGrou
 		return nil, util.NewAPIErrorWrap(util.ErrBadRequest, err)
 	}
 
-	userID := common.CurrentUserID(ctx)
-	if userID == "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user not authenticated"))
-	}
-
 	creq := &action.CreateProjectGroupRequest{
-		Name:          req.Name,
-		ParentRef:     req.ParentRef,
-		Visibility:    cstypes.Visibility(req.Visibility),
-		CurrentUserID: userID,
+		Name:       req.Name,
+		ParentRef:  req.ParentRef,
+		Visibility: cstypes.Visibility(req.Visibility),
 	}
 
 	projectGroup, err := h.ah.CreateProjectGroup(ctx, creq)

--- a/internal/services/gateway/api/remoterepo.go
+++ b/internal/services/gateway/api/remoterepo.go
@@ -23,7 +23,6 @@ import (
 
 	gitsource "agola.io/agola/internal/gitsources"
 	"agola.io/agola/internal/services/gateway/action"
-	"agola.io/agola/internal/services/gateway/common"
 	"agola.io/agola/internal/util"
 	csclient "agola.io/agola/services/configstore/client"
 	gwapitypes "agola.io/agola/services/gateway/api/types"
@@ -65,12 +64,7 @@ func (h *UserRemoteReposHandler) do(r *http.Request) ([]*gwapitypes.RemoteRepoRe
 	vars := mux.Vars(r)
 	remoteSourceRef := vars["remotesourceref"]
 
-	userID := common.CurrentUserID(ctx)
-	if userID == "" {
-		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user not authenticated"))
-	}
-
-	gitsource, _, _, err := h.ah.GetUserGitSource(ctx, remoteSourceRef, userID)
+	gitsource, _, _, err := h.ah.GetCurrentUserGitSource(ctx, remoteSourceRef)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}


### PR DESCRIPTION
There were few api handlers that fetched the current user and passed it to the actions. Move this in the right place directly inside the actions.