### PR TITLE
Update to golangci-lint v2.1.6

### DIFF
--- a/.agola/config.jsonnet
+++ b/.agola/config.jsonnet
@@ -39,7 +39,7 @@ local task_build_go(version, arch) = {
     { type: 'run', command: 'make' },
     { type: 'save_cache', key: 'cache-sum-{{ md5sum "go.sum" }}', contents: [{ source_dir: '/go/pkg/mod/cache' }] },
     { type: 'save_cache', key: 'cache-date-{{ year }}-{{ month }}-{{ day }}', contents: [{ source_dir: '/go/pkg/mod/cache' }] },
-    { type: 'run', name: 'install golangci-lint', command: 'curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.61.0' },
+    { type: 'run', name: 'install golangci-lint', command: 'curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.6' },
     { type: 'run', command: 'golangci-lint run --timeout 10m' },
     { type: 'run', name: 'build docker/k8s drivers tests binary', command: 'CGO_ENABLED=0 go test -c ./internal/services/executor/driver -o ./bin/docker-tests' },
     { type: 'run', name: 'build integration tests binary', command: 'go test -tags "sqlite_unlock_notify" -c ./tests -o ./bin/integration-tests' },

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,40 +1,56 @@
+version: "2"
 linters:
   enable:
-    - gci
-    - stylecheck
     - errorlint
-    - wrapcheck
     - paralleltest
-
-linters-settings:
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(agola.io/agola)
-      - blank
-      - dot
-  wrapcheck:
-    # An array of strings that specify substrings of signatures to ignore.
-    # If this set, it will override the default set of ignored signatures.
-    # See https://github.com/tomarrell/wrapcheck#configuration for more information.
-    ignoreSigs:
-      - .Errorf(
-      - errors.New(
-      - errors.Unwrap(
-      - .Wrap(
-      - .Wrapf(
-      - .WithMessage(
-      - .WithMessagef(
-      - .WithStack(
-      - .NewAPIError(
-      - .NewAPIErrorWrap(
-      - .APIErrorFromRemoteError(
-    ignoreSigRegexps:
-      - \.New.*Error\(
-    ignorePackageGlobs:
-      - encoding/*
-      - github.com/pkg/*
-
-  paralleltest:
-    ignore-missing: true
+    - staticcheck
+    - wrapcheck
+  settings:
+    paralleltest:
+      ignore-missing: true
+    wrapcheck:
+      ignore-sigs:
+        - .Errorf(
+        - errors.New(
+        - errors.Unwrap(
+        - .Wrap(
+        - .Wrapf(
+        - .WithMessage(
+        - .WithMessagef(
+        - .WithStack(
+        - .NewAPIError(
+        - .NewAPIErrorWrap(
+        - .APIErrorFromRemoteError(
+      ignore-sig-regexps:
+        - \.New.*Error\(
+      ignore-package-globs:
+        - encoding/*
+        - github.com/pkg/*
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(agola.io/agola)
+        - blank
+        - dot
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/agola/cmd/runlist.go
+++ b/cmd/agola/cmd/runlist.go
@@ -119,7 +119,7 @@ func runList(cmd *cobra.Command, args []string) error {
 		} else {
 			getRunsOptions = &gwclient.GetRunsOptions{ListOptions: &gwclient.ListOptions{Cursor: cursor}}
 		}
-		getRunsOptions.ListOptions.Limit = limit - runCount
+		getRunsOptions.Limit = limit - runCount
 
 		var resp *gwclient.Response
 		if isProject {

--- a/internal/gitsources/gitea/parse.go
+++ b/internal/gitsources/gitea/parse.go
@@ -155,10 +155,9 @@ func webhookDataFromPullRequest(hook *pullRequestHook) *types.WebhookData {
 	if sender == "" {
 		sender = hook.Sender.Login
 	}
-	prFromSameRepo := false
-	if hook.PullRequest.Base.Repo.URL == hook.PullRequest.Head.Repo.URL {
-		prFromSameRepo = true
-	}
+
+	prFromSameRepo := hook.PullRequest.Base.Repo.URL == hook.PullRequest.Head.Repo.URL
+
 	whd := &types.WebhookData{
 		Event:           types.WebhookEventPullRequest,
 		CommitSHA:       hook.PullRequest.Head.Sha,

--- a/internal/gitsources/github/github.go
+++ b/internal/gitsources/github/github.go
@@ -124,11 +124,8 @@ func newHTTPTransport(opts httpOpts) *http.Transport {
 }
 
 func getURLs(apiURL, webURL string) (string, string) {
-	isPublicGithub := false
 	// TODO(sgotti) improve detection of public github url (handle also trailing slash)
-	if apiURL == GitHubAPIURL {
-		isPublicGithub = true
-	}
+	isPublicGithub := apiURL == GitHubAPIURL
 
 	if isPublicGithub {
 		webURL = GitHubWebURL

--- a/internal/gitsources/github/parse.go
+++ b/internal/gitsources/github/parse.go
@@ -116,10 +116,7 @@ func webhookDataFromPullRequest(hook *github.PullRequestEvent) (*types.WebhookDa
 	if sender == nil {
 		sender = hook.Sender.Login
 	}
-	prFromSameRepo := false
-	if hook.PullRequest.Base.Repo.URL == hook.PullRequest.Head.Repo.URL {
-		prFromSameRepo = true
-	}
+	prFromSameRepo := hook.PullRequest.Base.Repo.URL == hook.PullRequest.Head.Repo.URL
 
 	whd := &types.WebhookData{
 		Event:           types.WebhookEventPullRequest,

--- a/internal/gitsources/gitlab/parse.go
+++ b/internal/gitsources/gitlab/parse.go
@@ -139,10 +139,7 @@ func webhookDataFromPullRequest(hook *pullRequestHook) *types.WebhookData {
 	if sender == "" {
 		sender = hook.User.Username
 	}
-	prFromSameRepo := false
-	if hook.ObjectAttributes.Source.URL == hook.ObjectAttributes.Target.URL {
-		prFromSameRepo = true
-	}
+	prFromSameRepo := hook.ObjectAttributes.Source.URL == hook.ObjectAttributes.Target.URL
 
 	whd := &types.WebhookData{
 		Event:           types.WebhookEventPullRequest,

--- a/internal/migration/destination/runservice/db/db.go
+++ b/internal/migration/destination/runservice/db/db.go
@@ -133,10 +133,7 @@ func (d *DB) GetRuns(tx *sql.Tx, groups []string, lastRun bool, phaseFilter []ty
 }
 
 func (d *DB) getRunsFilteredQuery(phaseFilter []types.RunPhase, resultFilter []types.RunResult, groups []string, lastRun bool, startRunSequence uint64, limit int, sortDirection types.SortDirection) *sq.SelectBuilder {
-	useSubquery := false
-	if len(groups) > 0 && lastRun {
-		useSubquery = true
-	}
+	useSubquery := len(groups) > 0 && lastRun
 
 	q := runSelect()
 	if useSubquery {

--- a/internal/objectstorage/atomic.go
+++ b/internal/objectstorage/atomic.go
@@ -56,10 +56,7 @@ func writeFileAtomicFunc(p, baseDir, tmpDir string, perm os.FileMode, persist bo
 	}
 	// sync parent dirs
 	pdir := filepath.Dir(p)
-	for {
-		if !strings.HasPrefix(pdir, baseDir) {
-			break
-		}
+	for strings.HasPrefix(pdir, baseDir) {
 		f, err := os.Open(pdir)
 		if err != nil {
 			f.Close()

--- a/internal/objectstorage/posix.go
+++ b/internal/objectstorage/posix.go
@@ -126,10 +126,7 @@ func (s *PosixStorage) DeleteObject(ctx context.Context, p string) error {
 	// TODO(sgotti) if this fails we ignore errors and the dirs will be left as
 	// empty, clean them asynchronously
 	pdir := filepath.Dir(fspath)
-	for {
-		if pdir == s.dataDir || !strings.HasPrefix(pdir, s.dataDir) {
-			break
-		}
+	for pdir != s.dataDir && strings.HasPrefix(pdir, s.dataDir) {
 		f, err := os.Open(pdir)
 		if err != nil {
 			return nil

--- a/internal/services/executor/executor.go
+++ b/internal/services/executor/executor.go
@@ -162,7 +162,7 @@ func (e *Executor) doRunStep(ctx context.Context, s *types.RunStep, et *rsapityp
 
 	workingDir, err = e.expandDir(ctx, et, pod, outf, workingDir)
 	if err != nil {
-		_, _ = outf.WriteString(fmt.Sprintf("failed to expand working dir %q. Error: %s\n", workingDir, err))
+		_, _ = fmt.Fprintf(outf, "failed to expand working dir %q. Error: %s\n", workingDir, err)
 		return -1, errors.WithStack(err)
 	}
 
@@ -213,7 +213,7 @@ func (e *Executor) doSaveToWorkspaceStep(ctx context.Context, s *types.SaveToWor
 
 	workingDir, err := e.expandDir(ctx, et, pod, logf, et.Spec.WorkingDir)
 	if err != nil {
-		_, _ = logf.WriteString(fmt.Sprintf("failed to expand working dir %q. Error: %s\n", et.Spec.WorkingDir, err))
+		_, _ = fmt.Fprintf(logf, "failed to expand working dir %q. Error: %s\n", et.Spec.WorkingDir, err)
 		return -1, errors.WithStack(err)
 	}
 
@@ -340,7 +340,7 @@ func (e *Executor) template(ctx context.Context, et *rsapitypes.ExecutorTask, po
 
 	workingDir, err := e.expandDir(ctx, et, pod, logf, et.Spec.WorkingDir)
 	if err != nil {
-		_, _ = io.WriteString(logf, fmt.Sprintf("failed to expand working dir %q. Error: %s\n", et.Spec.WorkingDir, err))
+		_, _ = fmt.Fprintf(logf, "failed to expand working dir %q. Error: %s\n", et.Spec.WorkingDir, err)
 		return "", errors.WithStack(err)
 	}
 
@@ -388,7 +388,7 @@ func (e *Executor) unarchive(ctx context.Context, et *rsapitypes.ExecutorTask, s
 
 	workingDir, err := e.expandDir(ctx, et, pod, logf, et.Spec.WorkingDir)
 	if err != nil {
-		_, _ = io.WriteString(logf, fmt.Sprintf("failed to expand working dir %q. Error: %s\n", et.Spec.WorkingDir, err))
+		_, _ = fmt.Fprintf(logf, "failed to expand working dir %q. Error: %s\n", et.Spec.WorkingDir, err)
 		return errors.WithStack(err)
 	}
 
@@ -518,7 +518,7 @@ func (e *Executor) archiveCache(ctx context.Context, s *types.SaveCacheStep, et 
 
 	workingDir, err := e.expandDir(ctx, et, pod, logf, et.Spec.WorkingDir)
 	if err != nil {
-		_, _ = io.WriteString(logf, fmt.Sprintf("failed to expand working dir %q. Error: %s\n", et.Spec.WorkingDir, err))
+		_, _ = fmt.Fprintf(logf, "failed to expand working dir %q. Error: %s\n", et.Spec.WorkingDir, err)
 		return -1, errors.WithStack(err)
 	}
 
@@ -926,15 +926,15 @@ func (e *Executor) setupTask(ctx context.Context, rt *runningTask) error {
 	defer cancel()
 	pod, err := e.driver.NewPod(podCtx, podConfig, outf)
 	if err != nil {
-		_, _ = outf.WriteString(fmt.Sprintf("Pod failed to start. Error: %s\n", err))
+		_, _ = fmt.Fprintf(outf, "Pod failed to start. Error: %s\n", err)
 		return errors.WithStack(err)
 	}
 	_, _ = outf.WriteString("Pod started.\n")
 
 	if et.Spec.WorkingDir != "" {
-		_, _ = outf.WriteString(fmt.Sprintf("Creating working dir %q.\n", et.Spec.WorkingDir))
+		_, _ = fmt.Fprintf(outf, "Creating working dir %q.\n", et.Spec.WorkingDir)
 		if err := e.mkdir(ctx, et, pod, outf, et.Spec.WorkingDir); err != nil {
-			_, _ = outf.WriteString(fmt.Sprintf("Failed to create working dir %q. Error: %s\n", et.Spec.WorkingDir, err))
+			_, _ = fmt.Fprintf(outf, "Failed to create working dir %q. Error: %s\n", et.Spec.WorkingDir, err)
 			return errors.WithStack(err)
 		}
 	}

--- a/internal/services/gateway/api/user.go
+++ b/internal/services/gateway/api/user.go
@@ -509,13 +509,13 @@ func (h *RegisterUserHandler) do(r *http.Request) (*gwapitypes.RegisterUserRespo
 
 func (h *RegisterUserHandler) registerUser(ctx context.Context, req *gwapitypes.RegisterUserRequest) (*gwapitypes.RegisterUserResponse, error) {
 	creq := &action.RegisterUserRequest{
-		UserName:         req.CreateUserRequest.UserName,
-		RemoteUserName:   req.CreateUserLARequest.RemoteSourceLoginName,
-		RemotePassword:   req.CreateUserLARequest.RemoteSourceLoginPassword,
-		RemoteSourceName: req.CreateUserLARequest.RemoteSourceName,
+		UserName:         req.UserName,
+		RemoteUserName:   req.RemoteSourceLoginName,
+		RemotePassword:   req.RemoteSourceLoginPassword,
+		RemoteSourceName: req.RemoteSourceName,
 	}
 
-	cresp, err := h.ah.HandleRemoteSourceAuth(ctx, req.CreateUserLARequest.RemoteSourceName, req.CreateUserLARequest.RemoteSourceLoginName, req.CreateUserLARequest.RemoteSourceLoginPassword, action.RemoteSourceRequestTypeRegisterUser, creq)
+	cresp, err := h.ah.HandleRemoteSourceAuth(ctx, req.RemoteSourceName, req.RemoteSourceLoginName, req.RemoteSourceLoginPassword, action.RemoteSourceRequestTypeRegisterUser, creq)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/internal/services/notification/runeventssender_test.go
+++ b/internal/services/notification/runeventssender_test.go
@@ -195,7 +195,7 @@ func (h *runEventsHandler) do(w http.ResponseWriter, r *http.Request) error {
 			continue
 		}
 
-		if _, err := w.Write([]byte(fmt.Sprintf("data: %s\n\n", runEventj))); err != nil {
+		if _, err := fmt.Fprintf(w, "data: %s\n\n", runEventj); err != nil {
 			h.log.Err(err).Send()
 			continue
 		}

--- a/internal/services/runservice/api/api.go
+++ b/internal/services/runservice/api/api.go
@@ -1105,7 +1105,7 @@ func (h *RunEventsHandler) sendRunEvents(ctx context.Context, afterRunEventSeque
 				return errors.WithStack(err)
 			}
 
-			if _, err := w.Write([]byte(fmt.Sprintf("data: %s\n\n", runEventj))); err != nil {
+			if _, err := fmt.Fprintf(w, "data: %s\n\n", runEventj); err != nil {
 				return errors.WithStack(err)
 			}
 

--- a/internal/services/runservice/db/db.go
+++ b/internal/services/runservice/db/db.go
@@ -135,10 +135,7 @@ func (d *DB) GetRuns(tx *sql.Tx, groups []string, lastRun bool, phaseFilter []ty
 }
 
 func (d *DB) getRunsFilteredQuery(phaseFilter []types.RunPhase, resultFilter []types.RunResult, groups []string, lastRun bool, startRunSequence uint64, limit int, sortDirection types.SortDirection) *sq.SelectBuilder {
-	useSubquery := false
-	if len(groups) > 0 && lastRun {
-		useSubquery = true
-	}
+	useSubquery := len(groups) > 0 && lastRun
 
 	q := runSelect()
 	if useSubquery {

--- a/internal/sqlg/gen/gen_ddl.go
+++ b/internal/sqlg/gen/gen_ddl.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 	"text/template"
 
-	"agola.io/agola/internal/sqlg"
-	"agola.io/agola/internal/sqlg/sql"
-
 	"github.com/Masterminds/sprig/v3"
 	"github.com/huandu/xstrings"
+
+	"agola.io/agola/internal/sqlg"
+	"agola.io/agola/internal/sqlg/sql"
 )
 
 type DDLGenericData struct {

--- a/internal/sqlg/gen/gen_dml.go
+++ b/internal/sqlg/gen/gen_dml.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 	"text/template"
 
-	"agola.io/agola/internal/sqlg"
-	"agola.io/agola/internal/sqlg/sql"
-
 	"github.com/Masterminds/sprig/v3"
 	"github.com/huandu/xstrings"
+
+	"agola.io/agola/internal/sqlg"
+	"agola.io/agola/internal/sqlg/sql"
 )
 
 type DMLGenericData struct {

--- a/internal/sqlg/gen/gen_methods.go
+++ b/internal/sqlg/gen/gen_methods.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"text/template"
 
-	"agola.io/agola/internal/sqlg"
 	"github.com/Masterminds/sprig/v3"
+
+	"agola.io/agola/internal/sqlg"
 )
 
 type MethodsData struct {

--- a/internal/util/string.go
+++ b/internal/util/string.go
@@ -29,10 +29,7 @@ func CountLines(s string) (uint, error) {
 	br := bufio.NewReader(strings.NewReader(s))
 
 	stop := false
-	for {
-		if stop {
-			break
-		}
+	for !stop {
 		_, err := br.ReadBytes('\n')
 		if err != nil {
 			if err != io.EOF {

--- a/services/configstore/client/client.go
+++ b/services/configstore/client/client.go
@@ -75,7 +75,7 @@ func NewClient(url, token string) *Client {
 }
 
 func (c *Client) GetResponse(ctx context.Context, method, path string, query url.Values, contentLength int64, header http.Header, ibody io.Reader) (*Response, error) {
-	cresp, err := c.Client.DoRequest(ctx, method, path, query, contentLength, header, ibody)
+	cresp, err := c.DoRequest(ctx, method, path, query, contentLength, header, ibody)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/services/gateway/client/client.go
+++ b/services/gateway/client/client.go
@@ -127,7 +127,7 @@ func (c *Client) getResponse(ctx context.Context, method, path string, query url
 		return resp, errors.WithStack(err)
 	}
 
-	resp.Cursor = resp.Response.Header.Get(agolaCursorHeader)
+	resp.Cursor = resp.Header.Get(agolaCursorHeader)
 
 	return resp, nil
 }

--- a/services/notification/client/client.go
+++ b/services/notification/client/client.go
@@ -73,7 +73,7 @@ func NewClient(url, token string) *Client {
 }
 
 func (c *Client) GetResponse(ctx context.Context, method, path string, query url.Values, contentLength int64, header http.Header, ibody io.Reader) (*Response, error) {
-	cresp, err := c.Client.DoRequest(ctx, method, path, query, contentLength, header, ibody)
+	cresp, err := c.DoRequest(ctx, method, path, query, contentLength, header, ibody)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/services/runservice/client/client.go
+++ b/services/runservice/client/client.go
@@ -75,7 +75,7 @@ func NewClient(url, token string) *Client {
 }
 
 func (c *Client) GetResponse(ctx context.Context, method, path string, query url.Values, contentLength int64, header http.Header, ibody io.Reader) (*Response, error) {
-	cresp, err := c.Client.DoRequest(ctx, method, path, query, contentLength, header, ibody)
+	cresp, err := c.DoRequest(ctx, method, path, query, contentLength, header, ibody)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}


### PR DESCRIPTION
Migrate to the new config file version.
Fix new lint errors.