### PR TITLE
*: update to go 1.25

### DIFF
--- a/.agola/config.jsonnet
+++ b/.agola/config.jsonnet
@@ -128,7 +128,7 @@ local task_build_push_images(name, target, push) =
         [
           task_build_go(version, arch),
         ]
-        for version in ['1.23', '1.24']
+        for version in ['1.24', '1.25']
         for arch in ['amd64' /*, 'arm64' */]
       ]) + [
         {
@@ -139,7 +139,7 @@ local task_build_push_images(name, target, push) =
             { type: 'run', command: 'SKIP_K8S_TESTS=1 AGOLA_TOOLBOX_PATH="./bin" ./bin/docker-tests -test.parallel 5 -test.v' },
           ],
           depends: [
-            'build go 1.24 amd64',
+            'build go 1.25 amd64',
           ],
         },
         {
@@ -162,7 +162,7 @@ local task_build_push_images(name, target, push) =
             { type: 'run', name: 'integration tests', command: 'AGOLA_BIN_DIR="./bin" GITEA_PATH=${PWD}/bin/gitea DOCKER_BRIDGE_ADDRESS="172.18.0.1" ./bin/integration-tests -test.parallel 3 -test.v' },
           ],
           depends: [
-            'build go 1.24 amd64',
+            'build go 1.25 amd64',
           ],
         },
         {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 ARG AGOLAWEB_IMAGE="agola-web"
 
-FROM $AGOLAWEB_IMAGE as agola-web
+FROM $AGOLAWEB_IMAGE AS agola-web
 
 #######
 ####### Build the backend
 #######
 
 # base build image
-FROM golang:1.24-bookworm AS build_base
+FROM golang:1.25-bookworm AS build_base
 
 WORKDIR /agola
 
@@ -52,7 +52,7 @@ ENTRYPOINT ["/bin/agola"]
 ####### Build the demo image
 #######
 
-FROM agola as agolademo
+FROM agola AS agolademo
 
 WORKDIR /
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module agola.io/agola
 
-go 1.23.0
+go 1.24
 
 require (
 	ariga.io/atlas v0.12.0


### PR DESCRIPTION
* go.mod use go 1.25 minimum version semantics.
* ci: use the current last two go versions: 1.24 and 1.25
* Dockerfile: use go 1.25 image