### PR TITLE
*: update gorilla CSRF version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-containerregistry v0.20.2
 	github.com/google/go-github/v66 v66.0.0
 	github.com/google/go-jsonnet v0.20.0
-	github.com/gorilla/csrf v1.7.2
+	github.com/gorilla/csrf v1.7.3
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/securecookie v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 h1:FKHo8hFI3A+7w0aUQu
 github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/csrf v1.7.2 h1:oTUjx0vyf2T+wkrx09Trsev1TE+/EbDAeHtSTbtC2eI=
-github.com/gorilla/csrf v1.7.2/go.mod h1:F1Fj3KG23WYHE6gozCmBAezKookxbIvUJT+121wTuLk=
+github.com/gorilla/csrf v1.7.3 h1:BHWt6FTLZAb2HtWT5KDBf6qgpZzvtbp9QWDRKZMXJC0=
+github.com/gorilla/csrf v1.7.3/go.mod h1:F1Fj3KG23WYHE6gozCmBAezKookxbIvUJT+121wTuLk=
 github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
 github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=

--- a/internal/services/config/config.go
+++ b/internal/services/config/config.go
@@ -265,7 +265,7 @@ type Web struct {
 	// TODO(sgotti) support encrypted private keys (add a private key password config entry)
 	TLSKeyFile string `yaml:"tlsKeyFile"`
 
-	// CORS allowed origins. Must be URLs. Wildcard ("*") is not accepted since cross origin requests will have credentials.
+	// CORS and CSRF allowed origins. Must be URLs. Wildcard ("*") is not accepted since cross origin requests will have credentials.
 	AllowedOrigins []string `yaml:"allowedOrigins"`
 }
 

--- a/internal/util/url.go
+++ b/internal/util/url.go
@@ -1,0 +1,54 @@
+// Copyright 2025 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"net"
+	"net/url"
+)
+
+// ExpandURLPorts returns a list of urls.
+// If the provided URL uses default http/https ports without a defined port of with a default port, two urls will be returned. One without the default port and one with the default port.
+func ExpandURLDefaultPorts(u *url.URL) []*url.URL {
+	hostname := u.Hostname()
+	port := u.Port()
+
+	// if a default port is defined add also the version without port defined
+	if (u.Scheme == "http" && (port == "" || port == "80")) || (u.Scheme == "https" && (port == "" || port == "443")) {
+		urls := []*url.URL{}
+
+		// without port
+		nu := new(url.URL)
+		*nu = *u
+		nu.Host = hostname
+		urls = append(urls, nu)
+
+		// with default port
+		nu = new(url.URL)
+		*nu = *u
+		switch u.Scheme {
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+		}
+		nu.Host = net.JoinHostPort(hostname, port)
+		urls = append(urls, nu)
+
+		return urls
+	}
+
+	return []*url.URL{u}
+}

--- a/internal/util/url_test.go
+++ b/internal/util/url_test.go
@@ -1,0 +1,82 @@
+// Copyright 2025 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util_test
+
+import (
+	"net/url"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	"agola.io/agola/internal/testutil"
+	"agola.io/agola/internal/util"
+)
+
+func TestExpandURLDefaultPorts(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		in   string
+		want []string
+	}{
+		{
+			name: "http without port",
+			in:   "http://localhost",
+			want: []string{"http://localhost", "http://localhost:80"},
+		},
+		{
+			name: "https without port",
+			in:   "https://localhost",
+			want: []string{"https://localhost", "https://localhost:443"},
+		},
+		{
+			name: "http with default port",
+			in:   "http://localhost:80",
+			want: []string{"http://localhost", "http://localhost:80"},
+		},
+		{
+			name: "https with default port",
+			in:   "https://localhost:443",
+			want: []string{"https://localhost", "https://localhost:443"},
+		},
+		{
+			name: "http with custom port",
+			in:   "http://localhost:8080",
+			want: []string{"http://localhost:8080"},
+		},
+		{
+			name: "https with custom port",
+			in:   "https://localhost:8443",
+			want: []string{"https://localhost:8443"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.in)
+			testutil.NilError(t, err)
+
+			outURLs := util.ExpandURLDefaultPorts(u)
+			// TODO: update the condition below to compare got with tt.want.
+
+			out := []string{}
+			for _, outURL := range outURLs {
+				out = append(out, outURL.String())
+			}
+
+			assert.Assert(t, cmp.DeepEqual(tt.want, out), "expected urls")
+		})
+	}
+}

--- a/tests/cookieclient_test.go
+++ b/tests/cookieclient_test.go
@@ -49,11 +49,12 @@ func (c *CookieClient) doRequest(ctx context.Context, method, path string, query
 		return nil, errors.WithStack(err)
 	}
 	u.RawQuery = query.Encode()
-	req, err := http.NewRequest(method, u.String(), ibody)
-	req = req.WithContext(ctx)
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), ibody)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+
+	req.Header.Set("Referer", "https://localhost:8080")
 
 	for k, v := range header {
 		req.Header[k] = v

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -347,8 +347,9 @@ func setup(ctx context.Context, t *testing.T, dir string, opts ...setupOption) *
 			GitserverURL:    "",
 			NotificationURL: "",
 			Web: config.Web{
-				ListenAddress: "",
-				TLS:           false,
+				ListenAddress:  "",
+				TLS:            false,
+				AllowedOrigins: []string{"https://localhost:8080"},
 			},
 			TokenSigning: config.TokenSigning{
 				Duration: 12 * time.Hour,
@@ -526,6 +527,7 @@ func setup(ctx context.Context, t *testing.T, dir string, opts ...setupOption) *
 	sc.config.Notification.ConfigstoreURL = csURL
 
 	sc.config.Executor.RunserviceURL = rsURL
+
 	err = sc.startAgola()
 	testutil.NilError(t, err)
 


### PR DESCRIPTION
This new versions fixes a CVE where Origin or Referer weren't correctly checked.

We have to define a list of trusted origins since we may use cross requests. Use the origins already provided in the gateway web config (currently used only for cors).

Also update tests.