### PR TITLE
errors: add WithWrapperErrorMsgf

### DIFF
--- a/internal/objectstorage/objectstorage.go
+++ b/internal/objectstorage/objectstorage.go
@@ -43,7 +43,7 @@ type ErrNotExist struct {
 
 func NewErrNotExist(err error, format string, args ...interface{}) error {
 	return &ErrNotExist{
-		util.NewWrapperError(err, util.WithWrapperErrorMsg(format, args...)),
+		util.NewWrapperError(err, util.WithWrapperErrorMsgf(format, args...)),
 	}
 }
 

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -116,9 +116,15 @@ func NewWrapperError(err error, options ...WrapperErrorOption) *WrapperError {
 
 type WrapperErrorOption func(e *WrapperError)
 
-func WithWrapperErrorMsg(format string, args ...interface{}) WrapperErrorOption {
+func WithWrapperErrorMsgf(format string, args ...any) WrapperErrorOption {
 	return func(e *WrapperError) {
 		e.msg = fmt.Sprintf(format, args...)
+	}
+}
+
+func WithWrapperErrorMsg(format string, a ...any) WrapperErrorOption {
+	return func(e *WrapperError) {
+		e.msg = fmt.Sprint(a...)
 	}
 }
 


### PR DESCRIPTION
Currently WithWrapperErrorMsg wants a format and args like fmt.Sprintf but new go vet checks for non-constant format string in calls so it cannot be used for dynamic messages.

Fix this by renaming WithWrapperErrorMsg to WithWrapperErrorMsgf and adding WithWrapperErrorMsg that uses fmt.Sprint .