### PR TITLE
gateway: unify/improve handling of authenticated user

### DIFF
--- a/internal/services/gateway/action/org.go
+++ b/internal/services/gateway/action/org.go
@@ -342,7 +342,7 @@ type OrgInvitationResponse struct {
 
 func (h *ActionHandler) GetOrgInvitations(ctx context.Context, orgRef string, limit int) ([]*cstypes.OrgInvitation, error) {
 	if !common.IsUserLogged(ctx) {
-		return nil, errors.Errorf("user not logged in")
+		return nil, util.NewAPIError(util.ErrForbidden, util.WithAPIErrorMsg("user not authenticated"))
 	}
 
 	org, _, err := h.configstoreClient.GetOrg(ctx, orgRef)
@@ -373,7 +373,7 @@ type CreateOrgInvitationRequest struct {
 
 func (h *ActionHandler) CreateOrgInvitation(ctx context.Context, req *CreateOrgInvitationRequest) (*OrgInvitationResponse, error) {
 	if !common.IsUserLogged(ctx) {
-		return nil, errors.Errorf("user not logged in")
+		return nil, util.NewAPIError(util.ErrForbidden, util.WithAPIErrorMsg("user not authenticated"))
 	}
 
 	if h.organizationMemberAddingMode != OrganizationMemberAddingModeInvitation {
@@ -484,9 +484,8 @@ func (h *ActionHandler) OrgInvitationAction(ctx context.Context, req *OrgInvitat
 }
 
 func (h *ActionHandler) DeleteOrgInvitation(ctx context.Context, orgRef string, userRef string) error {
-	userID := common.CurrentUserID(ctx)
-	if userID == "" {
-		return errors.Errorf("user not authenticated")
+	if !common.IsUserLogged(ctx) {
+		return util.NewAPIError(util.ErrForbidden, util.WithAPIErrorMsg("user not authenticated"))
 	}
 
 	orgInvitation, _, err := h.configstoreClient.GetOrgInvitation(ctx, orgRef, userRef)

--- a/internal/services/gateway/action/project.go
+++ b/internal/services/gateway/action/project.go
@@ -64,6 +64,9 @@ type CreateProjectRequest struct {
 }
 
 func (h *ActionHandler) CreateProject(ctx context.Context, req *CreateProjectRequest) (*csapitypes.Project, error) {
+	if !common.IsUserLogged(ctx) {
+		return nil, util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("user not authenticated"))
+	}
 	curUserID := common.CurrentUserID(ctx)
 
 	user, _, err := h.configstoreClient.GetUser(ctx, curUserID)

--- a/internal/services/gateway/action/run.go
+++ b/internal/services/gateway/action/run.go
@@ -330,6 +330,11 @@ type RunTaskActionsRequest struct {
 }
 
 func (h *ActionHandler) RunTaskAction(ctx context.Context, req *RunTaskActionsRequest) error {
+	if !common.IsUserLogged(ctx) {
+		return util.NewAPIError(util.ErrForbidden, util.WithAPIErrorMsg("user not authenticated"))
+	}
+	curUserID := common.CurrentUserID(ctx)
+
 	canDoRunAction, groupID, err := h.CanAuthUserDoRunActions(ctx, req.GroupType, req.Ref, actionTypeTaskAction)
 	if err != nil {
 		return errors.Wrapf(err, "failed to determine permissions")
@@ -346,11 +351,6 @@ func (h *ActionHandler) RunTaskAction(ctx context.Context, req *RunTaskActionsRe
 	}
 
 	runID := runResp.Run.ID
-
-	curUserID := common.CurrentUserID(ctx)
-	if curUserID == "" {
-		return util.NewAPIError(util.ErrBadRequest, util.WithAPIErrorMsg("no logged in user"))
-	}
 
 	switch req.ActionType {
 	case RunTaskActionTypeApprove:

--- a/tests/auth_test.go
+++ b/tests/auth_test.go
@@ -227,7 +227,7 @@ func TestCookieAuth(t *testing.T) {
 	}, nil)
 	testutil.NilError(t, err)
 
-	// Test auth passing recevied login response cookies
+	// Test auth passing received login response cookies
 	authCookieName := common.AuthCookieName(false)
 	secondaryAuthCookieName := common.SecondaryAuthCookieName()
 	cookies := resp.Cookies()


### PR DESCRIPTION
Auth check returning an Unauthenticated (http 401) error must be performed by the auth checker. In the action we assume it's done and in case of missing auth user we return a Forbidden error (http 403).